### PR TITLE
Fix unlocking sequence to prevent test failures

### DIFF
--- a/filelock.py
+++ b/filelock.py
@@ -332,9 +332,10 @@ class WindowsFileLock(BaseFileLock):
         return None
 
     def _release(self):
-        msvcrt.locking(self._lock_file_fd, msvcrt.LK_UNLCK, 1)
-        os.close(self._lock_file_fd)
+        fd = self._lock_file_fd
         self._lock_file_fd = None
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        os.close(fd)
 
         try:
             os.remove(self._lock_file)
@@ -365,9 +366,10 @@ class UnixFileLock(BaseFileLock):
         return None
 
     def _release(self):
-        fcntl.flock(self._lock_file_fd, fcntl.LOCK_UN)
-        os.close(self._lock_file_fd)
+        fd = self._lock_file_fd
         self._lock_file_fd = None
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
         return None
 
 # Soft lock


### PR DESCRIPTION
During the locking sequence, the global lock is acquired before the file descriptor variable on the class is set. Therefore, the class is never prematurely reports that it has the lock when it doesn't.

When unlocking, the global lock is released before the file descriptor variable is set back to `None`, and so there is a short (but significant) amount of time where `is_locked` reports `True` even though the class no longer has the global lock.

This leads to transient test failures when one thread is able to acquire the lock and call `is_locked` on the other lock while the other thread is still in the process of closing the file and setting the file descriptor variable back to `None`.

If we follow the same paradigm used in the locking sequence but in reverse, it should eliminate these transient test failures.

Thanks,

--scott
