### PR TITLE
proposed fix for issue #67

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,10 @@ repos:
     hooks:
       - id: tox-ini-fmt
         args: ["-p", "fix"]
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: "0.9.2"
+    hooks:
+      - id: pyproject-fmt
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+v3.10.5 (2023-03-25)
+--------------------
+- Add explicit error check as certain UNIX filesystems do not support flock. by :user:`jahrules`.
+
 v3.10.4 (2023-03-24)
 --------------------
 - Update os.open to preserve mode= for certain edge cases. by :user:`jahrules`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ optional-dependencies.docs = [
 optional-dependencies.testing = [
   "covdefaults>=2.3",
   "coverage>=7.2.2",
+  "diff-cover>=7.5",
   "pytest>=7.2.2",
   "pytest-cov>=4",
   "pytest-mock>=3.10",
@@ -57,6 +58,21 @@ build.hooks.vcs.version-file = "src/filelock/version.py"
 build.targets.sdist.include = ["/src", "/tests"]
 version.source = "vcs"
 
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+known_first_party = ["filelock"]
+add_imports = ["from __future__ import annotations"]
+
+[tool.flake8]
+max-complexity = 22
+max-line-length = 120
+unused-arguments-ignore-abstract-functions = true
+noqa-require-code = true
+dictionaries = ["en_US", "python", "technical", "django"]
+
 [tool.coverage]
 html.show_contexts = true
 html.skip_covered = false
@@ -66,14 +82,6 @@ report.fail_under = 76
 run.parallel = true
 run.plugins = ["covdefaults"]
 
-[tool.black]
-line-length = 120
-
-[tool.isort]
-profile = "black"
-known_first_party = ["filelock"]
-add_imports = ["from __future__ import annotations"]
-
 [tool.mypy]
 python_version = "3.11"
 show_error_codes = true
@@ -82,10 +90,3 @@ overrides = [{ module = ["appdirs.*", "jnius.*"], ignore_missing_imports = true 
 
 [tool.pep8]
 max-line-length = "120"
-
-[tool.flake8]
-max-complexity = 22
-max-line-length = 120
-unused-arguments-ignore-abstract-functions = true
-noqa-require-code = true
-dictionaries = ["en_US", "python", "technical", "django"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ optional-dependencies.testing = [
   "coverage>=7.2.2",
   "pytest>=7.2.2",
   "pytest-cov>=4",
+  "pytest-mock>=3.10",
   "pytest-timeout>=2.1",
 ]
 urls.Documentation = "https://py-filelock.readthedocs.io"

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -39,8 +39,10 @@ else:  # pragma: win32 no cover
                 pass  # This locked is not owned by this UID
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError:
+            except OSError as err:
                 os.close(fd)
+                if err.errno == 38:  # NotImplemented error number
+                    raise NotImplementedError("FileSystem does not appear to support flock; user SoftFileLock instead")
             else:
                 self._lock_file_fd = fd
 

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+from errno import ENOSYS
 from typing import cast
 
 from ._api import BaseFileLock
@@ -39,9 +40,9 @@ else:  # pragma: win32 no cover
                 pass  # This locked is not owned by this UID
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError as err:
+            except OSError as exception:
                 os.close(fd)
-                if err.errno == 38:  # NotImplemented error number
+                if exception.errno == ENOSYS:  # NotImplemented error
                     raise NotImplementedError("FileSystem does not appear to support flock; user SoftFileLock instead")
             else:
                 self._lock_file_fd = fd

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -503,7 +503,7 @@ def test_wrong_platform(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows filesystems support flock")
 def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     import fcntl
-    def dummy_flock(fd: Union[int, HasFileno], operation: str) -> None:
+    def dummy_flock(fd: Union[int, HasFileno], operation: int) -> None:
         raise OSError(ENOSYS, "mock error")
         return fd, operation  # needed for strict type checker
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -501,8 +501,8 @@ def test_wrong_platform(tmp_path: Path) -> None:
 def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     import fcntl
     def dummy_flock(fd: IO[str], operation: str) -> None:
-        if operation not in fd:  # fd and operation will never be equal
-            raise OSError(ENOSYS, "mock error")
+        raise OSError(ENOSYS, "mock error")
+        return fd, operation  # needed for strict type checker
 
     lock_path = tmp_path / "a.lock"
     _fcntl_flock = fcntl.flock

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -509,7 +509,8 @@ def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     try:
         fcntl.flock = dummy_flock
         with pytest.raises(NotImplementedError):
-            with FileLock(str(lock_path)): pass
+            with FileLock(str(lock_path)):
+                pass
 
     finally:
         fcntl.flock = _fcntl_flock

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -500,7 +500,7 @@ def test_wrong_platform(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows filesystems support flock")
 def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     import fcntl
-    def dummy_flock(fd: IO[Any], operation: str) -> None:
+    def dummy_flock(fd: IO[str], operation: str) -> None:
         if operation not in fd:  # fd and operation will never be equal
             raise OSError(ENOSYS, "mock error")
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import fcntl
 import inspect
 import logging
 import os
@@ -12,7 +11,7 @@ from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
 from types import TracebackType
-from typing import Callable, Iterator, Tuple, Type, Union
+from typing import Callable, IO, Iterator, Tuple, Type, Union
 
 import pytest
 from _pytest.logging import LogCaptureFixture
@@ -500,7 +499,8 @@ def test_wrong_platform(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows filesystems support flock")
 def test_flock_not_implemented_unix(tmp_path: Path) -> None:
-    def dummy_flock(fd, operation):
+    import fcntl
+    def dummy_flock(fd: IO, operation: str) -> None:
         if fd != operation:  # fd and operation will never be equal
             raise OSError(ENOSYS, "mock error")
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -11,7 +11,7 @@ from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
 from types import TracebackType
-from typing import Callable, IO, Iterator, Tuple, Type, TYPE_CHECKING, Union
+from typing import Callable, Iterator, Tuple, Type, TYPE_CHECKING, Union
 
 import pytest
 from _pytest.logging import LogCaptureFixture

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -11,7 +11,7 @@ from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
 from types import TracebackType
-from typing import Callable, Iterator, Tuple, Type, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Callable, Iterator, Tuple, Type, Union
 
 import pytest
 from _pytest.logging import LogCaptureFixture
@@ -504,7 +504,7 @@ def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     if sys.platform == "win32":
         pytest.skip("Windows filesystems support flock")
 
-    def dummy_flock(fd: Union[int, HasFileno], operation: int) -> None:
+    def dummy_flock(fd: int | HasFileno, operation: int) -> None:
         raise OSError(ENOSYS, "mock error")
         return fd, operation  # needed for strict type checker
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -499,8 +499,9 @@ def test_wrong_platform(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows filesystems support flock")
-def test_flock_not_implemented_UNIX(tmp_path: Path) -> None:
+def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     def dummy_flock(fd, operation):
+        fd, operation = ""  # added so the linter will be happy
         raise OSError(ENOSYS, "mock error")
 
     lock_path = tmp_path / "a.lock"

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -11,7 +11,7 @@ from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
 from types import TracebackType
-from typing import Callable, IO, Iterator, Tuple, Type, Union
+from typing import Callable, IO, Iterator, Tuple, Type, TYPE_CHECKING, Union
 
 import pytest
 from _pytest.logging import LogCaptureFixture
@@ -24,6 +24,9 @@ from filelock import (
     UnixFileLock,
     WindowsFileLock,
 )
+
+if TYPE_CHECKING:
+    from _typeshed import HasFileno
 
 
 @pytest.mark.parametrize(
@@ -500,7 +503,7 @@ def test_wrong_platform(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows filesystems support flock")
 def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     import fcntl
-    def dummy_flock(fd: IO[str], operation: str) -> None:
+    def dummy_flock(fd: Union[int, HasFileno], operation: str) -> None:
         raise OSError(ENOSYS, "mock error")
         return fd, operation  # needed for strict type checker
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -500,8 +500,8 @@ def test_wrong_platform(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows filesystems support flock")
 def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     import fcntl
-    def dummy_flock(fd: IO, operation: str) -> None:
-        if fd != operation:  # fd and operation will never be equal
+    def dummy_flock(fd: IO[Any], operation: str) -> None:
+        if operation not in fd:  # fd and operation will never be equal
             raise OSError(ENOSYS, "mock error")
 
     lock_path = tmp_path / "a.lock"

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -501,7 +501,7 @@ def test_wrong_platform(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows filesystems support flock")
 def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     def dummy_flock(fd, operation):
-        fd, operation = ""  # added so the linter will be happy
+        fd = operation = ""  # added so the linter will be happy
         raise OSError(ENOSYS, "mock error")
 
     lock_path = tmp_path / "a.lock"

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -501,8 +501,8 @@ def test_wrong_platform(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows filesystems support flock")
 def test_flock_not_implemented_unix(tmp_path: Path) -> None:
     def dummy_flock(fd, operation):
-        fd = operation = ""  # added so the linter will be happy
-        raise OSError(ENOSYS, "mock error")
+        if fd != operation:  # fd and operation will never be equal
+            raise OSError(ENOSYS, "mock error")
 
     lock_path = tmp_path / "a.lock"
     _fcntl_flock = fcntl.flock

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -508,12 +508,12 @@ def test_flock_not_implemented_unix(tmp_path: Path) -> None:
         return fd, operation  # needed for strict type checker
 
     lock_path = tmp_path / "a.lock"
-    _fcntl_flock = fcntl.flock
+    _fcntl_flock = fcntl.flock  # type: ignore[attr-defined]
     try:
-        fcntl.flock = dummy_flock
+        fcntl.flock = dummy_flock  # type: ignore[attr-defined]
         with pytest.raises(NotImplementedError):
             with FileLock(str(lock_path)):
                 pass
 
     finally:
-        fcntl.flock = _fcntl_flock
+        fcntl.flock = _fcntl_flock  # type: ignore[attr-defined]

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
       --cov-config=pyproject.toml --no-cov-on-fail --cov-report term-missing:skip-covered --cov-context=test \
       --cov-report html:{envtmpdir}{/}htmlcov --cov-report xml:{toxworkdir}{/}coverage.{envname}.xml \
       tests}
-    diff-cover --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}/coverage.xml
+    diff-cover --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}{/}coverage.{envname}.xml
 package = wheel
 wheel_build_env = .pkg
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
       --cov-config=pyproject.toml --no-cov-on-fail --cov-report term-missing:skip-covered --cov-context=test \
       --cov-report html:{envtmpdir}{/}htmlcov --cov-report xml:{toxworkdir}{/}coverage.{envname}.xml \
       tests}
+    diff-cover --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}/coverage.xml
 package = wheel
 wheel_build_env = .pkg
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -7,7 +7,6 @@ enosys
 extlinks
 filelock
 filemode
-fileno
 frameinfo
 fspath
 getframeinfo
@@ -31,6 +30,5 @@ skipif
 stacklevel
 trunc
 typehints
-typeshed
 unlck
 win32

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -3,6 +3,7 @@ autodoc
 autosectionlabel
 caplog
 eacces
+enoent
 extlinks
 filelock
 filemode

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -10,6 +10,7 @@ filemode
 frameinfo
 fspath
 getframeinfo
+hasfileno
 intersphinx
 intervall
 isabstract
@@ -30,5 +31,6 @@ skipif
 stacklevel
 trunc
 typehints
+typeshed
 unlck
 win32

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -3,7 +3,7 @@ autodoc
 autosectionlabel
 caplog
 eacces
-enoent
+enosys
 extlinks
 filelock
 filemode

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -7,10 +7,10 @@ enosys
 extlinks
 filelock
 filemode
+fileno
 frameinfo
 fspath
 getframeinfo
-hasfileno
 intersphinx
 intervall
 isabstract


### PR DESCRIPTION
This is a proposed fix for https://github.com/tox-dev/py-filelock/issues/67

As suggested in the issue; we're checking the OSError for NotImplemented (which is errno 38).

OSError 38 is not fatal; so this results in the reported issue of an indeterminate loop.

I don't see a clear way to "fall back" from a UnixFileLock to a SoftFileLock; so my proposal is to raise a fatal error with a clear message to the end user.

I also don't see a good way to create a testcase for this; as raising an OSError code 38 requires a condition that can't be easily simulated. I'm open to ideas for this if I'm missing something obvious.