### PR TITLE
lock.acquire bug

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -218,7 +218,6 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
                 if not self.is_locked:
                     _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)
                     self._acquire()
-                if self.is_locked:
                     _LOGGER.debug("Lock %s acquired on %s", lock_id, lock_filename)
                     break
                 if blocking is False:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -612,6 +612,7 @@ def test_lock_can_be_non_thread_local(
 
     lock.release(force=True)
 
+
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_lock_acquire(
     tmp_path: Path,
@@ -624,4 +625,3 @@ def test_lock_acquire(
     lock.release(force=True)
     lock.acquire()
     assert lock.is_locked
-

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -611,3 +611,17 @@ def test_lock_can_be_non_thread_local(
     assert lock.lock_counter == 2
 
     lock.release(force=True)
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_lock_acquire(
+    tmp_path: Path,
+    lock_type: type[BaseFileLock],
+) -> None:
+    lock = lock_type(tmp_path / "test.lock", thread_local=False)
+    lock.acquire()
+    with pytest.raises(TimeoutError):
+        lock.acquire(timeout=0.1)
+    lock.release(force=True)
+    lock.acquire()
+    assert lock.is_locked
+


### PR DESCRIPTION
Rather obvious bug.
Consider the test_case:

```python
    lock = lock_type(tmp_path / "test.lock", thread_local=False)
    lock.acquire()
    with pytest.raises(TimeoutError):
        lock.acquire(timeout=0.1)
    lock.release(force=True)
    lock.acquire()
    assert lock.is_locked
```