### PR TITLE
Add a test method cleanup

### DIFF
--- a/test.py
+++ b/test.py
@@ -30,6 +30,7 @@
 Some tests for the file lock.
 """
 
+import os
 import time
 import unittest
 import threading
@@ -63,6 +64,10 @@ class BaseTest(object):
         Asserts that the lock file *self.lock* is not locked.
         """
         self.assertFalse(self.lock.is_locked)
+        try:
+            os.remove(self.lock.lock_file)
+        except OSError:
+            pass
         return None
 
     def test_simple(self):


### PR DESCRIPTION
The `FileLockTest` class doesn't remove the lock file when the tests complete. When the `SoftFileLockTest` class starts, the lock file already exists and so all of the tests hang.

This change makes the `BaseTest` class clean up the lock file if it is left after the testing concludes.

Tested on Fedora 23, with consistent failure using Python 2.7 and Python 3.4.

Thanks,

--scott

**EDIT:** I think this was a regression caused by #8 
