### PR TITLE
Fix misspelled keyword argument `poll_interval` for method `acquire`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v3.3.3 (2021-11-15)
+-------------------
+- Fix misspelled keyword argument ``poll_interval`` for method ``acquire`` :pr:`119` - by :user:`XuehaiPan`.
+
 v3.3.2 (2021-10-29)
 -------------------
 - Accept path types (like ``pathlib.Path`` and ``pathlib.PurePath``) in the constructor for ``FileLock`` objects.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-v3.3.3 (2021-11-15)
+v3.4.0 (2021-11-16)
 -------------------
-- Fix misspelled keyword argument ``poll_interval`` for method ``acquire`` :pr:`119` - by :user:`XuehaiPan`.
+- Add correct spelling of poll interval parameter for :meth:`acquire <filelock.BaseFileLock.acquire>` method, raise
+  deprecation warning when using the misspelled form :pr:`119` - by :user:`XuehaiPan`.
 
 v3.3.2 (2021-10-29)
 -------------------

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -111,7 +111,7 @@ class BaseFileLock(ABC):
         self,
         timeout: Optional[float] = None,
         poll_interval: float = 0.05,
-        poll_intervall: Optional[float] = None,  # kept for backward compatibility, will be removed in a future release
+        poll_intervall: Optional[float] = None,
     ) -> AcquireReturnProxy:
         """
         Try to acquire the file lock.
@@ -119,6 +119,7 @@ class BaseFileLock(ABC):
         :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default :attr:`~timeout` is and
          if ``timeout < 0``, there is no timeout and this method will block until the lock could be acquired
         :param poll_interval: interval of trying to acquire the lock file
+        :param poll_intervall: deprecated, kept for backwards compatibility, use ``poll_interval`` instead
         :raises Timeout: if fails to acquire lock within the timeout period
         :return: a context object that will unlock the file when the context is exited
 
@@ -137,23 +138,17 @@ class BaseFileLock(ABC):
 
         .. versionchanged:: 2.0.0
 
-            This method returns now a *proxy* object instead of *self*,
-            so that it can be used in a with statement without side effects.
-
+            This method returns now a *proxy* object instead of *self*, so that it can be used in a with statement \
+            without side effects.
 
         """
         # Use the default timeout, if no timeout is provided.
         if timeout is None:
             timeout = self.timeout
 
-        # Remove this and argument `poll_intervall` above in a future release
         if poll_intervall is not None:
-            warnings.warn(
-                "poll_intervall is a deprecated misspelled keyword "
-                "and will be removed in a future release. "
-                "Please use poll_interval instead.",
-                DeprecationWarning,
-            )
+            msg = "use poll_interval instead of poll_intervall"
+            warnings.warn(msg, DeprecationWarning)
             poll_interval = poll_intervall
 
         # Increment the number right at the beginning. We can still undo it, if something fails.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import warnings
 from abc import ABC, abstractmethod
 from threading import Lock
 from types import TracebackType
@@ -106,13 +107,18 @@ class BaseFileLock(ABC):
         """
         return self._lock_file_fd is not None
 
-    def acquire(self, timeout: Optional[float] = None, poll_intervall: float = 0.05) -> AcquireReturnProxy:
+    def acquire(
+        self,
+        timeout: Optional[float] = None,
+        poll_interval: float = 0.05,
+        poll_intervall: Optional[float] = None,  # kept for backward compatibility, will be removed in a future release
+    ) -> AcquireReturnProxy:
         """
         Try to acquire the file lock.
 
         :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default :attr:`~timeout` is and
          if ``timeout < 0``, there is no timeout and this method will block until the lock could be acquired
-        :param poll_intervall: interval of trying to acquire the lock file
+        :param poll_interval: interval of trying to acquire the lock file
         :raises Timeout: if fails to acquire lock within the timeout period
         :return: a context object that will unlock the file when the context is exited
 
@@ -140,6 +146,16 @@ class BaseFileLock(ABC):
         if timeout is None:
             timeout = self.timeout
 
+        # Remove this and argument `poll_intervall` above in a future release
+        if poll_intervall is not None:
+            warnings.warn(
+                "poll_intervall is a deprecated misspelled keyword "
+                "and will be removed in a future release. "
+                "Please use poll_interval instead.",
+                DeprecationWarning,
+            )
+            poll_interval = poll_intervall
+
         # Increment the number right at the beginning. We can still undo it, if something fails.
         with self._thread_lock:
             self._lock_counter += 1
@@ -162,8 +178,8 @@ class BaseFileLock(ABC):
                     raise Timeout(self._lock_file)
                 else:
                     msg = "Lock %s not acquired on %s, waiting %s seconds ..."
-                    _LOGGER.debug(msg, lock_id, lock_filename, poll_intervall)
-                    time.sleep(poll_intervall)
+                    _LOGGER.debug(msg, lock_id, lock_filename, poll_interval)
+                    time.sleep(poll_interval)
         except BaseException:  # Something did go wrong, so decrement the counter.
             with self._thread_lock:
                 self._lock_counter = max(0, self._lock_counter - 1)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -350,3 +350,13 @@ def test_cleanup_soft_lock(tmp_path: Path) -> None:
     with lock:
         assert lock_path.exists()
     assert not lock_path.exists()
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_poll_intervall_deprecated(lock_type: Type[BaseFileLock], tmp_path: Path) -> None:
+    # raises DeprecationWarning when using deprecated argument poll_intervall
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    with pytest.deprecated_call():
+        lock.acquire(poll_intervall=0.05)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -354,9 +354,8 @@ def test_cleanup_soft_lock(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_poll_intervall_deprecated(lock_type: Type[BaseFileLock], tmp_path: Path) -> None:
-    # raises DeprecationWarning when using deprecated argument poll_intervall
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path))
 
-    with pytest.deprecated_call():
+    with pytest.deprecated_call(match="use poll_interval instead of poll_intervall"):
         lock.acquire(poll_intervall=0.05)


### PR DESCRIPTION
Fix misspelled keyword argument `poll_interval` for method `acquire`. Fixes #62.

I tried my best to add the backward compatibility layer in this PR to not break existing codebases.