### PR TITLE
Add a test thread class to surface test failures

### DIFF
--- a/test.py
+++ b/test.py
@@ -30,12 +30,29 @@
 Some tests for the file lock.
 """
 
+import sys
 import time
 import unittest
 import threading
 import random
 
 import filelock
+
+
+class ExThread(threading.Thread):
+    ex = None
+
+    def run(self):
+        try:
+            threading.Thread.run(self)
+        except:
+            self.ex = sys.exc_info()
+
+    def join(self):
+        threading.Thread.join(self)
+        if self.ex is not None:
+            wrapper_ex = self.ex[1]
+            raise wrapper_ex.__class__, wrapper_ex, self.ex[2]
 
 
 class BaseTest(object):
@@ -150,7 +167,7 @@ class BaseTest(object):
 
         NUM_THREADS = 250
 
-        threads = [threading.Thread(target = my_thread) for i in range(NUM_THREADS)]
+        threads = [ExThread(target = my_thread) for i in range(NUM_THREADS)]
         for thread in threads:
             thread.start()
         for thread in threads:
@@ -190,8 +207,8 @@ class BaseTest(object):
         lock1 = self.LOCK_TYPE(self.lock.lock_file)
         lock2 = self.LOCK_TYPE(self.lock.lock_file)
 
-        threads1 = [threading.Thread(target = thread1) for i in range(NUM_THREADS)]
-        threads2 = [threading.Thread(target = thread2) for i in range(NUM_THREADS)]
+        threads1 = [ExThread(target = thread1) for i in range(NUM_THREADS)]
+        threads2 = [ExThread(target = thread2) for i in range(NUM_THREADS)]
 
         for i in range(NUM_THREADS):
             threads1[i].start()


### PR DESCRIPTION
Right now, if there is a test failure in a thread, the exception is displayed but the test never fails because the exception never happens in the main thread.

This change adds a wrapper to `threading.Thread` which catches exceptions therein and re-throws them when the thread is joined in the main thread.

The only downside is that only the first thread with an exception is seen, even though multiple threads may have failed.

Thanks,

--scott
