### PR TITLE
*updated* docs config for older sphinx compatibility

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@
 
 import sys
 import os
+import alabaster
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -115,7 +116,7 @@ html_theme = 'alabaster'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [alabaster.get_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
This change makes it possible to build the docs using older versions of `sphinx`, as are used on RHEL 7. The change appears to be forward-compatible to the version of `sphinx` used on the bleeding-edge of Fedora Linux.