### PR TITLE
Workaround for a bug in the Google Drive app

### DIFF
--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -32,16 +32,27 @@ else:  # pragma: win32 no cover
 
         def _acquire(self) -> None:
             open_mode = os.O_RDWR | os.O_CREAT
-            fd = os.open(self._lock_file, open_mode)
-            try:
-                if os.fstat(fd).st_size == 0:
-                    os.write(fd, b"Lock files must not be empty, or the Google Drive app will replace them.")
-                    os.fsync(fd)
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError:
-                os.close(fd)
-            else:
-                self._lock_file_fd = fd
+            while True:
+                # Make sure we have a non-empty file.
+                fd = os.open(self._lock_file, open_mode)
+                try:
+                    if os.fstat(fd).st_size == 0:
+                        os.write(fd, b"Lock files must not be empty, or the Google Drive app will replace them.")
+                finally:
+                    os.close(fd)
+
+                fd = os.open(self._lock_file, open_mode)
+                try:
+                    if os.fstat(fd).st_size == 0:
+                        # Looks like Google Drive already replaced the file. Try again.
+                        os.close(fd)
+                        continue
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError:
+                    os.close(fd)
+                else:
+                    self._lock_file_fd = fd
+                break
 
         def _release(self) -> None:
             # Do not remove the lockfile:

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -31,9 +31,12 @@ else:  # pragma: win32 no cover
         """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
 
         def _acquire(self) -> None:
-            open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+            open_mode = os.O_RDWR | os.O_CREAT
             fd = os.open(self._lock_file, open_mode)
             try:
+                if os.fstat(fd).st_size == 0:
+                    os.write(fd, "Lock files must not be empty, or the Google Drive app will replace them.".encode("UTF-8"))
+                    os.fsync(fd)
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except OSError:
                 os.close(fd)

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -35,7 +35,7 @@ else:  # pragma: win32 no cover
             fd = os.open(self._lock_file, open_mode)
             try:
                 if os.fstat(fd).st_size == 0:
-                    os.write(fd, "Lock files must not be empty, or the Google Drive app will replace them.".encode("UTF-8"))
+                    os.write(fd, b"Lock files must not be empty, or the Google Drive app will replace them.")
                     os.fsync(fd)
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except OSError:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -44,3 +44,4 @@ stacklevel
 frameinfo
 getframeinfo
 lineno
+fstat


### PR DESCRIPTION
The Google Drive app has some interesting behavior if it tries to sync the directory that contains the lock file. If the file is empty, it will replace the file with another empty file of equal name. The lock stays with the original inode. Another process can lock the same file again, because it now gets a different inode.

This does not happen with files that aren't empty, so I changed the code to write a small explanation into the lock file when it first gets created.