### PR TITLE
Fix: #225 :Get rid of warning about inability to link to _thread._local.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ autosectionlabel_prefix_document = True
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpicky = True
-nitpick_ignore = []
+nitpick_ignore = [("py:class", "_thread._local")]
 extlinks = {
     "issue": ("https://github.com/tox-dev/py-filelock/issues/%s", "issue #%s"),
     "pr": ("https://github.com/tox-dev/py-filelock/issues/%s", "PR #%s"),

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ wheel_build_env = .pkg
 extras =
     testing
 passenv =
-    PYTEST_*
+    PYTEST_ADDOPTS
 setenv =
     COVERAGE_FILE = {toxworkdir}{/}.coverage.{envname}
 commands =
@@ -38,8 +38,6 @@ basepython = python3.10
 skip_install = true
 deps =
     pre-commit>=3.2.1
-passenv =
-    *
 commands =
     pre-commit run --all-files --show-diff-on-failure
     python -c 'import pathlib; print("hint: run \{\} install to add checks as pre-commit hook".format(pathlib.Path(r"{envdir}") / "bin" / "pre-commit"))'
@@ -85,7 +83,7 @@ description = build documentation
 extras =
     docs
 commands =
-    sphinx-build -d "{envtmpdir}{/}doctree" docs "{toxworkdir}{/}docs_out" --color -b html {posargs}
+    sphinx-build -d "{envtmpdir}{/}doctree" docs "{toxworkdir}{/}docs_out" --color -b html -W {posargs}
     python -c 'print(r"documentation available under file://{toxworkdir}{/}docs_out{/}index.html")'
 
 [testenv:readme]

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,13 +1,17 @@
+addnodes
 autoclass
 autodoc
 autosectionlabel
 caplog
+contnode
+docutils
 eacces
 enosys
 extlinks
 fchmod
 filelock
 filemode
+fromdocname
 fspath
 getframeinfo
 intersphinx


### PR DESCRIPTION
I'm not sure why it resolves this way, but there is no link for that pathing

Related sphinx issue: https://github.com/sphinx-doc/sphinx/issues/9338