### PR TITLE
Use license_files instead of license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/tox-dev/py-filelock
 author = Benedikt Schmitt
 author_email = benedikt@benediktschmitt.de
 license = Unlicense
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ url = https://github.com/tox-dev/py-filelock
 author = Benedikt Schmitt
 author_email = benedikt@benediktschmitt.de
 license = Unlicense
+license_file = LICENSE
 license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Fix the following warning:

```
/usr/lib/python3.10/site-packages/setuptools/config/setupcfg.py:459: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
```

Ref: https://github.com/pypa/setuptools/pull/2620