### PR TITLE
Lower typing-extension dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  'typing-extensions>=4.7.1; python_version < "3.11"',
+  'typing-extensions>=4; python_version < "3.11"',
 ]
 optional-dependencies.docs = [
   "furo>=2023.7.26",


### PR DESCRIPTION
Hi 👋 

First, thank you for actively maintaining filelock as it is heavily used by one of the most trendy AI libraries our there, and therefore our production services too.

This is my first attempt at contributing to this repository, I hope to do things the right way :) 

I would like to contribute with this PR to loosen constraints a bit on the `typing-extensions` dependency that has been introduced in #259, part of the [3.12.3](https://github.com/tox-dev/filelock/releases/tag/3.12.3) release:

https://github.com/tox-dev/filelock/blob/890e3f03b0ab96f66907626d4a8af248b5073b17/pyproject.toml#L42C1-L42C1


I have encountered several issues while trying to resolve dependencies since then, for example using `pip-tools` with `tensorflow` and `transformers` as dependencies lead to:
```
There are incompatible versions in the resolved dependencies:
typing-extensions<4.6.0,>=3.6.6 (from tensorflow==2.13.0)
typing-extensions>=4.7.1 (from filelock==3.12.3->transformers==4.32.1)
```

I looked at the changes introduced in #259, and why is `typing-extensions` needed, and it seems like the one and only occurrence of `typing_extension` is here: https://github.com/tox-dev/filelock/blob/890e3f03b0ab96f66907626d4a8af248b5073b17/src/filelock/_api.py#L22 so that to have a proper `Self` type as part of the return signature of https://github.com/tox-dev/filelock/blob/890e3f03b0ab96f66907626d4a8af248b5073b17/src/filelock/_api.py#L256

After reviewing the `typing_extension` [documentation](https://typing-extensions.readthedocs.io/en/latest/), it seems like `Self` was introduced in `4.0.0`.

Hence, what do you think about lowering the `typing_extension` dependency version to make dependency resolving a bit easier on projects leveraging `filelock` ?

All tests pass locally using tox through all the python versions, with `typing-extensions==4` and upward!

Thanks for your time and help, looking forward to your feedback on this!