### PR TITLE
Create parent directories if necessary

### DIFF
--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -7,7 +7,7 @@ from errno import EACCES, EEXIST
 from pathlib import Path
 
 from ._api import BaseFileLock
-from ._util import raise_on_not_writable_file, ensure_directory_exists
+from ._util import ensure_directory_exists, raise_on_not_writable_file
 
 
 class SoftFileLock(BaseFileLock):

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -7,7 +7,7 @@ from errno import EACCES, EEXIST
 from pathlib import Path
 
 from ._api import BaseFileLock
-from ._util import raise_on_not_writable_file
+from ._util import raise_on_not_writable_file, ensure_directory_exists
 
 
 class SoftFileLock(BaseFileLock):
@@ -15,6 +15,7 @@ class SoftFileLock(BaseFileLock):
 
     def _acquire(self) -> None:
         raise_on_not_writable_file(self.lock_file)
+        ensure_directory_exists(self.lock_file)
         # first check for exists and read-only mode as the open will mask this case as EEXIST
         flags = (
             os.O_WRONLY  # open for writing only

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -7,6 +7,7 @@ from errno import ENOSYS
 from typing import cast
 
 from ._api import BaseFileLock
+from ._util import ensure_directory_exists
 
 #: a flag to indicate if the fcntl API is available
 has_fcntl = False
@@ -33,6 +34,7 @@ else:  # pragma: win32 no cover
         """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
 
         def _acquire(self) -> None:
+            ensure_directory_exists(self.lock_file)
             open_flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
             fd = os.open(self.lock_file, open_flags, self._context.mode)
             with suppress(PermissionError):  # This locked is not owned by this UID

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -35,9 +35,10 @@ def raise_on_not_writable_file(filename: str) -> None:
 def ensure_directory_exists(filename: str) -> None:
     """
     Ensure the directory containing the file exists (create it if necessary)
-    :param filename: file
+    :param filename: file.
     """
     os.makedirs(os.path.dirname(os.path.abspath(filename)), exist_ok=True)
+
 
 __all__ = [
     "raise_on_not_writable_file",

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -43,4 +43,5 @@ def ensure_directory_exists(filename: Path | str) -> None:
 
 __all__ = [
     "raise_on_not_writable_file",
+    "ensure_directory_exists",
 ]

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -5,7 +5,6 @@ import stat
 import sys
 from errno import EACCES, EISDIR
 from pathlib import Path
-from typing import Union
 
 
 def raise_on_not_writable_file(filename: str) -> None:
@@ -34,7 +33,7 @@ def raise_on_not_writable_file(filename: str) -> None:
                 raise IsADirectoryError(EISDIR, "Is a directory", filename)
 
 
-def ensure_directory_exists(filename: Union[Path, str]) -> None:
+def ensure_directory_exists(filename: Path | str) -> None:
     """
     Ensure the directory containing the file exists (create it if necessary)
     :param filename: file.

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -4,6 +4,8 @@ import os
 import stat
 import sys
 from errno import EACCES, EISDIR
+from pathlib import Path
+from typing import Union
 
 
 def raise_on_not_writable_file(filename: str) -> None:
@@ -32,12 +34,12 @@ def raise_on_not_writable_file(filename: str) -> None:
                 raise IsADirectoryError(EISDIR, "Is a directory", filename)
 
 
-def ensure_directory_exists(filename: str) -> None:
+def ensure_directory_exists(filename: Union[Path, str]) -> None:
     """
     Ensure the directory containing the file exists (create it if necessary)
     :param filename: file.
     """
-    os.makedirs(os.path.dirname(os.path.abspath(filename)), exist_ok=True)
+    Path(filename).parent.mkdir(parents=True, exist_ok=True)
 
 
 __all__ = [

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -32,6 +32,13 @@ def raise_on_not_writable_file(filename: str) -> None:
                 raise IsADirectoryError(EISDIR, "Is a directory", filename)
 
 
+def ensure_directory_exists(filename: str) -> None:
+    """
+    Ensure the directory containing the file exists (create it if necessary)
+    :param filename: file
+    """
+    os.makedirs(os.path.dirname(os.path.abspath(filename)), exist_ok=True)
+
 __all__ = [
     "raise_on_not_writable_file",
 ]

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import cast
 
 from ._api import BaseFileLock
-from ._util import raise_on_not_writable_file, ensure_directory_exists
+from ._util import ensure_directory_exists, raise_on_not_writable_file
 
 if sys.platform == "win32":  # pragma: win32 cover
     import msvcrt

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import cast
 
 from ._api import BaseFileLock
-from ._util import raise_on_not_writable_file
+from ._util import raise_on_not_writable_file, ensure_directory_exists
 
 if sys.platform == "win32":  # pragma: win32 cover
     import msvcrt
@@ -18,6 +18,7 @@ if sys.platform == "win32":  # pragma: win32 cover
 
         def _acquire(self) -> None:
             raise_on_not_writable_file(self.lock_file)
+            ensure_directory_exists(self.lock_file)
             flags = (
                 os.O_RDWR  # open for read and write
                 | os.O_CREAT  # create file if not exists

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -23,27 +23,20 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-@pytest.mark.parametrize(
-    ("lock_type", "path_type"),
-    [
-        (FileLock, str),
-        (FileLock, PurePath),
-        (FileLock, Path),
-        (SoftFileLock, str),
-        (SoftFileLock, PurePath),
-        (SoftFileLock, Path),
-    ],
-)
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+@pytest.mark.parametrize("path_type", [str, PurePath, Path])
+@pytest.mark.parametrize("filename", ["a", "new/b", "new2/new3/c"])
 def test_simple(
     lock_type: type[BaseFileLock],
     path_type: type[str] | type[Path],
+    filename: str,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
     # test lock creation by passing a `str`
-    lock_path = tmp_path / "a"
+    lock_path = tmp_path / filename
     lock = lock_type(path_type(lock_path))
     with lock as locked:
         assert lock.is_locked
@@ -113,7 +106,6 @@ WindowsOnly = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 @pytest.mark.parametrize(
     ("expected_error", "match", "bad_lock_file"),
     [
-        pytest.param(FileNotFoundError, "No such file or directory:", "a/b", id="non_existent_directory"),
         pytest.param(FileNotFoundError, "No such file or directory:", "", id="blank_filename"),
         pytest.param(ValueError, "embedded null (byte|character)", "\0", id="null_byte"),
         # Should be PermissionError on Windows


### PR DESCRIPTION
Closes #176

Implements @gaborbernat's https://github.com/tox-dev/py-filelock/issues/176#issuecomment-1340238126; i.e., creates any necessary parent directories on `acquire` so that the `open` call doesn't cause a `FileNotFoundError` if those directories do not exist. 

This could also be done using `pathlib`, but I chose to use `os` for consistency with the rest of the package. Also, I haven't tested if the change is actually needed on Windows too (I've made the same change to `windows.py` anyway).