### PR TITLE
use fchmod

### DIFF
--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -35,7 +35,7 @@ else:  # pragma: win32 no cover
             open_flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
             fd = os.open(self._lock_file, open_flags, self._mode)
             try:
-                os.chmod(fd, self._mode)
+                os.fchmod(fd, self._mode)
             except PermissionError:
                 pass  # This locked is not owned by this UID
             try:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -5,6 +5,7 @@ caplog
 eacces
 enosys
 extlinks
+fchmod
 filelock
 filemode
 fspath


### PR DESCRIPTION
I'm getting a TypeError when py-filelock calls os.chmod(). The problem occurs when using pypy3.9, but not python3.11  I'm running into this in the context of trying to install pre-commit, but the problem appears to be in py-filelock.

```
$ mamba create --name filelock
$ mamba activate filelock
$ mamba install pypy "python<3.10"
$ pip install pre-commit
$ pre-commit
An unexpected error has occurred: CalledProcessError: command: ('/Users/jakefennick/mambaforge-pypy3/envs/filelock/bin/python3.9', '-mvirtualenv', '/Users/jakefennick/.cache/pre-commit/repocvpepigy/py_env-python3.9')
return code: 1
stdout:
    RuntimeError: failed to build image pip, wheel, setuptools because:
    Traceback (most recent call last):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/seed/embed/via_app_data/via_app_data.py", line 52, in _install
        with parent.non_reentrant_lock_for_key(wheel_img.name):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/contextlib.py", line 119, in __enter__
        return next(self.gen)
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/util/lock.py", line 146, in non_reentrant_lock_for_key
        with _CountedFileLock(str(self.path / f"{name}.lock")):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_api.py", line 227, in __enter__
        self.acquire()
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/util/lock.py", line 29, in acquire
        super().acquire(timeout, poll_interval)
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_api.py", line 182, in acquire
        self._acquire()
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_unix.py", line 38, in _acquire
        os.chmod(fd, self._mode)
    TypeError: expected str, bytes or os.PathLike object, not int
    
    Traceback (most recent call last):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/seed/embed/via_app_data/via_app_data.py", line 52, in _install
        with parent.non_reentrant_lock_for_key(wheel_img.name):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/contextlib.py", line 119, in __enter__
        return next(self.gen)
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/util/lock.py", line 146, in non_reentrant_lock_for_key
        with _CountedFileLock(str(self.path / f"{name}.lock")):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_api.py", line 227, in __enter__
        self.acquire()
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/util/lock.py", line 29, in acquire
        super().acquire(timeout, poll_interval)
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_api.py", line 182, in acquire
        self._acquire()
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_unix.py", line 38, in _acquire
        os.chmod(fd, self._mode)
    TypeError: expected str, bytes or os.PathLike object, not int
    
    Traceback (most recent call last):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/seed/embed/via_app_data/via_app_data.py", line 52, in _install
        with parent.non_reentrant_lock_for_key(wheel_img.name):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/contextlib.py", line 119, in __enter__
        return next(self.gen)
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/util/lock.py", line 146, in non_reentrant_lock_for_key
        with _CountedFileLock(str(self.path / f"{name}.lock")):
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_api.py", line 227, in __enter__
        self.acquire()
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/virtualenv/util/lock.py", line 29, in acquire
        super().acquire(timeout, poll_interval)
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_api.py", line 182, in acquire
        self._acquire()
      File "/Users/jakefennick/mambaforge-pypy3/envs/filelock/lib/pypy3.9/site-packages/filelock/_unix.py", line 38, in _acquire
        os.chmod(fd, self._mode)
    TypeError: expected str, bytes or os.PathLike object, not int
stderr: (none)
Check the log at /Users/jakefennick/.cache/pre-commit/pre-commit.log
```

https://docs.python.org/3/library/os.html#os.chmod

Although the documentation claims that os.chmod accepts both a path-like object as well as an integer file descriptor, it does not seem to work here. However, in this case we 100% know we have a file descriptor, so directly calling os.fchmod should always work.