### PR TITLE
*removed* misleading shebang from module

### DIFF
--- a/filelock.py
+++ b/filelock.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This is free and unencumbered software released into the public domain.
 #
 # Anyone is free to copy, modify, publish, use, compile, sell, or


### PR DESCRIPTION
A shebang is only used when a file is executed directly from the shell (e.g. `./filelock.py`). This shebang should be removed for a couple of reasons, either of which render the shebang incorrect:
1. The file does not have executable permissions, and even if it did, they would be removed when the file is installed.
2. Executing the file doesn't do anything useful (it doesn't handle `__main__`).

This was flagged by the RPM linter when packaged for Fedora Linux.