### PR TITLE
Restore 'if TYPE_CHECKING' syntax for FileLock definition

### DIFF
--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -32,9 +32,11 @@ else:  # pragma: win32 no cover
         if warnings is not None:
             warnings.warn("only soft file lock is available", stacklevel=2)
 
-
-#: Alias for the lock, which should be used for the current platform.
-FileLock: type[BaseFileLock] = SoftFileLock if TYPE_CHECKING else _FileLock  # type: ignore[assignment]
+if TYPE_CHECKING:  # noqa: SIM108
+    FileLock = SoftFileLock
+else:
+    #: Alias for the lock, which should be used for the current platform.
+    FileLock = _FileLock
 
 
 __all__ = [


### PR DESCRIPTION
Apparently, the ternary form of 'if TYPE_CHECKING:' is not understood by mypy as can been seen by the following example:

    $ cat t.py
    from filelock import FileLock

    def use_lock(lock: FileLock) -> None:
        with lock:
            pass
    $ mypy t.py
    t.py:3: error: Variable "filelock.FileLock" is not valid as a type  [valid-type]
    t.py:3: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
    t.py:4: error: FileLock? has no attribute "__enter__"  [attr-defined]
    t.py:4: error: FileLock? has no attribute "__exit__"  [attr-defined]
    Found 3 errors in 1 file (checked 1 source file)