### PR TITLE
codecov: disable comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
The comment system is very spammy and the stats already get reported to
the CI, with a link to the codecov website for the full details, so I'd
say there isn't much of a need for the comment on PRs.

Signed-off-by: Filipe Laíns <lains@riseup.net>