### PR TITLE
CI: 'sudo: required' no longer required 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
-      sudo: required
       dist: xenial
     - python: "3.8-dev"
-      sudo: required
       dist: xenial
   allow_failures:
     - python: "3.8-dev"


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration