### PR TITLE
Properly pickle of Timeout objects + test cases

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,12 @@
 Changelog
 =========
+v3.10.1 (2023-03-22)
+--------------------
+- Handle pickle for :class:`filelock.Timeout` :pr:`203` - by :user:`TheMatt2`.
+
 v3.10.0 (2023-03-15)
--------------------
-- Add support for explicit file modes for lockfiles :pr:`192 - by :user:`jahrules`.
+--------------------
+- Add support for explicit file modes for lockfiles :pr:`192` - by :user:`jahrules`.
 
 v3.9.1 (2023-03-14)
 -------------------
@@ -10,7 +14,7 @@ v3.9.1 (2023-03-14)
 
 v3.9.0 (2022-12-28)
 -------------------
-- Move build backend to ``hatchling`` :pr:`185 - by :user:`gaborbernat`.
+- Move build backend to ``hatchling`` :pr:`185` - by :user:`gaborbernat`.
 
 v3.8.1 (2022-12-04)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ line-length = 120
 [tool.isort]
 profile = "black"
 known_first_party = ["filelock"]
+add_imports = ["from __future__ import annotations"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -18,13 +18,13 @@ class Timeout(TimeoutError):
         return self.__class__, (self.filename,)
 
     def __str__(self) -> str:
-        return self.args[0] # type: ignore[no-any-return]
-                            # args[0] is explicitly set to str in __init__
+        return self.args[0]  # type: ignore[no-any-return]
+        # args[0] is explicitly set to str in __init__
 
     @property
     def lock_file(self) -> str:
         # For compatibility
-        return self.filename # type: ignore[no-any-return] # OSError.filename is str
+        return self.filename  # type: ignore[no-any-return] # OSError.filename is str
 
 
 __all__ = ["Timeout"]

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -7,23 +7,24 @@ class Timeout(TimeoutError):
     """Raised when the lock could not be acquired in *timeout* seconds."""
 
     def __init__(self, lock_file: str) -> None:
-        #: The path of the file lock.
-        super().__init__(f"The file lock '{lock_file}' could not be acquired.")
-
-        # Set filename so name of lock file is visible
-        self.filename = lock_file
+        super().__init__()
+        self._lock_file = lock_file
 
     def __reduce__(self) -> str | tuple[Any, ...]:
-        # Properly pickle the exception
-        return self.__class__, (self.filename,)
+        return self.__class__, (self._lock_file,)  # Properly pickle the exception
 
     def __str__(self) -> str:
-        return self.args[0]  # type: ignore[no-any-return] # args[0] is explicitly set to str in __init__
+        return f"The file lock '{self._lock_file}' could not be acquired."
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.lock_file!r})"
 
     @property
     def lock_file(self) -> str:
-        # For compatibility
-        return self.filename  # type: ignore[no-any-return] # OSError.filename is str
+        """:return: The path of the file lock."""
+        return self._lock_file
 
 
-__all__ = ["Timeout"]
+__all__ = [
+    "Timeout",
+]

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -18,13 +18,13 @@ class Timeout(TimeoutError):
         return self.__class__, (self.filename,)
 
     def __str__(self) -> str:
-        return self.args[0] # type: ignore[no-any-return]
-                            # args[0] is explicitly set to str in __init__
+        return self.args[0]  # type: ignore[no-any-return]
+                             # args[0] is explicitly set to str in __init__
 
     @property
     def lock_file(self) -> str:
         # For compatibility
-        return self.filename # type: ignore[no-any-return] # OSError.filename is str
+        return self.filename  # type: ignore[no-any-return] # OSError.filename is str
 
 
 __all__ = ["Timeout"]

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Tuple, Union
+from typing import Any
 
 
 class Timeout(TimeoutError):

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Any, Tuple, Union
 
 
@@ -12,7 +13,7 @@ class Timeout(TimeoutError):
         # Set filename so name of lock file is visible
         self.filename = lock_file
 
-    def __reduce__(self) -> Union[str, Tuple[Any, ...]]:
+    def __reduce__(self) -> str | tuple[Any, ...]:
         # Properly pickle the exception
         return self.__class__, (self.filename,)
 

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -18,12 +18,13 @@ class Timeout(TimeoutError):
         return self.__class__, (self.filename,)
 
     def __str__(self) -> str:
-        return self.args[0]
+        return self.args[0] # type: ignore[no-any-return]
+                            # args[0] is explicitly set to str in __init__
 
     @property
     def lock_file(self) -> str:
         # For compatibility
-        return self.filename
+        return self.filename # type: ignore[no-any-return] # OSError.filename is str
 
 
 __all__ = ["Timeout"]

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any, Tuple, Union
 
 
 class Timeout(TimeoutError):
@@ -6,12 +7,22 @@ class Timeout(TimeoutError):
 
     def __init__(self, lock_file: str) -> None:
         #: The path of the file lock.
-        self.lock_file = lock_file
+        super().__init__(f"The file lock '{lock_file}' could not be acquired.")
+
+        # Set filename so name of lock file is visible
+        self.filename = lock_file
+
+    def __reduce__(self) -> Union[str, Tuple[Any, ...]]:
+        # Properly pickle the exception
+        return self.__class__, (self.filename,)
 
     def __str__(self) -> str:
-        return f"The file lock '{self.lock_file}' could not be acquired."
+        return self.args[0]
+
+    @property
+    def lock_file(self) -> str:
+        # For compatibility
+        return self.filename
 
 
-__all__ = [
-    "Timeout",
-]
+__all__ = ["Timeout"]

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pickle
+
+from filelock import Timeout
+
+
+def test_timeout_str() -> None:
+    timeout = Timeout("/path/to/lock")
+    assert str(timeout) == "The file lock '/path/to/lock' could not be acquired."
+
+
+def test_timeout_repr() -> None:
+    timeout = Timeout("/path/to/lock")
+    assert repr(timeout) == "Timeout('/path/to/lock')"
+
+
+def test_timeout_lock_file() -> None:
+    timeout = Timeout("/path/to/lock")
+    assert timeout.lock_file == "/path/to/lock"
+
+
+def test_timeout_pickle() -> None:
+    timeout = Timeout("/path/to/lock")
+    timeout_loaded = pickle.loads(pickle.dumps(timeout))
+
+    assert timeout.__class__ == timeout_loaded.__class__
+    assert str(timeout) == str(timeout_loaded)
+    assert repr(timeout) == repr(timeout_loaded)
+    assert timeout.lock_file == timeout_loaded.lock_file

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import inspect
 import logging
 import os
-import pickle
 import sys
 import threading
 from contextlib import contextmanager
@@ -269,39 +268,6 @@ def test_timeout(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_1.release()
     assert not lock_1.is_locked
     assert not lock_2.is_locked
-
-
-def test_timeout_attributes() -> None:
-    # test Timeout error attributes
-    timeout = Timeout("/path/to/lock")
-
-    # Test string representation
-    assert str(timeout) == "The file lock '/path/to/lock' could not be acquired."
-    assert timeout.args == ("The file lock '/path/to/lock' could not be acquired.",)
-
-    # Test repr
-    assert repr(timeout) == "Timeout(\"The file lock '/path/to/lock' could not be acquired.\")"
-
-    # filename / lock_file attribute
-    assert timeout.filename == "/path/to/lock"
-    assert timeout.lock_file == "/path/to/lock"
-
-
-def test_timeout_pickle() -> None:
-    # test Timeout error pickles correctly
-    timeout_1 = Timeout("/path/to/lock")
-
-    # Test pickled object
-    timeout_2 = pickle.loads(pickle.dumps(timeout_1))
-
-    # Make sure the attributes are the same
-    # (Can't compare exceptions directly: https://stackoverflow.com/questions/15844131)
-    assert type(timeout_1) is type(timeout_2)
-    assert str(timeout_1) == str(timeout_2)
-    assert repr(timeout_1) == repr(timeout_2)
-    assert timeout_1.args == timeout_2.args
-    assert timeout_1.filename == timeout_2.filename
-    assert timeout_1.lock_file == timeout_2.lock_file
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -289,19 +289,19 @@ def test_timeout_attributes() -> None:
 
 def test_timeout_pickle() -> None:
     # test Timeout error pickles correctly
-    timeout = Timeout("/path/to/lock")
+    timeout_1 = Timeout("/path/to/lock")
 
     # Test pickled object
-    timeout2 = pickle.loads(pickle.dumps(timeout))
+    timeout_2 = pickle.loads(pickle.dumps(timeout_1))
 
     # Make sure the attributes are the same
     # (Can't compare exceptions directly: https://stackoverflow.com/questions/15844131)
-    assert type(timeout) is type(timeout2)
-    assert str(timeout) == str(timeout2)
-    assert repr(timeout) == repr(timeout2)
-    assert timeout.args == timeout2.args
-    assert timeout.filename == timeout2.filename
-    assert timeout.lock_file == timeout2.lock_file
+    assert type(timeout_1) is type(timeout_2)
+    assert str(timeout_1) == str(timeout_2)
+    assert repr(timeout_1) == repr(timeout_2)
+    assert timeout_1.args == timeout_2.args
+    assert timeout_1.filename == timeout_2.filename
+    assert timeout_1.lock_file == timeout_2.lock_file
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import inspect
 import logging
 import os
-import sys
 import pickle
+import sys
 import threading
 from contextlib import contextmanager
 from inspect import getframeinfo, stack
@@ -280,7 +280,7 @@ def test_timeout_attributes() -> None:
     assert timeout.args == ("The file lock '/path/to/lock' could not be acquired.",)
 
     # Test repr
-    assert repr(timeout) == 'Timeout("The file lock \'/path/to/lock\' could not be acquired.")'
+    assert repr(timeout) == "Timeout(\"The file lock '/path/to/lock' could not be acquired.\")"
 
     # filename / lock_file attribute
     assert timeout.filename == "/path/to/lock"


### PR DESCRIPTION
This is a fix for bug #202.

Timeout now registers a `__reduce__()` function to allow for proper pickling.
Tests check `Timeout` object has proper attributes and pickle successfully.