### PR TITLE
Fix README rendering on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,12 +3,6 @@ py-filelock
 
 .. image:: https://travis-ci.org/benediktschmitt/py-filelock.svg?branch=master
     :target: https://travis-ci.org/benediktschmitt/py-filelock
-    
-`Similar Libraries <#similar-libraries>`_
-~ `Installation <#installation>`_
-~ `Documentation <#documentation>`_
-~ `Contributions <#contributions>`_
-~ `License <#license>`_
 
 This package contains a single module, which implements a platform independent
 file lock in Python, which provides a simple way of inter-process communication:


### PR DESCRIPTION
The rST parser used on PyPI rejects anything with warnings, which is why the rendering is broken for the current version: https://pypi.org/project/filelock/3.0.9/

This can be checked with:

```
$ pip install docutils pygments
$ python setup.py check --metadata --restructuredtext
running check
warning: check: Duplicate implicit target name: "similar libraries".

warning: check: Duplicate implicit target name: "installation".

warning: check: Duplicate implicit target name: "documentation".

warning: check: Duplicate implicit target name: "contributions".

warning: check: Duplicate implicit target name: "license".
```

I fixed the warnings by removing the 'ToC' at the top. The README isn't so long so I don't think this is a huge loss. After this change, the check passes:

```
$ python setup.py check --metadata --restructuredtext
running check
```