### PR TITLE
Use Python 3.10 instead of 3.10.0-rc2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,18 +28,18 @@ jobs:
           - windows-latest
           - macos-latest
         py:
-          - 3.10
-          - 3.9
-          - 3.8
-          - 3.7
-          - 3.6
-          - pypy3
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
+          - "3.6"
+          - "pypy3"
 
     steps:
       - name: Setup python for tox
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install tox
         run: python -m pip install tox
       - uses: actions/checkout@v2
@@ -97,10 +97,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Setup Python 3.10
+      - name: Setup Python "3.10"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install tox
         run: python -m pip install tox
       - name: Setup test suite
@@ -116,7 +116,7 @@ jobs:
       - name: Setup python to build package
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install https://pypi.org/project/build
         run: python -m pip install build
       - uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
           - windows-latest
           - macos-latest
         py:
-          - 3.10.0-rc.2
+          - 3.10
           - 3.9
           - 3.8
           - 3.7
@@ -39,7 +39,7 @@ jobs:
       - name: Setup python for tox
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.0-rc.2
+          python-version: 3.10
       - name: Install tox
         run: python -m pip install tox
       - uses: actions/checkout@v2
@@ -97,10 +97,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Setup Python 3.10.0-rc.2
+      - name: Setup Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.0-rc.2
+          python-version: 3.10
       - name: Install tox
         run: python -m pip install tox
       - name: Setup test suite
@@ -116,7 +116,7 @@ jobs:
       - name: Setup python to build package
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.0-rc.2
+          python-version: 3.10
       - name: Install https://pypi.org/project/build
         run: python -m pip install build
       - uses: actions/checkout@v2


### PR DESCRIPTION
I noticed that the GitHub workflow still uses a release candidate of Python 3.10. Now that it has been properly released I think it should be swapped out for the proper version.

Since `3.10` ends with a `0`, the version has to be wrapped in quotation marks such that it does not get truncated. For the sake of consistency I have applied this change to the other version numbers as well.