### PR TITLE
Fix #220: Allow filelock test thread to catch any exceptions

### DIFF
--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -185,7 +185,7 @@ class ExThread(threading.Thread):
     def run(self) -> None:
         try:
             super().run()
-        except:  # pragma: no cover
+        except BaseException:  # pragma: no cover
             self.ex = sys.exc_info()  # pragma: no cover
 
     def join(self, timeout: float | None = None) -> None:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -185,7 +185,7 @@ class ExThread(threading.Thread):
     def run(self) -> None:
         try:
             super().run()
-        except BaseException:  # pragma: no cover
+        except Exception:  # pragma: no cover
             self.ex = sys.exc_info()  # pragma: no cover
 
     def join(self, timeout: float | None = None) -> None:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -185,7 +185,7 @@ class ExThread(threading.Thread):
     def run(self) -> None:
         try:
             super().run()
-        except RuntimeError:  # pragma: no cover
+        except:  # pragma: no cover
             self.ex = sys.exc_info()  # pragma: no cover
 
     def join(self, timeout: float | None = None) -> None:


### PR DESCRIPTION
Fixes a potential issue in test_filelock.py in #220

If someone where to introduce a bug (such as reintroducing #31 ) that caused file locking
not to secure exclusive access, no test actually fails. Instead, a warning is shown by Pytest.

This fixes the issue by catching any error in a thread while testing, and reraising it in the main thread.

```

tests/test_error.py ....                                                                                                                                [  8%]
tests/test_filelock.py ....................F.........................                                                                                   [100%]

========================================================================== FAILURES ===========================================================================
_____________________________________________________ test_threaded_lock_different_lock_obj[UnixFileLock] _____________________________________________________

self = <ExThread(t1_0, stopped 123145355259904)>

    def run(self) -> None:
        try:
>           super().run()

tests/test_filelock.py:187: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ExThread(t1_0, stopped 123145355259904)>

    def run(self):
        """Method representing the thread's activity.
    
        You may override this method in a subclass. The standard run() method
        invokes the callable object passed to the object's constructor as the
        target argument, if any, with sequential and keyword arguments taken
        from the args and kwargs arguments, respectively.
    
        """
        try:
            if self._target is not None:
>               self._target(*self._args, **self._kwargs)

.../threading.py:975: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def t_1() -> None:
        for _ in range(1000):
            with lock_1:
                assert lock_1.is_locked
>               assert not lock_2.is_locked
E               assert not True
E                +  where True = <filelock._unix.UnixFileLock object at 0x102083990>.is_locked

tests/test_filelock.py:229: AssertionError

The above exception was the direct cause of the following exception:

lock_type = <class 'filelock._unix.UnixFileLock'>
tmp_path = PosixPath('.../pytest-18/test_threaded_lock_different_l0')

    @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
    @pytest.mark.skipif(hasattr(sys, "pypy_version_info") and sys.platform == "win32", reason="deadlocks randomly")
    def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
        # Runs multiple threads, which acquire the same lock file with a different FileLock object. When thread group 1
        # acquired the lock, thread group 2 must not hold their lock.
    
        def t_1() -> None:
            for _ in range(1000):
                with lock_1:
                    assert lock_1.is_locked
                    assert not lock_2.is_locked
    
        def t_2() -> None:
            for _ in range(1000):
                with lock_2:
                    assert not lock_1.is_locked
                    assert lock_2.is_locked
    
        lock_path = tmp_path / "a"
        lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
        threads = [(ExThread(t_1, f"t1_{i}"), ExThread(t_2, f"t2_{i}")) for i in range(10)]
    
        for thread_1, thread_2 in threads:
            thread_1.start()
            thread_2.start()
        for thread_1, thread_2 in threads:
>           thread_1.join()

tests/test_filelock.py:245: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ExThread(t1_0, stopped 123145355259904)>, timeout = None

    def join(self, timeout: float | None = None) -> None:
        super().join(timeout=timeout)
        if self.ex is not None:
            print(f"fail from thread {self.name}")  # pragma: no cover
>           raise RuntimeError from self.ex[1]  # pragma: no cover
E           RuntimeError

tests/test_filelock.py:195: RuntimeError
-------------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------------
fail from thread t1_0
=================================================================== short test summary info ===================================================================
FAILED tests/test_filelock.py::test_threaded_lock_different_lock_obj[UnixFileLock] - RuntimeError
================================================================ 1 failed, 49 passed in 2.65s =================================================================
``` 