### PR TITLE
Use time.monotonic() for calculating timeouts.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 v3.5.1 (2022-02-16)
 -------------------
-- Use `time.monotonic` instead of `time.time` for calculating timeouts.
+- Use ``time.monotonic`` instead of ``time.time`` for calculating timeouts.
 
 v3.5.0 (2022-02-15)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 v3.5.1 (2022-02-16)
 -------------------
-- Use time.monotonic() instead of time.time() for calculating timeouts.
+- Use `time.monotonic` instead of `time.time` for calculating timeouts.
 
 v3.5.0 (2022-02-15)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v3.5.1 (2022-02-16)
+-------------------
+- Use time.monotonic() instead of time.time() for calculating timeouts.
+
 v3.5.0 (2022-02-15)
 -------------------
 - Enable use as context decorator

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -161,7 +161,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
 
         lock_id = id(self)
         lock_filename = self._lock_file
-        start_time = time.time()
+        start_time = time.monotonic()
         try:
             while True:
                 with self._thread_lock:
@@ -172,7 +172,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
                 if self.is_locked:
                     _LOGGER.debug("Lock %s acquired on %s", lock_id, lock_filename)
                     break
-                elif 0 <= timeout < time.time() - start_time:
+                elif 0 <= timeout < time.monotonic() - start_time:
                     _LOGGER.debug("Timeout on acquiring lock %s on %s", lock_id, lock_filename)
                     raise Timeout(self._lock_file)
                 else:


### PR DESCRIPTION
time.time() is affected by system clock updates (for example, by the NTP
daemon). This can cause timeouts to be unpredictable if clock jumps forwards or
backwards while code is waiting to acquire a lock.

time.monotonic() returns a time value that is not affected by clock updates and
does not have this issue. In Python 3.5 and later it is available on all systems[1].

[1] https://docs.python.org/3/library/time.html#time.monotonic