### PR TITLE
Fix lock hang on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear==23.3.23
-          - flake8-comprehensions==3.11.1
+          - flake8-comprehensions==3.12
           - flake8-pytest-style==1.7.2
           - flake8-spellcheck==0.28
           - flake8-unused-arguments==0.0.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,13 @@ dynamic = [
 optional-dependencies.docs = [
   "furo>=2023.3.27",
   "sphinx>=6.1.3",
-  "sphinx-autodoc-typehints!=1.23.4,>=1.22",
+  "sphinx-autodoc-typehints!=1.23.4,>=1.23",
 ]
 optional-dependencies.testing = [
   "covdefaults>=2.3",
   "coverage>=7.2.3",
   "diff-cover>=7.5",
-  "pytest>=7.2.2",
+  "pytest>=7.3.1",
   "pytest-cov>=4",
   "pytest-mock>=3.10",
   "pytest-timeout>=2.1",

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -5,14 +5,14 @@ import sys
 from errno import EACCES, EEXIST
 
 from ._api import BaseFileLock
-from ._util import raise_unwritable_file
+from ._util import raise_on_not_writable_file
 
 
 class SoftFileLock(BaseFileLock):
     """Simply watches the existence of the lock file."""
 
     def _acquire(self) -> None:
-        raise_unwritable_file(self._lock_file)
+        raise_on_not_writable_file(self._lock_file)
         # first check for exists and read-only mode as the open will mask this case as EEXIST
         flags = (
             os.O_WRONLY  # open for writing only

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -5,14 +5,14 @@ import sys
 from errno import EACCES, EEXIST
 
 from ._api import BaseFileLock
-from ._util import raise_on_exist_ro_file
+from ._util import raise_unwritable_file
 
 
 class SoftFileLock(BaseFileLock):
     """Simply watches the existence of the lock file."""
 
     def _acquire(self) -> None:
-        raise_on_exist_ro_file(self._lock_file)
+        raise_unwritable_file(self._lock_file)
         # first check for exists and read-only mode as the open will mask this case as EEXIST
         flags = (
             os.O_WRONLY  # open for writing only

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -2,9 +2,18 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
+from errno import EACCES, EISDIR
 
 
-def raise_on_exist_ro_file(filename: str) -> None:
+def raise_unwritable_file(filename: str) -> None:
+    """
+    Raise an exception if attempting to open the file for writing would fail.
+    This is done so files that will never be writable can be separated from
+    files that are writable but currently locked
+    :param filename: file to check
+    :raises OSError: as if the file was opened for writing
+    """
     try:
         file_stat = os.stat(filename)  # use stat to do exists + can write to check without race condition
     except OSError:
@@ -12,9 +21,17 @@ def raise_on_exist_ro_file(filename: str) -> None:
 
     if file_stat.st_mtime != 0:  # if os.stat returns but modification is zero that's an invalid os.stat - ignore it
         if not (file_stat.st_mode & stat.S_IWUSR):
-            raise PermissionError(f"Permission denied: {filename!r}")
+            raise PermissionError(EACCES, "Permission denied", filename)
+
+        if stat.S_ISDIR(file_stat.st_mode):
+            if sys.platform == "win32":
+                # On Windows, this is PermissionError
+                raise PermissionError(EACCES, "Permission denied", filename)
+            else:
+                # On linux / macOS, this is IsADirectoryError
+                raise IsADirectoryError(EISDIR, "Is a directory", filename)
 
 
 __all__ = [
-    "raise_on_exist_ro_file",
+    "raise_unwritable_file",
 ]

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -6,7 +6,7 @@ import sys
 from errno import EACCES, EISDIR
 
 
-def raise_unwritable_file(filename: str) -> None:
+def raise_on_not_writable_file(filename: str) -> None:
     """
     Raise an exception if attempting to open the file for writing would fail.
     This is done so files that will never be writable can be separated from
@@ -24,14 +24,14 @@ def raise_unwritable_file(filename: str) -> None:
             raise PermissionError(EACCES, "Permission denied", filename)
 
         if stat.S_ISDIR(file_stat.st_mode):
-            if sys.platform == "win32":
+            if sys.platform == "win32":  # pragma: win32 cover
                 # On Windows, this is PermissionError
                 raise PermissionError(EACCES, "Permission denied", filename)
-            else:
+            else:  # pragma: win32 no cover
                 # On linux / macOS, this is IsADirectoryError
                 raise IsADirectoryError(EISDIR, "Is a directory", filename)
 
 
 __all__ = [
-    "raise_unwritable_file",
+    "raise_on_not_writable_file",
 ]

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -6,7 +6,7 @@ from errno import EACCES
 from typing import cast
 
 from ._api import BaseFileLock
-from ._util import raise_unwritable_file
+from ._util import raise_on_not_writable_file
 
 if sys.platform == "win32":  # pragma: win32 cover
     import msvcrt
@@ -15,7 +15,7 @@ if sys.platform == "win32":  # pragma: win32 cover
         """Uses the :func:`msvcrt.locking` function to hard lock the lock file on windows systems."""
 
         def _acquire(self) -> None:
-            raise_unwritable_file(self._lock_file)
+            raise_on_not_writable_file(self._lock_file)
             flags = (
                 os.O_RDWR  # open for read and write
                 | os.O_CREAT  # create file if not exists

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -135,7 +135,7 @@ else:
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 @pytest.mark.parametrize(
-    "expected_error,match,bad_lock_file",
+    ("expected_error", "match", "bad_lock_file"),
     bad_lock_file_errors,
     ids=[e[0].__name__ for e in bad_lock_file_errors],
 )

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -114,31 +114,38 @@ def test_ro_file(lock_type: type[BaseFileLock], tmp_file_ro: Path) -> None:
 
 if sys.platform == "win32":
     # filenames that will raise errors
-    bad_lock_file_errors: list[Tuple[Type[Exception], str, str]] = [
-        (FileNotFoundError, "No such file or directory:", "a/b"),       # non-existent directory
-        (FileNotFoundError, "No such file or directory:", ""),          # blank filename
-        (PermissionError, "Permission denied:", "."),                   # current directory
-        (PermissionError, "Permission denied:", "/"),                   # root directory
-        (OSError, "Invalid argument", '<>:"/\\|?*\a'),                  # invalid characters
-        (ValueError, "embedded null (byte|character)", "\0")            # null character
+    bad_lock_file_errors: list[tuple[type[Exception], str, str]] = [
+        (FileNotFoundError, "No such file or directory:", "a/b"),  # non-existent directory
+        (FileNotFoundError, "No such file or directory:", ""),  # blank filename
+        (PermissionError, "Permission denied:", "."),  # current directory
+        (PermissionError, "Permission denied:", "/"),  # root directory
+        (OSError, "Invalid argument", '<>:"/\\|?*\a'),  # invalid characters
+        (ValueError, "embedded null (byte|character)", "\0"),  # null character
     ]
 else:
     # filenames that will raise errors
-    bad_lock_file_errors: list[Tuple[Type[Exception], str, str]] = [
-        (FileNotFoundError, "No such file or directory:", "a/b"),       # non-existent directory
-        (FileNotFoundError, "No such file or directory:", ""),          # blank filename
-        (IsADirectoryError, "Is a directory", "."),                     # current directory
-        (IsADirectoryError, "Is a directory", "/"),                     # root directory
-        (ValueError, "embedded null (byte|character)", "\0")            # null byte
+    bad_lock_file_errors: list[tuple[type[Exception], str, str]] = [
+        (FileNotFoundError, "No such file or directory:", "a/b"),  # non-existent directory
+        (FileNotFoundError, "No such file or directory:", ""),  # blank filename
+        (IsADirectoryError, "Is a directory", "."),  # current directory
+        (IsADirectoryError, "Is a directory", "/"),  # root directory
+        (ValueError, "embedded null (byte|character)", "\0"),  # null byte
     ]
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-@pytest.mark.parametrize("expected_error,match,bad_lock_file", bad_lock_file_errors,
-                         ids=[e[0].__name__ for e in bad_lock_file_errors])
+@pytest.mark.parametrize(
+    "expected_error,match,bad_lock_file",
+    bad_lock_file_errors,
+    ids=[e[0].__name__ for e in bad_lock_file_errors],
+)
 @pytest.mark.timeout(5)  # timeout in case of infinite loop
-def test_bad_lock_file(lock_type: type[BaseFileLock],
-                       expected_error: Type[Exception], match: str, bad_lock_file: str) -> None:
+def test_bad_lock_file(
+    lock_type: type[BaseFileLock],
+    expected_error: type[Exception],
+    match: str,
+    bad_lock_file: str,
+) -> None:
     lock = lock_type(bad_lock_file)
 
     with pytest.raises(expected_error, match=match):

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -120,7 +120,7 @@ if sys.platform == "win32":
         (PermissionError, "Permission denied:", "."),                   # current directory
         (PermissionError, "Permission denied:", "/"),                   # root directory
         (OSError, "Invalid argument", '<>:"/\\|?*\a'),                  # invalid characters
-        (ValueError, "embedded null character", "\0")                   # null character
+        (ValueError, "embedded null (byte|character)", "\0")            # null character
     ]
 else:
     # filenames that will raise errors
@@ -129,7 +129,7 @@ else:
         (FileNotFoundError, "No such file or directory:", ""),          # blank filename
         (IsADirectoryError, "Is a directory", "."),                     # current directory
         (IsADirectoryError, "Is a directory", "/"),                     # root directory
-        (ValueError, "embedded null character", "\0")                   # null character
+        (ValueError, "embedded null (byte|character)", "\0")            # null byte
     ]
 
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -36,5 +36,4 @@ stacklevel
 trunc
 typehints
 unlck
-unwritable
 win32

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -6,6 +6,7 @@ caplog
 contnode
 docutils
 eacces
+eisdir
 enosys
 extlinks
 fchmod
@@ -35,4 +36,5 @@ stacklevel
 trunc
 typehints
 unlck
+unwritable
 win32


### PR DESCRIPTION
Solves an issue where `FileLock` and `SoftFileLock` could hang sit in an infinite loop if `PermissionError` or `OSError` is encountered on Windows while trying to lock the file.

Originally mentioned on #147.

On Windows, if the name of the file given is invalid, such as forgetting to to double backspace on windows, the EINVAL message is not accounted for in the error handling.

```python
import filelock

filename = "C:\path\to\lock\but\backslash\is\not\escaped"
with filelock.FileLock(filename):
    pass # waits forever and never completes
```

If you had just tried to open the file, you would see the following message:

```
filename = "C:\path\to\lock\but\backslash\is\not\escaped"
f = open(filename)
```

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 22] Invalid argument: 'C:\\path\to\\lock\x08ut\x08ackslash\\is\not\\escaped'
```

The issue that is being danced around is it seems `PermissionError` will randomly occur on `os.open()` when trying to open the lock file. I have been unable to figure out *why* Windows raises `PermissionError`, but that seems somewhat a mute point.

https://github.com/tox-dev/py-filelock/blob/dceb9e5b7e4edd232435521f20efe189fe88f71b/src/filelock/_windows.py#L24-L28

The problem is any error raised, other than the one explicitly handled, ignoring other errors.
This is corrected by ignoring some explicit errors, but allowing other errors to be raised.

This also adds a check for if the path of the lock file is a directory. On Windows, trying to open a path that is a directory as a file would raise a `PermissionError` that can't be differentiated from the exception that is sometimes raised from just trying to open the file in the middle of a bunch of locking and unlocking.

Renamed `utils.raise_on_exist_ro_file(filename)` to `utils.raise_unwritable_file(filename)` to better describe what is does, now that the directory check has been added to it.