### PR TITLE
Handle Unwritable Path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: v1.11.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [ black==20.8b1 ]
+        additional_dependencies: [ black==21.9b0 ]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -334,7 +334,7 @@ class WindowsFileLock(BaseFileLock):
         try:
             fd = os.open(self._lock_file, open_mode)
         except OSError:
-            pass
+            raise
         else:
             try:
                 msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -366,6 +366,28 @@ class FileLockTest(BaseTest, unittest.TestCase):
 
     LOCK_TYPE = filelock.FileLock
     LOCK_PATH = "test.lock"
+    LOCK_PATH_UNWRITABLE = "test.lock.unwritable"
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            os.mkdir(cls.LOCK_PATH_UNWRITABLE, 0)
+        except:
+            cls.fail("Could not create unwritable directory")
+
+    def test_write_fail(self):
+        """Ensures graceful failure of lock when path not writable."""
+        lock1 = self.LOCK_TYPE("{}/test".format(self.LOCK_PATH_UNWRITABLE))
+        with self.assertRaises(OSError):
+            lock1.acquire()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up."""
+        try:
+            os.rmdir(cls.LOCK_PATH_UNWRITABLE)
+        except:
+            pass
 
 
 class SoftFileLockTest(BaseTest, unittest.TestCase):

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -29,6 +29,7 @@ param
 pygments
 rdwr
 returnproxy
+rmdir
 seealso
 src
 thread1
@@ -41,4 +42,5 @@ typehints
 unittest
 unlck
 unlicense
+unwritable
 wronly


### PR DESCRIPTION
## Description

If the OS cannot open a file because the path is bad, it does not make sense to repeatedly attempt to open the file as it will continue to fail, indefinitely if the `-1` default timeout is used, without any feedback to the user.

This modifies the behavior to raise the OSError/IOError exception received on Windows or Unix so FileLock exits rather than a futile infinite loop that will never succeed.

Tests are written to demonstrate the behavior.