### PR TITLE
Fix test_bad_lock_file for other OSes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     rev: "0.11.2"
     hooks:
       - id: pyproject-fmt
+        additional_dependencies: ["tox>=4.6"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.9-for-vscode"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs>=0.3",
-  "hatchling>=1.17",
+  "hatchling>=1.17.1",
 ]
 
 [project]
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Internet",
   "Topic :: Software Development :: Libraries",
   "Topic :: System",

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -115,15 +115,17 @@ WindowsOnly = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
         pytest.param(FileNotFoundError, "No such file or directory:", "a/b", id="non_existent_directory"),
         pytest.param(FileNotFoundError, "No such file or directory:", "", id="blank_filename"),
         pytest.param(ValueError, "embedded null (byte|character)", "\0", id="null_byte"),
-
         # Should be PermissionError on Windows
-        pytest.param(PermissionError, "Permission denied:", ".", id="current_directory") if sys.platform == "win32" else (
-
-        # Should be IsADirectoryError on MacOS and Linux
-        pytest.param(IsADirectoryError, "Is a directory", ".", id="current_directory") if sys.platform in ["darwin", "linux"] else
-
-        # Should be some type of OSError at least on other OSes
-        pytest.param(OSError, None, ".", id="current_directory"))
+        pytest.param(PermissionError, "Permission denied:", ".", id="current_directory")
+        if sys.platform == "win32"
+        else (
+            # Should be IsADirectoryError on MacOS and Linux
+            pytest.param(IsADirectoryError, "Is a directory", ".", id="current_directory")
+            if sys.platform in ["darwin", "linux"]
+            else
+            # Should be some type of OSError at least on other OSes
+            pytest.param(OSError, None, ".", id="current_directory")
+        ),
     ]
     + [pytest.param(OSError, "Invalid argument", i, id=f"invalid_{i}", marks=WindowsOnly) for i in '<>:"|?*\a']
     + [pytest.param(PermissionError, "Permission denied:", i, id=f"permission_{i}", marks=WindowsOnly) for i in "/\\"],

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -123,7 +123,7 @@ WindowsOnly = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
             pytest.param(IsADirectoryError, "Is a directory", ".", id="current_directory")
             if sys.platform in ["darwin", "linux"]
             else
-            # Should be some type of OSError at least on other OSes
+            # Should be some type of OSError at least on other operating systems
             pytest.param(OSError, None, ".", id="current_directory")
         ),
     ]

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -115,12 +115,15 @@ WindowsOnly = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
         pytest.param(FileNotFoundError, "No such file or directory:", "a/b", id="non_existent_directory"),
         pytest.param(FileNotFoundError, "No such file or directory:", "", id="blank_filename"),
         pytest.param(ValueError, "embedded null (byte|character)", "\0", id="null_byte"),
-        pytest.param(
-            PermissionError if sys.platform == "win32" else IsADirectoryError,
-            "Permission denied:" if sys.platform == "win32" else "Is a directory",
-            ".",
-            id="current_directory",
-        ),
+
+        # Should be PermissionError on Windows
+        pytest.param(PermissionError, "Permission denied:", ".", id="current_directory") if sys.platform == "win32" else (
+
+        # Should be IsADirectoryError on MacOS and Linux
+        pytest.param(IsADirectoryError, "Is a directory", ".", id="current_directory") if sys.platform in ["darwin", "linux"] else
+
+        # Should be some type of OSError at least on other OSes
+        pytest.param(OSError, None, ".", id="current_directory"))
     ]
     + [pytest.param(OSError, "Invalid argument", i, id=f"invalid_{i}", marks=WindowsOnly) for i in '<>:"|?*\a']
     + [pytest.param(PermissionError, "Permission denied:", i, id=f"permission_{i}", marks=WindowsOnly) for i in "/\\"],


### PR DESCRIPTION
Fixes issue #233 on Solaris due to `open('.')` raising OSError "Invalid Argument", instead of the expected "Is a directory".

Fixed by loosening the test to just confirm an OSError is raised, instead of specific type.
The point of the test is to make sure the error raised by the invalid file name is neither suppressed by filelock, nor does it cause filelock to go into an infinite loop. As such, it is sufficient to make sure an OSError is raised, and not checking further. The change only applies if `sys.platform` is not `win32`, `darwin`, or `linux`. To the best of my knowledge, all three of these can be expected to behalf as expected. However, all other operating systems, such as Solaris' `sunos5` will have this new check.