### PR TITLE
Fixed link to LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ take some time for me to respond.
 
 ## License
 
-This package is [public domain](./LICENSE.rst).
+This package is [public domain](./LICENSE).


### PR DESCRIPTION
It was redirecting to a 404 before