### PR TITLE
Don't remove file after releasing lock

### DIFF
--- a/filelock.py
+++ b/filelock.py
@@ -367,12 +367,6 @@ class UnixFileLock(BaseFileLock):
         os.close(self._lock_file_fd)
         self._lock_file_fd = None
 
-        try:
-            os.remove(self._lock_file)
-        # Probably another instance of the application
-        # that acquired the file lock.
-        except OSError:
-            pass
         return None
 
 # Soft lock


### PR DESCRIPTION
Deleting file makes lock unreliable. File should exist in first place. Here is test that proves it.
http://s000.tinyupload.com/index.php?file_id=01315450548811350116
To run it you just need to install docker and execute ./run.sh as user from docker group.
