### PR TITLE
Raise NotImplementedError if using wrong class

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Future
-------
+v3.6.0 (2022-02-17)
+-------------------
 - Fix pylint warning "Abstract class :class:`WindowsFileLock <filelock.WindowsFileLock>` with abstract methods instantiated"
   :pr:`135` - by :user:`vonschultz`
 - Fix pylint warning "Abstract class :class:`UnixFileLock <filelock.UnixFileLock>` with abstract methods instantiated"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Future
+------
+- Fix pylint warning "Abstract class :class:`WindowsFileLock <filelock.WindowsFileLock>` with abstract methods instantiated"
+  :pr:`135` - by :user:`vonschultz`
+- Fix pylint warning "Abstract class :class:`UnixFileLock <filelock.UnixFileLock>` with abstract methods instantiated"
+  :pr:`135` - by :user:`vonschultz`
+
 v3.4.2 (2021-12-16)
 -------------------
 - Drop support for python ``3.6``

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -14,6 +14,10 @@ from ._error import Timeout
 _LOGGER = logging.getLogger("filelock")
 
 
+class PlatformMismatchError(Exception):
+    """Exception raised when attempting Unix locks on Windows, or vice versa."""
+
+
 # This is a helper class which is returned by :meth:`BaseFileLock.acquire` and wraps the lock to make sure __enter__
 # is not called twice when entering the with statement. If we would simply return *self*, the lock would be acquired
 # again in the *__enter__* method of the BaseFileLock, but not released again automatically. issue #37 (memory leak)
@@ -236,4 +240,5 @@ class BaseFileLock(ABC):
 __all__ = [
     "BaseFileLock",
     "AcquireReturnProxy",
+    "PlatformMismatchError",
 ]

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -14,10 +14,6 @@ from ._error import Timeout
 _LOGGER = logging.getLogger("filelock")
 
 
-class PlatformMismatchError(Exception):
-    """Exception raised when attempting Unix locks on Windows, or vice versa."""
-
-
 # This is a helper class which is returned by :meth:`BaseFileLock.acquire` and wraps the lock to make sure __enter__
 # is not called twice when entering the with statement. If we would simply return *self*, the lock would be acquired
 # again in the *__enter__* method of the BaseFileLock, but not released again automatically. issue #37 (memory leak)
@@ -240,5 +236,4 @@ class BaseFileLock(ABC):
 __all__ = [
     "BaseFileLock",
     "AcquireReturnProxy",
-    "PlatformMismatchError",
 ]

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -5,14 +5,20 @@ import sys
 from abc import ABC
 from typing import cast
 
-from ._api import BaseFileLock
+from ._api import BaseFileLock, PlatformMismatchError
 
 #: a flag to indicate if the fcntl API is available
 has_fcntl = False
 if sys.platform == "win32":  # pragma: win32 cover
 
-    class UnixFileLock(BaseFileLock, ABC):
+    class UnixFileLock(BaseFileLock):
         """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
+
+        def _acquire(self) -> None:
+            raise PlatformMismatchError()
+
+        def _release(self) -> None:
+            raise PlatformMismatchError()
 
 else:  # pragma: win32 no cover
     try:

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -4,7 +4,7 @@ import os
 import sys
 from typing import cast
 
-from ._api import BaseFileLock, PlatformMismatchError
+from ._api import BaseFileLock
 
 #: a flag to indicate if the fcntl API is available
 has_fcntl = False
@@ -14,10 +14,10 @@ if sys.platform == "win32":  # pragma: win32 cover
         """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
 
         def _acquire(self) -> None:
-            raise PlatformMismatchError()
+            raise NotImplementedError
 
         def _release(self) -> None:
-            raise PlatformMismatchError()
+            raise NotImplementedError
 
 else:  # pragma: win32 no cover
     try:

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-from abc import ABC
 from typing import cast
 
 from ._api import BaseFileLock, PlatformMismatchError

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-from abc import ABC
 from errno import ENOENT
 from typing import cast
 

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -6,7 +6,7 @@ from abc import ABC
 from errno import ENOENT
 from typing import cast
 
-from ._api import BaseFileLock
+from ._api import BaseFileLock, PlatformMismatchError
 from ._util import raise_on_exist_ro_file
 
 if sys.platform == "win32":  # pragma: win32 cover
@@ -49,8 +49,14 @@ if sys.platform == "win32":  # pragma: win32 cover
 
 else:  # pragma: win32 no cover
 
-    class WindowsFileLock(BaseFileLock, ABC):
+    class WindowsFileLock(BaseFileLock):
         """Uses the :func:`msvcrt.locking` function to hard lock the lock file on windows systems."""
+
+        def _acquire(self) -> None:
+            raise PlatformMismatchError()
+
+        def _release(self) -> None:
+            raise PlatformMismatchError()
 
 
 __all__ = [

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -5,7 +5,7 @@ import sys
 from errno import ENOENT
 from typing import cast
 
-from ._api import BaseFileLock, PlatformMismatchError
+from ._api import BaseFileLock
 from ._util import raise_on_exist_ro_file
 
 if sys.platform == "win32":  # pragma: win32 cover
@@ -52,10 +52,10 @@ else:  # pragma: win32 no cover
         """Uses the :func:`msvcrt.locking` function to hard lock the lock file on windows systems."""
 
         def _acquire(self) -> None:
-            raise PlatformMismatchError()
+            raise NotImplementedError
 
         def _release(self) -> None:
-            raise PlatformMismatchError()
+            raise NotImplementedError
 
 
 __all__ = [

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -386,19 +386,14 @@ def test_context_decorator(lock_type: type[BaseFileLock], tmp_path: Path) -> Non
 
 
 def test_wrong_platform(tmp_path: Path) -> None:
-    assert not inspect.isabstract(  # noqa: SC200
-        UnixFileLock
-    ), "UnixFileLock must not be an abstract class, or pylint will complain in client code"
-    assert not inspect.isabstract(  # noqa: SC200
-        WindowsFileLock
-    ), "WindowsFileLock must not be an abstract class, or pylint will complain in client code"
-    assert inspect.isabstract(BaseFileLock)  # noqa: SC200
+    assert not inspect.isabstract(UnixFileLock)
+    assert not inspect.isabstract(WindowsFileLock)
+    assert inspect.isabstract(BaseFileLock)
 
     lock_type = UnixFileLock if sys.platform == "win32" else WindowsFileLock
     lock = lock_type(str(tmp_path / "lockfile"))
 
     with pytest.raises(NotImplementedError):
         lock.acquire()
-
     with pytest.raises(NotImplementedError):
         lock._release()

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -385,26 +385,13 @@ def test_context_decorator(lock_type: type[BaseFileLock], tmp_path: Path) -> Non
     assert not lock.is_locked
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Tests behavior of UnixFileLock on Windows systems")
-def test_unix_lock_on_windows(tmp_path: Path) -> None:
-    lock = UnixFileLock(str(tmp_path / "lockfile"))
+def test_wrong_platform(tmp_path: Path) -> None:
+    lock_type = UnixFileLock if sys.platform == "win32" else WindowsFileLock
+    lock = lock_type(str(tmp_path / "lockfile"))
 
     assert not inspect.isabstract(  # noqa: SC200
         UnixFileLock
     ), "UnixFileLock must not be an abstract class, or pylint will complain in client code"
-    assert inspect.isabstract(BaseFileLock)  # noqa: SC200
-
-    with pytest.raises(NotImplementedError):
-        lock.acquire()
-
-    with pytest.raises(NotImplementedError):
-        lock._release()
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Tests behavior of WindowsFileLock on non-Windows systems")
-def test_windows_lock_on_unix(tmp_path: Path) -> None:
-    lock = WindowsFileLock(str(tmp_path / "lockfile"))
-
     assert not inspect.isabstract(  # noqa: SC200
         WindowsFileLock
     ), "WindowsFileLock must not be an abstract class, or pylint will complain in client code"

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -389,10 +389,10 @@ def test_context_decorator(lock_type: type[BaseFileLock], tmp_path: Path) -> Non
 def test_unix_lock_on_windows(tmp_path: Path) -> None:
     lock = UnixFileLock(str(tmp_path / "lockfile"))
 
-    assert not inspect.isabstract(
+    assert not inspect.isabstract(  # noqa: SC200
         UnixFileLock
     ), "UnixFileLock must not be an abstract class, or pylint will complain in client code"
-    assert inspect.isabstract(BaseFileLock)
+    assert inspect.isabstract(BaseFileLock)  # noqa: SC200
 
     with pytest.raises(NotImplementedError):
         lock.acquire()
@@ -405,10 +405,10 @@ def test_unix_lock_on_windows(tmp_path: Path) -> None:
 def test_windows_lock_on_unix(tmp_path: Path) -> None:
     lock = WindowsFileLock(str(tmp_path / "lockfile"))
 
-    assert not inspect.isabstract(
+    assert not inspect.isabstract(  # noqa: SC200
         WindowsFileLock
     ), "WindowsFileLock must not be an abstract class, or pylint will complain in client code"
-    assert inspect.isabstract(BaseFileLock)
+    assert inspect.isabstract(BaseFileLock)  # noqa: SC200
 
     with pytest.raises(NotImplementedError):
         lock.acquire()

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -386,9 +386,6 @@ def test_context_decorator(lock_type: type[BaseFileLock], tmp_path: Path) -> Non
 
 
 def test_wrong_platform(tmp_path: Path) -> None:
-    lock_type = UnixFileLock if sys.platform == "win32" else WindowsFileLock
-    lock = lock_type(str(tmp_path / "lockfile"))
-
     assert not inspect.isabstract(  # noqa: SC200
         UnixFileLock
     ), "UnixFileLock must not be an abstract class, or pylint will complain in client code"
@@ -396,6 +393,9 @@ def test_wrong_platform(tmp_path: Path) -> None:
         WindowsFileLock
     ), "WindowsFileLock must not be an abstract class, or pylint will complain in client code"
     assert inspect.isabstract(BaseFileLock)  # noqa: SC200
+
+    lock_type = UnixFileLock if sys.platform == "win32" else WindowsFileLock
+    lock = lock_type(str(tmp_path / "lockfile"))
 
     with pytest.raises(NotImplementedError):
         lock.acquire()

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -371,7 +371,6 @@ def test_poll_intervall_deprecated(lock_type: type[BaseFileLock], tmp_path: Path
             pytest.fail("No warnings of stacklevel=2 matching.")
 
 
-
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_context_decorator(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path = tmp_path / "a"

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -15,6 +15,7 @@ fmt
 fspath
 intersphinx
 intervall
+isabstract
 iwgrp
 iwoth
 iwusr


### PR DESCRIPTION
Instead of leaving abstract methods without definition when running on the other platform (Unix vs Windows), define them and raise a `NotImplementedError` if called on the wrong platform.

This fixes pylint warnings such as
```
   Abstract class 'WindowsFileLock' with abstract methods instantiated
   Abstract class 'UnixFileLock' with abstract methods instantiated
```

Fixes tox-dev/py-filelock#102