### PR TITLE
Make the lock a thread local variable

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -6,7 +6,7 @@ import os
 import time
 import warnings
 from abc import ABC, abstractmethod
-from threading import local, Lock
+from threading import Lock, local
 from types import TracebackType
 from typing import Any
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -6,7 +6,7 @@ import os
 import time
 import warnings
 from abc import ABC, abstractmethod
-from threading import Lock
+from threading import local, Lock
 from types import TracebackType
 from typing import Any
 
@@ -36,7 +36,7 @@ class AcquireReturnProxy:
         self.lock.release()
 
 
-class BaseFileLock(ABC, contextlib.ContextDecorator):
+class BaseFileLock(ABC, contextlib.ContextDecorator, local):
     """Abstract base class for a file lock object."""
 
     def __init__(

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -6,7 +6,7 @@ import os
 import time
 import warnings
 from abc import ABC, abstractmethod
-from threading import Lock, local
+from threading import local
 from types import TracebackType
 from typing import Any
 
@@ -66,9 +66,6 @@ class BaseFileLock(ABC, contextlib.ContextDecorator, local):
 
         # The mode for the lock files
         self._mode: int = mode
-
-        # We use this lock primarily for the lock counter.
-        self._thread_lock: Lock = Lock()
 
         # The lock counter is used for implementing the nested locking mechanism. Whenever the lock is acquired, the
         # counter is increased and the lock is only released, when this value is 0 again.
@@ -168,18 +165,16 @@ class BaseFileLock(ABC, contextlib.ContextDecorator, local):
             poll_interval = poll_intervall
 
         # Increment the number right at the beginning. We can still undo it, if something fails.
-        with self._thread_lock:
-            self._lock_counter += 1
+        self._lock_counter += 1
 
         lock_id = id(self)
         lock_filename = self._lock_file
         start_time = time.perf_counter()
         try:
             while True:
-                with self._thread_lock:
-                    if not self.is_locked:
-                        _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)
-                        self._acquire()
+                if not self.is_locked:
+                    _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)
+                    self._acquire()
                 if self.is_locked:
                     _LOGGER.debug("Lock %s acquired on %s", lock_id, lock_filename)
                     break
@@ -194,8 +189,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator, local):
                     _LOGGER.debug(msg, lock_id, lock_filename, poll_interval)
                     time.sleep(poll_interval)
         except BaseException:  # Something did go wrong, so decrement the counter.
-            with self._thread_lock:
-                self._lock_counter = max(0, self._lock_counter - 1)
+            self._lock_counter = max(0, self._lock_counter - 1)
             raise
         return AcquireReturnProxy(lock=self)
 
@@ -206,17 +200,16 @@ class BaseFileLock(ABC, contextlib.ContextDecorator, local):
 
         :param force: If true, the lock counter is ignored and the lock is released in every case/
         """
-        with self._thread_lock:
-            if self.is_locked:
-                self._lock_counter -= 1
+        if self.is_locked:
+            self._lock_counter -= 1
 
-                if self._lock_counter == 0 or force:
-                    lock_id, lock_filename = id(self), self._lock_file
+            if self._lock_counter == 0 or force:
+                lock_id, lock_filename = id(self), self._lock_file
 
-                    _LOGGER.debug("Attempting to release lock %s on %s", lock_id, lock_filename)
-                    self._release()
-                    self._lock_counter = 0
-                    _LOGGER.debug("Lock %s released on %s", lock_id, lock_filename)
+                _LOGGER.debug("Attempting to release lock %s on %s", lock_id, lock_filename)
+                self._release()
+                self._lock_counter = 0
+                _LOGGER.debug("Lock %s released on %s", lock_id, lock_filename)
 
     def __enter__(self) -> BaseFileLock:
         """

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import sys
 from errno import ENOENT
-from threading import local
 from typing import cast
 
 from ._api import BaseFileLock
@@ -12,7 +11,7 @@ from ._util import raise_on_exist_ro_file
 if sys.platform == "win32":  # pragma: win32 cover
     import msvcrt
 
-    class WindowsFileLock(BaseFileLock, local):
+    class WindowsFileLock(BaseFileLock):
         """Uses the :func:`msvcrt.locking` function to hard lock the lock file on windows systems."""
 
         def _acquire(self) -> None:

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from errno import ENOENT
+from threading import local
 from typing import cast
 
 from ._api import BaseFileLock
@@ -11,7 +12,7 @@ from ._util import raise_on_exist_ro_file
 if sys.platform == "win32":  # pragma: win32 cover
     import msvcrt
 
-    class WindowsFileLock(BaseFileLock):
+    class WindowsFileLock(BaseFileLock, local):
         """Uses the :func:`msvcrt.locking` function to hard lock the lock file on windows systems."""
 
         def _acquire(self) -> None:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -83,6 +83,10 @@ def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have read only folders")
+@pytest.mark.skipif(
+    sys.platform != "win32" and os.geteuid() == 0,  # noqa: SC200
+    reason="Cannot make a read only file (that the current user: root can't read)",
+)
 def test_ro_folder(lock_type: type[BaseFileLock], tmp_path_ro: Path) -> None:
     lock = lock_type(str(tmp_path_ro / "a"))
     with pytest.raises(PermissionError, match="Permission denied"):
@@ -98,6 +102,10 @@ def tmp_file_ro(tmp_path: Path) -> Iterator[Path]:
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+@pytest.mark.skipif(
+    sys.platform != "win32" and os.geteuid() == 0,  # noqa: SC200
+    reason="Cannot make a read only file (that the current user: root can't read)",
+)
 def test_ro_file(lock_type: type[BaseFileLock], tmp_file_ro: Path) -> None:
     lock = lock_type(str(tmp_file_ro))
     with pytest.raises(PermissionError, match="Permission denied"):

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -514,16 +514,16 @@ def test_soft_errors(tmp_path: Path, mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_thrashing_with_threadpool_passing_lock_to_threads(tmp_path: Path, lock_type: BaseFileLock) -> None:
+def test_thrashing_with_thread_pool_passing_lock_to_threads(tmp_path: Path, lock_type: BaseFileLock) -> None:
     lock_file = tmp_path / "test.txt.lock"
     txt_file = tmp_path / "test.txt"
 
     # notice how lock is passed to the function below
     lock = lock_type(lock_file)
 
-    def mess_with_file(lock, txt_file):
+    def mess_with_file(lock: BaseFileLock, txt_file: Path):
         with lock:
-            for _ in range (3):
+            for _ in range(3):
                 u = str(uuid4())
                 txt_file.write_text(u)
                 assert txt_file.read_text() == u
@@ -539,16 +539,16 @@ def test_thrashing_with_threadpool_passing_lock_to_threads(tmp_path: Path, lock_
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_thrashing_with_threadpool_global_lock(tmp_path: Path, lock_type: BaseFileLock) -> None:
+def test_thrashing_with_thread_pool_global_lock(tmp_path: Path, lock_type: BaseFileLock) -> None:
     lock_file = tmp_path / "test.txt.lock"
     txt_file = tmp_path / "test.txt"
 
     # Notice how lock is scoped to be allowed in the nested function below
     lock = lock_type(lock_file)
 
-    def mess_with_file(txt_file):
+    def mess_with_file(txt_file: Path):
         with lock:
-            for _ in range (3):
+            for _ in range(3):
                 u = str(uuid4())
                 txt_file.write_text(u)
                 assert txt_file.read_text() == u
@@ -564,13 +564,13 @@ def test_thrashing_with_threadpool_global_lock(tmp_path: Path, lock_type: BaseFi
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_thrashing_with_threadpool_lock_recreated_in_each_thread(tmp_path: Path, lock_type: BaseFileLock) -> None:
+def test_thrashing_with_thread_pool_lock_recreated_in_each_thread(tmp_path: Path, lock_type: BaseFileLock) -> None:
     lock_file = tmp_path / "test.txt.lock"
     txt_file = tmp_path / "test.txt"
 
-    def mess_with_file(lock_type, lock_file, txt_file):
+    def mess_with_file(lock_type: type, lock_file: Path, txt_file: Path):
         with lock_type(lock_file):
-            for _ in range (3):
+            for _ in range(3):
                 u = str(uuid4())
                 txt_file.write_text(u)
                 assert txt_file.read_text() == u


### PR DESCRIPTION
Fixes #82

With this, i can successfully run on win32 and on wsl (ubuntu)

```
import tempfile
import pathlib
import threading
from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
from filelock import FileLock
import time
import logging

#log = logging.getLogger("filelock")
#log.setLevel(logging.DEBUG)
#log.addHandler(logging.StreamHandler())

TEST_FILE = pathlib.Path(tempfile.gettempdir()) / 'test_file.txt'
TEST_LOCK_FILE =  pathlib.Path(tempfile.gettempdir()) / 'test_file.txt.lock'
LOCK = FileLock(TEST_LOCK_FILE)

def test():
    with LOCK:
        assert TEST_FILE.read_text() == 'hi'
        TEST_FILE.write_text('')
        assert TEST_FILE.read_text() == ''
        TEST_FILE.write_text('hi')
        assert TEST_FILE.read_text() == 'hi'
        return True

if __name__ == '__main__':
    print(f"Test file: {TEST_FILE}")
    print(f"Test lock file: {TEST_LOCK_FILE}")
    TEST_FILE.write_text('hi')

    results = []

    # works with ProcessPoolExecutor but not with ThreadPoolExecutor
    # It also is more likely to work if we sleep after calling submit()
    with ThreadPoolExecutor(max_workers=256) as pool:
        for i in range(1000):
            if i % 10 == 0:
                print (f"Loop: {i+1}")
            results.append(pool.submit(test))

        for idx, result in enumerate(results):
            print (f"Checking result: {idx + 1}")
            assert result.result() == True
```

(which is a version of the original failing code from #82 )