### PR TITLE
Conditionally disable/enable thread-local lock behavior.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+v3.12.0 (2023-04-18)
+--------------------
+- Make the thread local behaviour something the caller can enable/disable via a flag during the lock creation, it's on
+  by default.
+- Better error handling on Windows.
+
 v3.11.0 (2023-04-06)
 --------------------
 - Make the lock thread local.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -143,6 +143,29 @@ Asyncio support
 This library currently does not support asyncio. We'd recommend adding an asyncio variant though if someone can make a
 pull request for it, `see here <https://github.com/tox-dev/py-filelock/issues/99>`_.
 
+FileLocks and threads
+---------------------
+
+By default the :class:`FileLock <filelock.FileLock>` internally uses :class:`threading.local <threading.local>`
+to ensure that the lock is thread-local. If you have a use case where you'd like an instance of ``FileLock`` to be shared
+across threads, you can set the ``thread_local`` parameter to ``False`` when creating a lock. For example:
+
+.. code-block:: python
+
+    lock = FileLock("test.lock", thread_local=False)
+    # lock will be re-entrant across threads
+
+    # The same behavior would also work with other instances of BaseFileLock like SoftFileLock:
+    soft_lock = SoftFileLock("soft_test.lock", thread_local=False)
+    # soft_lock will be re-entrant across threads.
+
+
+Behavior where :class:`FileLock <filelock.FileLock>` is thread-local started in version 3.11.0. Previous versions,
+were not thread-local by default.
+
+Note: If disabling thread-local, be sure to remember that locks are re-entrant: You will be able to
+:meth:`acquire <filelock.BaseFileLock.acquire>` the same lock multiple times across multiple threads.
+
 Contributions and issues
 ------------------------
 

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -32,11 +32,10 @@ else:  # pragma: win32 no cover
         if warnings is not None:
             warnings.warn("only soft file lock is available", stacklevel=2)
 
-#: Alias for the lock, which should be used for the current platform. On Windows, this is an alias for
-# :class:`WindowsFileLock`, on Unix for :class:`UnixFileLock` and otherwise for :class:`SoftFileLock`.
 if TYPE_CHECKING:
     FileLock = SoftFileLock
 else:
+    #: Alias for the lock, which should be used for the current platform.
     FileLock = _FileLock
 
 

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -12,7 +12,7 @@ class SoftFileLock(BaseFileLock):
     """Simply watches the existence of the lock file."""
 
     def _acquire(self) -> None:
-        raise_on_not_writable_file(self._lock_file)
+        raise_on_not_writable_file(self.lock_file)
         # first check for exists and read-only mode as the open will mask this case as EEXIST
         flags = (
             os.O_WRONLY  # open for writing only
@@ -21,7 +21,7 @@ class SoftFileLock(BaseFileLock):
             | os.O_TRUNC  # truncate the file to zero byte
         )
         try:
-            file_handler = os.open(self._lock_file, flags, self._mode)
+            file_handler = os.open(self.lock_file, flags, self._context.mode)
         except OSError as exception:  # re-raise unless expected exception
             if not (
                 exception.errno == EEXIST  # lock already exist
@@ -29,13 +29,13 @@ class SoftFileLock(BaseFileLock):
             ):  # pragma: win32 no cover
                 raise
         else:
-            self._lock_file_fd = file_handler
+            self._context.lock_file_fd = file_handler
 
     def _release(self) -> None:
-        os.close(self._lock_file_fd)  # type: ignore # the lock file is definitely not None
-        self._lock_file_fd = None
+        os.close(self._context.lock_file_fd)  # type: ignore # the lock file is definitely not None
+        self._context.lock_file_fd = None
         try:
-            os.remove(self._lock_file)
+            os.remove(self.lock_file)
         except OSError:  # the file is already deleted and that's what we want
             pass
 

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -33,9 +33,9 @@ else:  # pragma: win32 no cover
 
         def _acquire(self) -> None:
             open_flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
-            fd = os.open(self._lock_file, open_flags, self._mode)
+            fd = os.open(self.lock_file, open_flags, self._context.mode)
             try:
-                os.fchmod(fd, self._mode)
+                os.fchmod(fd, self._context.mode)
             except PermissionError:
                 pass  # This locked is not owned by this UID
             try:
@@ -45,14 +45,14 @@ else:  # pragma: win32 no cover
                 if exception.errno == ENOSYS:  # NotImplemented error
                     raise NotImplementedError("FileSystem does not appear to support flock; user SoftFileLock instead")
             else:
-                self._lock_file_fd = fd
+                self._context.lock_file_fd = fd
 
         def _release(self) -> None:
             # Do not remove the lockfile:
             #   https://github.com/tox-dev/py-filelock/issues/31
             #   https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
-            fd = cast(int, self._lock_file_fd)
-            self._lock_file_fd = None
+            fd = cast(int, self._context.lock_file_fd)
+            self._context.lock_file_fd = None
             fcntl.flock(fd, fcntl.LOCK_UN)
             os.close(fd)
 

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -12,7 +12,7 @@ if sys.platform == "win32":  # pragma: win32 cover
     import msvcrt
 
     class WindowsFileLock(BaseFileLock):
-        """Uses the :func:`msvcrt.locking` function to hard lock the lock file on windows systems."""
+        """Uses the :func:`msvcrt.locking` function to hard lock the lock file on Windows systems."""
 
         def _acquire(self) -> None:
             raise_on_not_writable_file(self.lock_file)
@@ -51,7 +51,7 @@ if sys.platform == "win32":  # pragma: win32 cover
 else:  # pragma: win32 no cover
 
     class WindowsFileLock(BaseFileLock):
-        """Uses the :func:`msvcrt.locking` function to hard lock the lock file on windows systems."""
+        """Uses the :func:`msvcrt.locking` function to hard lock the lock file on Windows systems."""
 
         def _acquire(self) -> None:
             raise NotImplementedError


### PR DESCRIPTION
Should resolve https://github.com/tox-dev/py-filelock/issues/230.

TLDR: We now have a thread_local=True by default. If set to False, locks will be re-entrant across threads (a-la 3.10.7 and older behavior).