### PR TITLE
Update `FileLock` constructor to accept `pathlib.Path`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v3.3.2 (2021-10-26)
+v3.3.2 (2021-10-29)
 -------------------
 - Accept path types (like ``pathlib.Path`` and ``pathlib.PurePath``) in the constructor for ``FileLock`` objects.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v3.3.2 (2021-10-26)
+-------------------
+- Accept path types (like ``pathlib.Path`` and ``pathlib.PurePath``) in the constructor for ``FileLock`` objects.
+
 v3.3.1 (2021-10-15)
 -------------------
 - Add changelog to the documentation :pr:`108` - by :user:`gaborbernat`

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -4,7 +4,7 @@ import time
 from abc import ABC, abstractmethod
 from threading import Lock
 from types import TracebackType
-from typing import Optional, Type, Union
+from typing import Any, Optional, Type, Union
 
 from ._error import Timeout
 
@@ -35,7 +35,7 @@ class AcquireReturnProxy:
 class BaseFileLock(ABC):
     """Abstract base class for a file lock object."""
 
-    def __init__(self, lock_file: Union[str, os.PathLike], timeout: float = -1) -> None:
+    def __init__(self, lock_file: Union[str, "os.PathLike[Any]"], timeout: float = -1) -> None:
         """
         Create a new lock object.
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -45,7 +45,7 @@ class BaseFileLock(ABC):
          A timeout of 0 means, that there is exactly one attempt to acquire the file lock.
         """
         # The path to the lock file.
-        self._lock_file: str = os.fspath(lock_file)  # noqa: SC200
+        self._lock_file: str = os.fspath(lock_file)
 
         # The file descriptor for the *_lock_file* as it is returned by the os.open() function.
         # This file lock is only NOT None, if the object currently holds the lock.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -1,7 +1,7 @@
 import logging
+import os
 import time
 from abc import ABC, abstractmethod
-from pathlib import Path
 from threading import Lock
 from types import TracebackType
 from typing import Optional, Type, Union
@@ -35,7 +35,7 @@ class AcquireReturnProxy:
 class BaseFileLock(ABC):
     """Abstract base class for a file lock object."""
 
-    def __init__(self, lock_file: Union[str, Path], timeout: float = -1) -> None:
+    def __init__(self, lock_file: Union[str, os.PathLike], timeout: float = -1) -> None:
         """
         Create a new lock object.
 
@@ -45,7 +45,7 @@ class BaseFileLock(ABC):
          A timeout of 0 means, that there is exactly one attempt to acquire the file lock.
         """
         # The path to the lock file.
-        self._lock_file: str = str(lock_file)
+        self._lock_file: str = os.fspath(lock_file)  # noqa: SC200
 
         # The file descriptor for the *_lock_file* as it is returned by the os.open() function.
         # This file lock is only NOT None, if the object currently holds the lock.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from abc import ABC, abstractmethod
+from pathlib import Path
 from threading import Lock
 from types import TracebackType
 from typing import Optional, Type, Union
@@ -34,7 +35,7 @@ class AcquireReturnProxy:
 class BaseFileLock(ABC):
     """Abstract base class for a file lock object."""
 
-    def __init__(self, lock_file: str, timeout: float = -1) -> None:
+    def __init__(self, lock_file: Union[str, Path], timeout: float = -1) -> None:
         """
         Create a new lock object.
 
@@ -44,7 +45,7 @@ class BaseFileLock(ABC):
          A timeout of 0 means, that there is exactly one attempt to acquire the file lock.
         """
         # The path to the lock file.
-        self._lock_file: str = lock_file
+        self._lock_file: str = str(lock_file)
 
         # The file descriptor for the *_lock_file* as it is returned by the os.open() function.
         # This file lock is only NOT None, if the object currently holds the lock.

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import threading
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR
 from types import TracebackType
 from typing import Callable, Iterator, Optional, Tuple, Type, Union
@@ -14,7 +14,15 @@ from filelock import BaseFileLock, FileLock, SoftFileLock, Timeout
 
 
 @pytest.mark.parametrize(
-    ("lock_type", "path_type"), [(FileLock, str), (FileLock, Path), (SoftFileLock, str), (SoftFileLock, Path)]
+    ("lock_type", "path_type"),
+    [
+        (FileLock, str),
+        (FileLock, PurePath),
+        (FileLock, Path),
+        (SoftFileLock, str),
+        (SoftFileLock, PurePath),
+        (SoftFileLock, Path),
+    ],
 )
 def test_simple(
     lock_type: Type[BaseFileLock], path_type: Union[Type[str], Type[Path]], tmp_path: Path, caplog: LogCaptureFixture

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -13,25 +13,21 @@ from _pytest.logging import LogCaptureFixture
 from filelock import BaseFileLock, FileLock, SoftFileLock, Timeout
 
 
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_simple(lock_type: Type[BaseFileLock], tmp_path: Path, caplog: LogCaptureFixture) -> None:
+@pytest.mark.parametrize(
+    ("lock_type", "path_type"), [(FileLock, str), (FileLock, Path), (SoftFileLock, str), (SoftFileLock, Path)]
+)
+def test_simple(
+    lock_type: Type[BaseFileLock], path_type: Union[Type[str], Type[Path]], tmp_path: Path, caplog: LogCaptureFixture
+) -> None:
     caplog.set_level(logging.DEBUG)
 
     # test lock creation by passing a `str`
     lock_path = tmp_path / "a"
-    lock = lock_type(str(lock_path))
+    lock = lock_type(path_type(lock_path))
     with lock as locked:
         assert lock.is_locked
         assert lock is locked
     assert not lock.is_locked
-
-    # test creation by passing a `pathlib.Path`
-    lock_path_2 = tmp_path / "b"
-    lock_2 = lock_type(lock_path_2)
-    with lock_2 as locked:
-        assert lock_2.is_locked
-        assert lock_2 is locked
-    assert not lock_2.is_locked
 
     assert caplog.messages == [
         f"Attempting to acquire lock {id(lock)} on {lock_path}",

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -16,13 +16,22 @@ from filelock import BaseFileLock, FileLock, SoftFileLock, Timeout
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_simple(lock_type: Type[BaseFileLock], tmp_path: Path, caplog: LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
+
+    # test lock creation by passing a `str`
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path))
-
     with lock as locked:
         assert lock.is_locked
         assert lock is locked
     assert not lock.is_locked
+
+    # test creation by passing a `pathlib.Path`
+    lock_path_2 = tmp_path / "b"
+    lock_2 = lock_type(lock_path_2)
+    with lock_2 as locked:
+        assert lock_2.is_locked
+        assert lock_2 is locked
+    assert not lock_2.is_locked
 
     assert caplog.messages == [
         f"Attempting to acquire lock {id(lock)} on {lock_path}",

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -12,6 +12,7 @@ favicon
 fcntl
 filelock
 fmt
+fspath
 intersphinx
 intervall
 iwgrp


### PR DESCRIPTION
This is a small fix for people who employ `pathlib.Path` for their path handling. It allows a `Path` object to be passed to the constructor of `FileLock`. It is then converted to a normal `str` when storing it inside the object leaving the rest of the library unaffected.