### PR TITLE
updated os.open to preserve mode

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+v3.10.4 (2023-03-24)
+--------------------
+- Update os.open to preserve mode= for certain edge cases. by :user:`jahrules`.
+
 v3.10.3 (2023-03-23)
 --------------------
 - Fix permission issue - by :user:`jahrules`.

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -32,7 +32,7 @@ else:  # pragma: win32 no cover
 
         def _acquire(self) -> None:
             open_flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
-            fd = os.open(self._lock_file, open_flags)
+            fd = os.open(self._lock_file, open_flags, self._mode)
             try:
                 os.chmod(fd, self._mode)
             except PermissionError:


### PR DESCRIPTION
Updated os.open to resolve following issue:
https://github.com/tox-dev/py-filelock/issues/210