### PR TITLE
Add `stacklevel` to deprecation warnings for argument name change

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -111,6 +111,7 @@ class BaseFileLock(ABC):
         self,
         timeout: Optional[float] = None,
         poll_interval: float = 0.05,
+        *,
         poll_intervall: Optional[float] = None,
     ) -> AcquireReturnProxy:
         """
@@ -138,8 +139,8 @@ class BaseFileLock(ABC):
 
         .. versionchanged:: 2.0.0
 
-            This method returns now a *proxy* object instead of *self*, so that it can be used in a with statement \
-            without side effects.
+            This method returns now a *proxy* object instead of *self*,
+            so that it can be used in a with statement without side effects.
 
         """
         # Use the default timeout, if no timeout is provided.
@@ -148,7 +149,7 @@ class BaseFileLock(ABC):
 
         if poll_intervall is not None:
             msg = "use poll_interval instead of poll_intervall"
-            warnings.warn(msg, DeprecationWarning)
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
             poll_interval = poll_intervall
 
         # Increment the number right at the beginning. We can still undo it, if something fails.

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -39,3 +39,4 @@ unlck
 util
 win32
 wronly
+stacklevel

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -40,3 +40,6 @@ util
 win32
 wronly
 stacklevel
+frameinfo
+getframeinfo
+lineno


### PR DESCRIPTION
Changes:

1. Add `*` to function signature to mark the deprecated argument `poll_intervall` as keyword only.
2. Add `stacklevel=2` for deprecation warnings, show the file and lineno for the user's code rather than this module (filelock).

    From https://github.com/tox-dev/py-filelock/pull/119#issuecomment-974607426:

    > I don't know where it's coming from (maybe virtualenv?) but I'm getting a lot of warnings