### PR TITLE
use time.perf_counter instead of time.monotonic

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+in progress
+-----------
+- Use ``time.perf_counter`` instead of ``time.monotonic`` for calculating timeouts.
+
 v3.9.0 (2022-12-28)
 -------------------
 - Move build backend to ``hatchling`` :pr:`185 - by :user:`gaborbernat`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,6 @@
 Changelog
 =========
-in progress
+v3.9.1 (2023-03-14)
 -----------
 - Use ``time.perf_counter`` instead of ``time.monotonic`` for calculating timeouts.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 v3.9.1 (2023-03-14)
------------
+-------------------
 - Use ``time.perf_counter`` instead of ``time.monotonic`` for calculating timeouts.
 
 v3.9.0 (2022-12-28)

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -164,7 +164,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
 
         lock_id = id(self)
         lock_filename = self._lock_file
-        start_time = time.monotonic()
+        start_time = time.perf_counter()
         try:
             while True:
                 with self._thread_lock:
@@ -178,7 +178,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
                 elif blocking is False:
                     _LOGGER.debug("Failed to immediately acquire lock %s on %s", lock_id, lock_filename)
                     raise Timeout(self._lock_file)
-                elif 0 <= timeout < time.monotonic() - start_time:
+                elif 0 <= timeout < time.perf_counter() - start_time:
                     _LOGGER.debug("Timeout on acquiring lock %s on %s", lock_id, lock_filename)
                     raise Timeout(self._lock_file)
                 else:

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -164,7 +164,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
 
         lock_id = id(self)
         lock_filename = self._lock_file
-        start_time = time.perf_counter()  # noqa: SC200
+        start_time = time.perf_counter()
         try:
             while True:
                 with self._thread_lock:
@@ -178,7 +178,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
                 elif blocking is False:
                     _LOGGER.debug("Failed to immediately acquire lock %s on %s", lock_id, lock_filename)
                     raise Timeout(self._lock_file)
-                elif 0 <= timeout < time.perf_counter() - start_time:  # noqa: SC200
+                elif 0 <= timeout < time.perf_counter() - start_time:
                     _LOGGER.debug("Timeout on acquiring lock %s on %s", lock_id, lock_filename)
                     raise Timeout(self._lock_file)
                 else:

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -164,7 +164,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
 
         lock_id = id(self)
         lock_filename = self._lock_file
-        start_time = time.perf_counter()
+        start_time = time.perf_counter()  # noqa: SC200
         try:
             while True:
                 with self._thread_lock:
@@ -178,7 +178,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
                 elif blocking is False:
                     _LOGGER.debug("Failed to immediately acquire lock %s on %s", lock_id, lock_filename)
                     raise Timeout(self._lock_file)
-                elif 0 <= timeout < time.perf_counter() - start_time:
+                elif 0 <= timeout < time.perf_counter() - start_time:  # noqa: SC200
                     _LOGGER.debug("Timeout on acquiring lock %s on %s", lock_id, lock_filename)
                     raise Timeout(self._lock_file)
                 else:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -20,6 +20,7 @@ msvcrt
 nblck
 nitpicky
 notset
+perf
 pygments
 rdwr
 ro


### PR DESCRIPTION
Use `time.perf_counter` instead of `time.monotonic` for calculating timeouts. The former has much higher clock resolution with comparable overhead, hence giving user finer timing control.

See
https://github.com/tox-dev/py-filelock/issues/191