### PR TITLE
WIP: Async support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 /pip-wheel-metadata
 /src/filelock/version.py
 venv*
+.venv*
 .python-version
 test.lock
 test.softlock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ optional-dependencies.testing = [
   "pytest-cov>=4.1",
   "pytest-mock>=3.11.1",
   "pytest-timeout>=2.1",
+  "pytest-asyncio>=0.21.1",
 ]
 optional-dependencies.typing = [
   'typing-extensions>=4.7.1; python_version < "3.11"',
@@ -106,3 +107,6 @@ python_version = "3.11"
 show_error_codes = true
 strict = true
 overrides = [{ module = ["appdirs.*", "jnius.*"], ignore_missing_imports = true }]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,10 @@ optional-dependencies.testing = [
   "coverage>=7.3",
   "diff-cover>=7.7",
   "pytest>=7.4",
+  "pytest-asyncio>=0.21.1",
   "pytest-cov>=4.1",
   "pytest-mock>=3.11.1",
   "pytest-timeout>=2.1",
-  "pytest-asyncio>=0.21.1",
 ]
 optional-dependencies.typing = [
   'typing-extensions>=4.7.1; python_version < "3.11"',
@@ -93,6 +93,9 @@ ignore = [
     "PLR2004",  # Magic value used in comparison, consider replacing with a constant variable
 ]
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.coverage]
 html.show_contexts = true
 html.skip_covered = false
@@ -107,6 +110,3 @@ python_version = "3.11"
 show_error_codes = true
 strict = true
 overrides = [{ module = ["appdirs.*", "jnius.*"], ignore_missing_imports = true }]
-
-[tool.pytest.ini_options]
-asyncio_mode = "auto"

--- a/src/filelock/asyncio/__init__.py
+++ b/src/filelock/asyncio/__init__.py
@@ -1,0 +1,39 @@
+"""Async implementation of filelock."""
+from __future__ import annotations
+
+import sys
+import warnings
+from typing import TYPE_CHECKING
+
+from ._api import AsyncAcquireReturnProxy, BaseFileLock
+from ._error import Timeout
+from ._soft import SoftFileLock
+from ._unix import UnixFileLock, has_fcntl
+from ._windows import WindowsFileLock
+
+if sys.platform == "win32":  # pragma: win32 cover
+    _FileLock: type[BaseFileLock] = WindowsFileLock
+else:  # pragma: win32 no cover # noqa: PLR5501
+    if has_fcntl:
+        _FileLock: type[BaseFileLock] = UnixFileLock
+    else:
+        _FileLock = SoftFileLock
+        if warnings is not None:
+            warnings.warn("only soft file lock is available", stacklevel=2)
+
+if TYPE_CHECKING:  # noqa: SIM108
+    FileLock = SoftFileLock
+else:
+    #: Alias for the lock, which should be used for the current platform.
+    FileLock = _FileLock
+
+
+__all__ = [
+    "FileLock",
+    "SoftFileLock",
+    "Timeout",
+    "UnixFileLock",
+    "WindowsFileLock",
+    "BaseFileLock",
+    "AsyncAcquireReturnProxy",
+]

--- a/src/filelock/asyncio/_api.py
+++ b/src/filelock/asyncio/_api.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 
-_LOGGER = logging.getLogger("filelock")
+_LOGGER = logging.getLogger("filelock.asyncio")
 
 
 # This is a helper class which is returned by :meth:`BaseFileLock.acquire` and wraps the lock to make sure __enter__

--- a/src/filelock/asyncio/_api.py
+++ b/src/filelock/asyncio/_api.py
@@ -17,7 +17,7 @@ from ._error import Timeout
 if sys.version_info >= (3, 11):
     from asyncio import timeout as atimeout
 else:
-    from ..vendor.async_timeout import timeout as atimeout
+    from filelock.vendor.async_timeout import timeout as atimeout
 
 
 @asynccontextmanager

--- a/src/filelock/asyncio/_api.py
+++ b/src/filelock/asyncio/_api.py
@@ -19,6 +19,11 @@ if sys.version_info >= (3, 11):
 else:
     from ..vendor.async_timeout import timeout as atimeout
 
+if sys.version_info >= (3, 10):
+    from contextlib import AsyncContextDecorator
+else:
+    from ..vendor.contextlib import AsyncContextDecorator
+
 
 @asynccontextmanager
 async def async_timeout(timeout: float | None, lock_filename: str) -> None:
@@ -89,7 +94,7 @@ class ThreadLocalFileContext(FileLockContext, local):
     """A thread local version of the ``FileLockContext`` class."""
 
 
-class BaseFileLock(ABC, contextlib.AsyncContextDecorator):
+class BaseFileLock(ABC, AsyncContextDecorator):
     """Abstract base class for a file lock object."""
 
     def __init__(

--- a/src/filelock/asyncio/_api.py
+++ b/src/filelock/asyncio/_api.py
@@ -17,11 +17,11 @@ from ._error import Timeout
 if sys.version_info >= (3, 11):
     from asyncio import timeout as atimeout
 else:
-    from async_timeout import timeout as atimeout
+    from ..vendor.async_timeout import timeout as atimeout
 
 
 @asynccontextmanager
-async def wrapped_timeout(timeout: float | None, lock_filename: str) -> None:
+async def async_timeout(timeout: float | None, lock_filename: str) -> None:
     try:
         async with atimeout(timeout):
             yield
@@ -229,7 +229,7 @@ class BaseFileLock(ABC, contextlib.AsyncContextDecorator):
         lock_id = id(self)
         lock_filename = self.lock_file
         try:
-            async with wrapped_timeout(timeout, lock_filename):
+            async with async_timeout(timeout, lock_filename):
                 while True:
                     if not self.is_locked:
                         _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)

--- a/src/filelock/asyncio/_api.py
+++ b/src/filelock/asyncio/_api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import os
 import sys
@@ -22,7 +21,7 @@ else:
 if sys.version_info >= (3, 10):
     from contextlib import AsyncContextDecorator
 else:
-    from ..vendor.contextlib import AsyncContextDecorator
+    from filelock.vendor.contextlib import AsyncContextDecorator
 
 
 @asynccontextmanager

--- a/src/filelock/asyncio/_api.py
+++ b/src/filelock/asyncio/_api.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import sys
+import warnings
+from abc import ABC, abstractmethod
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from threading import local
+from typing import TYPE_CHECKING, Any
+
+from ._error import Timeout
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as atimeout
+else:
+    from async_timeout import timeout as atimeout
+
+
+@asynccontextmanager
+async def wrapped_timeout(timeout: float | None, lock_filename: str) -> None:
+    try:
+        async with atimeout(timeout):
+            yield
+    except asyncio.TimeoutError:
+        raise Timeout(lock_filename)
+
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+        from typing import Self
+    else:  # pragma: no cover (<py311)
+        from typing_extensions import Self
+
+
+_LOGGER = logging.getLogger("filelock")
+
+
+# This is a helper class which is returned by :meth:`BaseFileLock.acquire` and wraps the lock to make sure __enter__
+# is not called twice when entering the with statement. If we would simply return *self*, the lock would be acquired
+# again in the *__enter__* method of the BaseFileLock, but not released again automatically. issue #37 (memory leak)
+class AsyncAcquireReturnProxy:
+    """A context aware object that will release the lock file when exiting."""
+
+    def __init__(self, lock: BaseFileLock) -> None:
+        self.lock = lock
+
+    async def __aenter__(self) -> BaseFileLock:
+        return self.lock
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.lock.release()
+
+
+@dataclass
+class FileLockContext:
+    """A dataclass which holds the context for a ``BaseFileLock`` object."""
+
+    # The context is held in a separate class to allow optional use of thread local storage via the
+    # ThreadLocalFileContext class.
+
+    #: The path to the lock file.
+    lock_file: str
+
+    #: The default timeout value.
+    timeout: float
+
+    #: The mode for the lock files
+    mode: int
+
+    #: The file descriptor for the *_lock_file* as it is returned by the os.open() function, not None when lock held
+    lock_file_fd: int | None = None
+
+    #: The lock counter is used for implementing the nested locking mechanism.
+    lock_counter: int = 0  # When the lock is acquired is increased and the lock is only released, when this value is 0
+
+
+class ThreadLocalFileContext(FileLockContext, local):
+    """A thread local version of the ``FileLockContext`` class."""
+
+
+class BaseFileLock(ABC, contextlib.AsyncContextDecorator):
+    """Abstract base class for a file lock object."""
+
+    def __init__(
+        self,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1,
+        mode: int = 0o644,
+        thread_local: bool = True,  # noqa: FBT001, FBT002
+    ) -> None:
+        """
+        Create a new lock object.
+
+        :param lock_file: path to the file
+        :param timeout: default timeout when acquiring the lock, in seconds. It will be used as fallback value in
+        the acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it
+        to a negative value. A timeout of 0 means, that there is exactly one attempt to acquire the file lock.
+        :param mode: file permissions for the lockfile.
+        :param thread_local: Whether this object's internal context should be thread local or not.
+        If this is set to ``False`` then the lock will be reentrant across threads.
+        """
+        self._is_thread_local = thread_local
+
+        # Create the context. Note that external code should not work with the context directly  and should instead use
+        # properties of this class.
+        kwargs: dict[str, Any] = {
+            "lock_file": os.fspath(lock_file),
+            "timeout": timeout,
+            "mode": mode,
+        }
+        self._context: FileLockContext = (ThreadLocalFileContext if thread_local else FileLockContext)(**kwargs)
+
+    def is_thread_local(self) -> bool:
+        """:return: a flag indicating if this lock is thread local or not"""
+        return self._is_thread_local
+
+    @property
+    def lock_file(self) -> str:
+        """:return: path to the lock file"""
+        return self._context.lock_file
+
+    @property
+    def timeout(self) -> float:
+        """
+        :return: the default timeout value, in seconds
+
+        .. versionadded:: 2.0.0
+        """
+        return self._context.timeout
+
+    @timeout.setter
+    def timeout(self, value: float | str) -> None:
+        """
+        Change the default timeout value.
+
+        :param value: the new value, in seconds
+        """
+        self._context.timeout = float(value)
+
+    @abstractmethod
+    def _acquire(self) -> None:
+        """If the file lock could be acquired, self._context.lock_file_fd holds the file descriptor of the lock file."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _release(self) -> None:
+        """Releases the lock and sets self._context.lock_file_fd to None."""
+        raise NotImplementedError
+
+    @property
+    def is_locked(self) -> bool:
+        """
+
+        :return: A boolean indicating if the lock file is holding the lock currently.
+
+        .. versionchanged:: 2.0.0
+
+            This was previously a method and is now a property.
+        """
+        return self._context.lock_file_fd is not None
+
+    @property
+    def lock_counter(self) -> int:
+        """:return: The number of times this lock has been acquired (but not yet released)."""
+        return self._context.lock_counter
+
+    async def acquire(
+        self,
+        timeout: float | None = None,
+        poll_interval: float = 0.05,
+        *,
+        poll_intervall: float | None = None,
+        blocking: bool = True,
+    ) -> AsyncAcquireReturnProxy:
+        """
+        Try to acquire the file lock.
+
+        :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default :attr:`~timeout` is and
+         if ``timeout < 0``, there is no timeout and this method will block until the lock could be acquired
+        :param poll_interval: interval of trying to acquire the lock file
+        :param poll_intervall: deprecated, kept for backwards compatibility, use ``poll_interval`` instead
+        :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on the
+         first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
+        :raises Timeout: if fails to acquire lock within the timeout period
+        :return: a context object that will unlock the file when the context is exited
+
+        .. code-block:: python
+
+            # You can use this method in the context manager (recommended)
+            with lock.acquire():
+                pass
+
+            # Or use an equivalent try-finally construct:
+            lock.acquire()
+            try:
+                pass
+            finally:
+                lock.release()
+
+        .. versionchanged:: 2.0.0
+
+            This method returns now a *proxy* object instead of *self*,
+            so that it can be used in a with statement without side effects.
+
+        """
+        # Use the default timeout, if no timeout is provided.
+        if timeout is None:
+            timeout = self._context.timeout
+
+        if poll_intervall is not None:
+            msg = "use poll_interval instead of poll_intervall"
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            poll_interval = poll_intervall
+
+        # Increment the number right at the beginning. We can still undo it, if something fails.
+        self._context.lock_counter += 1
+
+        lock_id = id(self)
+        lock_filename = self.lock_file
+        try:
+            async with wrapped_timeout(timeout, lock_filename):
+                while True:
+                    if not self.is_locked:
+                        _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)
+                        self._acquire()
+                    if self.is_locked:
+                        _LOGGER.debug("Lock %s acquired on %s", lock_id, lock_filename)
+                        break
+                    if blocking is False:
+                        _LOGGER.debug("Failed to immediately acquire lock %s on %s", lock_id, lock_filename)
+                        raise Timeout(lock_filename)  # noqa: TRY301
+                    msg = "Lock %s not acquired on %s, waiting %s seconds ..."
+                    _LOGGER.debug(msg, lock_id, lock_filename, poll_interval)
+                    await asyncio.sleep(poll_interval)
+        except BaseException:  # Something did go wrong, so decrement the counter.
+            self._context.lock_counter = max(0, self._context.lock_counter - 1)
+            raise
+        return AsyncAcquireReturnProxy(lock=self)
+
+    def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
+        """
+        Releases the file lock. Please note, that the lock is only completely released, if the lock counter is 0. Also
+        note, that the lock file itself is not automatically deleted.
+
+        :param force: If true, the lock counter is ignored and the lock is released in every case/
+        """
+        if self.is_locked:
+            self._context.lock_counter -= 1
+
+            if self._context.lock_counter == 0 or force:
+                lock_id, lock_filename = id(self), self.lock_file
+
+                _LOGGER.debug("Attempting to release lock %s on %s", lock_id, lock_filename)
+                self._release()
+                self._context.lock_counter = 0
+                _LOGGER.debug("Lock %s released on %s", lock_id, lock_filename)
+
+    async def __aenter__(self) -> Self:
+        """
+        Acquire the lock.
+
+        :return: the lock object
+        """
+        await self.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """
+        Release the lock.
+
+        :param exc_type: the exception type if raised
+        :param exc_value: the exception value if raised
+        :param traceback: the exception traceback if raised
+        """
+        self.release()
+
+    def __del__(self) -> None:
+        """Called when the lock object is deleted."""
+        self.release(force=True)
+
+
+__all__ = [
+    "BaseFileLock",
+    "AsyncAcquireReturnProxy",
+]

--- a/src/filelock/asyncio/_error.py
+++ b/src/filelock/asyncio/_error.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class Timeout(TimeoutError):  # noqa: N818
+    """Raised when the lock could not be acquired in *timeout* seconds."""
+
+    def __init__(self, lock_file: str) -> None:
+        super().__init__()
+        self._lock_file = lock_file
+
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        return self.__class__, (self._lock_file,)  # Properly pickle the exception
+
+    def __str__(self) -> str:
+        return f"The file lock '{self._lock_file}' could not be acquired."
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.lock_file!r})"
+
+    @property
+    def lock_file(self) -> str:
+        """:return: The path of the file lock."""
+        return self._lock_file
+
+
+__all__ = [
+    "Timeout",
+]

--- a/src/filelock/asyncio/_soft.py
+++ b/src/filelock/asyncio/_soft.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import suppress
+from errno import EACCES, EEXIST
+from pathlib import Path
+
+from ._api import BaseFileLock
+from ._util import ensure_directory_exists, raise_on_not_writable_file
+
+
+class SoftFileLock(BaseFileLock):
+    """Simply watches the existence of the lock file."""
+
+    def _acquire(self) -> None:
+        raise_on_not_writable_file(self.lock_file)
+        ensure_directory_exists(self.lock_file)
+        # first check for exists and read-only mode as the open will mask this case as EEXIST
+        flags = (
+            os.O_WRONLY  # open for writing only
+            | os.O_CREAT
+            | os.O_EXCL  # together with above raise EEXIST if the file specified by filename exists
+            | os.O_TRUNC  # truncate the file to zero byte
+        )
+        try:
+            file_handler = os.open(self.lock_file, flags, self._context.mode)
+        except OSError as exception:  # re-raise unless expected exception
+            if not (
+                exception.errno == EEXIST  # lock already exist
+                or (exception.errno == EACCES and sys.platform == "win32")  # has no access to this lock
+            ):  # pragma: win32 no cover
+                raise
+        else:
+            self._context.lock_file_fd = file_handler
+
+    def _release(self) -> None:
+        assert self._context.lock_file_fd is not None  # noqa: S101
+        os.close(self._context.lock_file_fd)  # the lock file is definitely not None
+        self._context.lock_file_fd = None
+        with suppress(OSError):  # the file is already deleted and that's what we want
+            Path(self.lock_file).unlink()
+
+
+__all__ = [
+    "SoftFileLock",
+]

--- a/src/filelock/asyncio/_unix.py
+++ b/src/filelock/asyncio/_unix.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import suppress
+from errno import ENOSYS
+from typing import cast
+
+from ._api import BaseFileLock
+from ._util import ensure_directory_exists
+
+#: a flag to indicate if the fcntl API is available
+has_fcntl = False
+if sys.platform == "win32":  # pragma: win32 cover
+
+    class UnixFileLock(BaseFileLock):
+        """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
+
+        def _acquire(self) -> None:
+            raise NotImplementedError
+
+        def _release(self) -> None:
+            raise NotImplementedError
+
+else:  # pragma: win32 no cover
+    try:
+        import fcntl
+    except ImportError:
+        pass
+    else:
+        has_fcntl = True
+
+    class UnixFileLock(BaseFileLock):
+        """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
+
+        def _acquire(self) -> None:
+            ensure_directory_exists(self.lock_file)
+            open_flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+            fd = os.open(self.lock_file, open_flags, self._context.mode)
+            with suppress(PermissionError):  # This locked is not owned by this UID
+                os.fchmod(fd, self._context.mode)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exception:
+                os.close(fd)
+                if exception.errno == ENOSYS:  # NotImplemented error
+                    msg = "FileSystem does not appear to support flock; user SoftFileLock instead"
+                    raise NotImplementedError(msg) from exception
+            else:
+                self._context.lock_file_fd = fd
+
+        def _release(self) -> None:
+            # Do not remove the lockfile:
+            #   https://github.com/tox-dev/py-filelock/issues/31
+            #   https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
+            fd = cast(int, self._context.lock_file_fd)
+            self._context.lock_file_fd = None
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+
+__all__ = [
+    "has_fcntl",
+    "UnixFileLock",
+]

--- a/src/filelock/asyncio/_util.py
+++ b/src/filelock/asyncio/_util.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from errno import EACCES, EISDIR
+from pathlib import Path
+
+
+def raise_on_not_writable_file(filename: str) -> None:
+    """
+    Raise an exception if attempting to open the file for writing would fail.
+    This is done so files that will never be writable can be separated from
+    files that are writable but currently locked
+    :param filename: file to check
+    :raises OSError: as if the file was opened for writing.
+    """
+    try:  # use stat to do exists + can write to check without race condition
+        file_stat = os.stat(filename)  # noqa: PTH116
+    except OSError:
+        return  # swallow does not exist or other errors
+
+    if file_stat.st_mtime != 0:  # if os.stat returns but modification is zero that's an invalid os.stat - ignore it
+        if not (file_stat.st_mode & stat.S_IWUSR):
+            raise PermissionError(EACCES, "Permission denied", filename)
+
+        if stat.S_ISDIR(file_stat.st_mode):
+            if sys.platform == "win32":  # pragma: win32 cover
+                # On Windows, this is PermissionError
+                raise PermissionError(EACCES, "Permission denied", filename)
+            else:  # pragma: win32 no cover # noqa: RET506
+                # On linux / macOS, this is IsADirectoryError
+                raise IsADirectoryError(EISDIR, "Is a directory", filename)
+
+
+def ensure_directory_exists(filename: Path | str) -> None:
+    """
+    Ensure the directory containing the file exists (create it if necessary)
+    :param filename: file.
+    """
+    Path(filename).parent.mkdir(parents=True, exist_ok=True)
+
+
+__all__ = [
+    "raise_on_not_writable_file",
+    "ensure_directory_exists",
+]

--- a/src/filelock/asyncio/_windows.py
+++ b/src/filelock/asyncio/_windows.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import suppress
+from errno import EACCES
+from pathlib import Path
+from typing import cast
+
+from ._api import BaseFileLock
+from ._util import ensure_directory_exists, raise_on_not_writable_file
+
+if sys.platform == "win32":  # pragma: win32 cover
+    import msvcrt
+
+    class WindowsFileLock(BaseFileLock):
+        """Uses the :func:`msvcrt.locking` function to hard lock the lock file on Windows systems."""
+
+        def _acquire(self) -> None:
+            raise_on_not_writable_file(self.lock_file)
+            ensure_directory_exists(self.lock_file)
+            flags = (
+                os.O_RDWR  # open for read and write
+                | os.O_CREAT  # create file if not exists
+                | os.O_TRUNC  # truncate file if not empty
+            )
+            try:
+                fd = os.open(self.lock_file, flags, self._context.mode)
+            except OSError as exception:
+                if exception.errno != EACCES:  # has no access to this lock
+                    raise
+            else:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                except OSError as exception:
+                    os.close(fd)  # close file first
+                    if exception.errno != EACCES:  # file is already locked
+                        raise
+                else:
+                    self._context.lock_file_fd = fd
+
+        def _release(self) -> None:
+            fd = cast(int, self._context.lock_file_fd)
+            self._context.lock_file_fd = None
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            os.close(fd)
+
+            with suppress(OSError):  # Probably another instance of the application hat acquired the file lock.
+                Path(self.lock_file).unlink()
+
+else:  # pragma: win32 no cover
+
+    class WindowsFileLock(BaseFileLock):
+        """Uses the :func:`msvcrt.locking` function to hard lock the lock file on Windows systems."""
+
+        def _acquire(self) -> None:
+            raise NotImplementedError
+
+        def _release(self) -> None:
+            raise NotImplementedError
+
+
+__all__ = [
+    "WindowsFileLock",
+]

--- a/src/filelock/vendor/async_timeout.py
+++ b/src/filelock/vendor/async_timeout.py
@@ -8,7 +8,6 @@ import warnings
 from types import TracebackType
 from typing import Optional, Type
 
-
 if sys.version_info >= (3, 8):
     from typing import final
 else:
@@ -100,9 +99,7 @@ class Timeout:
 
     __slots__ = ("_deadline", "_loop", "_state", "_timeout_handler", "_task")
 
-    def __init__(
-        self, deadline: Optional[float], loop: asyncio.AbstractEventLoop
-    ) -> None:
+    def __init__(self, deadline: Optional[float], loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
         self._state = _State.INIT
 

--- a/src/filelock/vendor/async_timeout.py
+++ b/src/filelock/vendor/async_timeout.py
@@ -1,0 +1,242 @@
+"""
+Vendored from https://github.com/aio-libs/async-timeout/blob/master/async_timeout/__init__.py
+"""
+import asyncio
+import enum
+import sys
+import warnings
+from types import TracebackType
+from typing import Optional, Type
+
+
+if sys.version_info >= (3, 8):
+    from typing import final
+else:
+    from typing_extensions import final
+
+
+if sys.version_info >= (3, 11):
+
+    def _uncancel_task(task: "asyncio.Task[object]") -> None:
+        task.uncancel()
+
+else:
+
+    def _uncancel_task(task: "asyncio.Task[object]") -> None:
+        pass
+
+
+__version__ = "4.0.3"
+
+
+__all__ = ("timeout", "timeout_at", "Timeout")
+
+
+def timeout(delay: Optional[float]) -> "Timeout":
+    """timeout context manager.
+
+    Useful in cases when you want to apply timeout logic around block
+    of code or in cases when asyncio.wait_for is not suitable. For example:
+
+    >>> async with timeout(0.001):
+    ...     async with aiohttp.get('https://github.com') as r:
+    ...         await r.text()
+
+
+    delay - value in seconds or None to disable timeout logic
+    """
+    loop = asyncio.get_running_loop()
+    if delay is not None:
+        deadline = loop.time() + delay  # type: Optional[float]
+    else:
+        deadline = None
+    return Timeout(deadline, loop)
+
+
+def timeout_at(deadline: Optional[float]) -> "Timeout":
+    """Schedule the timeout at absolute time.
+
+    deadline argument points on the time in the same clock system
+    as loop.time().
+
+    Please note: it is not POSIX time but a time with
+    undefined starting base, e.g. the time of the system power on.
+
+    >>> async with timeout_at(loop.time() + 10):
+    ...     async with aiohttp.get('https://github.com') as r:
+    ...         await r.text()
+
+
+    """
+    loop = asyncio.get_running_loop()
+    return Timeout(deadline, loop)
+
+
+class _State(enum.Enum):
+    INIT = "INIT"
+    ENTER = "ENTER"
+    TIMEOUT = "TIMEOUT"
+    EXIT = "EXIT"
+
+
+@final
+class Timeout:
+    # Internal class, please don't instantiate it directly
+    # Use timeout() and timeout_at() public factories instead.
+    #
+    # Implementation note: `async with timeout()` is preferred
+    # over `with timeout()`.
+    # While technically the Timeout class implementation
+    # doesn't need to be async at all,
+    # the `async with` statement explicitly points that
+    # the context manager should be used from async function context.
+    #
+    # This design allows to avoid many silly misusages.
+    #
+    # TimeoutError is raised immediately when scheduled
+    # if the deadline is passed.
+    # The purpose is to time out as soon as possible
+    # without waiting for the next await expression.
+
+    __slots__ = ("_deadline", "_loop", "_state", "_timeout_handler", "_task")
+
+    def __init__(
+        self, deadline: Optional[float], loop: asyncio.AbstractEventLoop
+    ) -> None:
+        self._loop = loop
+        self._state = _State.INIT
+
+        self._task: Optional["asyncio.Task[object]"] = None
+        self._timeout_handler = None  # type: Optional[asyncio.Handle]
+        if deadline is None:
+            self._deadline = None  # type: Optional[float]
+        else:
+            self.update(deadline)
+
+    def __enter__(self) -> "Timeout":
+        warnings.warn(
+            "with timeout() is deprecated, use async with timeout() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._do_enter()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        self._do_exit(exc_type)
+        return None
+
+    async def __aenter__(self) -> "Timeout":
+        self._do_enter()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        self._do_exit(exc_type)
+        return None
+
+    @property
+    def expired(self) -> bool:
+        """Is timeout expired during execution?"""
+        return self._state == _State.TIMEOUT
+
+    @property
+    def deadline(self) -> Optional[float]:
+        return self._deadline
+
+    def reject(self) -> None:
+        """Reject scheduled timeout if any."""
+        # cancel is maybe better name but
+        # task.cancel() raises CancelledError in asyncio world.
+        if self._state not in (_State.INIT, _State.ENTER):
+            raise RuntimeError(f"invalid state {self._state.value}")
+        self._reject()
+
+    def _reject(self) -> None:
+        self._task = None
+        if self._timeout_handler is not None:
+            self._timeout_handler.cancel()
+            self._timeout_handler = None
+
+    def shift(self, delay: float) -> None:
+        """Advance timeout on delay seconds.
+
+        The delay can be negative.
+
+        Raise RuntimeError if shift is called when deadline is not scheduled
+        """
+        deadline = self._deadline
+        if deadline is None:
+            raise RuntimeError("cannot shift timeout if deadline is not scheduled")
+        self.update(deadline + delay)
+
+    def update(self, deadline: float) -> None:
+        """Set deadline to absolute value.
+
+        deadline argument points on the time in the same clock system
+        as loop.time().
+
+        If new deadline is in the past the timeout is raised immediately.
+
+        Please note: it is not POSIX time but a time with
+        undefined starting base, e.g. the time of the system power on.
+        """
+        if self._state == _State.EXIT:
+            raise RuntimeError("cannot reschedule after exit from context manager")
+        if self._state == _State.TIMEOUT:
+            raise RuntimeError("cannot reschedule expired timeout")
+        if self._timeout_handler is not None:
+            self._timeout_handler.cancel()
+        self._deadline = deadline
+        if self._state != _State.INIT:
+            self._reschedule()
+
+    def _reschedule(self) -> None:
+        assert self._state == _State.ENTER
+        deadline = self._deadline
+        if deadline is None:
+            return
+
+        now = self._loop.time()
+        if self._timeout_handler is not None:
+            self._timeout_handler.cancel()
+
+        self._task = asyncio.current_task()
+        if deadline <= now:
+            self._timeout_handler = self._loop.call_soon(self._on_timeout)
+        else:
+            self._timeout_handler = self._loop.call_at(deadline, self._on_timeout)
+
+    def _do_enter(self) -> None:
+        if self._state != _State.INIT:
+            raise RuntimeError(f"invalid state {self._state.value}")
+        self._state = _State.ENTER
+        self._reschedule()
+
+    def _do_exit(self, exc_type: Optional[Type[BaseException]]) -> None:
+        if exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT:
+            assert self._task is not None
+            _uncancel_task(self._task)
+            self._timeout_handler = None
+            self._task = None
+            raise asyncio.TimeoutError
+        # timeout has not expired
+        self._state = _State.EXIT
+        self._reject()
+        return None
+
+    def _on_timeout(self) -> None:
+        assert self._task is not None
+        self._task.cancel()
+        self._state = _State.TIMEOUT
+        # drop the reference early
+        self._timeout_handler = None

--- a/src/filelock/vendor/contextlib.py
+++ b/src/filelock/vendor/contextlib.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from functools import wraps
 
 
-class AsyncContextDecorator(object):
-    """Vendored from https://github.com/python/cpython/blob/cf6f23b0e3cdef33f23967cf954a2ca4d1fa6528/Lib/contextlib.py#L89-L102"""
+class AsyncContextDecorator:
+    """Vendored from https://github.com/python/cpython/blob/cf6f23b0e3cdef33f23967cf954a2ca4d1fa6528/Lib/contextlib.py#L89-L102."""
 
     "A base class or mixin that enables async context managers to work as decorators."
 

--- a/src/filelock/vendor/contextlib.py
+++ b/src/filelock/vendor/contextlib.py
@@ -1,0 +1,19 @@
+from functools import wraps
+
+
+class AsyncContextDecorator(object):
+    """Vendored from https://github.com/python/cpython/blob/cf6f23b0e3cdef33f23967cf954a2ca4d1fa6528/Lib/contextlib.py#L89-L102"""
+
+    "A base class or mixin that enables async context managers to work as decorators."
+
+    def _recreate_cm(self):
+        """Return a recreated instance of self."""
+        return self
+
+    def __call__(self, func):
+        @wraps(func)
+        async def inner(*args, **kwds):
+            async with self._recreate_cm():
+                return await func(*args, **kwds)
+
+        return inner

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import inspect
+import logging
+import os
+import sys
+from contextlib import contextmanager
+from errno import ENOSYS
+from inspect import getframeinfo, stack
+from pathlib import Path, PurePath
+from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
+from types import TracebackType
+from typing import TYPE_CHECKING, Iterator, Tuple, Type, Union
+
+import pytest
+
+from filelock.asyncio import BaseFileLock, FileLock, SoftFileLock, Timeout, UnixFileLock, WindowsFileLock
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+@pytest.mark.parametrize("path_type", [str, PurePath, Path])
+@pytest.mark.parametrize("filename", ["a", "new/b", "new2/new3/c"])
+async def test_simple(
+    lock_type: type[BaseFileLock],
+    path_type: type[str | Path],
+    filename: str,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    # test lock creation by passing a `str`
+    lock_path = tmp_path / filename
+    lock = lock_type(path_type(lock_path))
+    async with lock as locked:
+        assert lock.is_locked
+        assert lock is locked
+    assert not lock.is_locked
+
+    assert caplog.messages == [
+        f"Attempting to acquire lock {id(lock)} on {lock_path}",
+        f"Lock {id(lock)} acquired on {lock_path}",
+        f"Attempting to release lock {id(lock)} on {lock_path}",
+        f"Lock {id(lock)} released on {lock_path}",
+    ]
+    assert [r.levelno for r in caplog.records] == [logging.DEBUG, logging.DEBUG, logging.DEBUG, logging.DEBUG]
+    assert [r.name for r in caplog.records] == ["filelock", "filelock", "filelock", "filelock"]
+    assert logging.getLogger("filelock").level == logging.NOTSET
+
+
+@contextmanager
+def make_ro(path: Path) -> Iterator[None]:
+    write = S_IWUSR | S_IWGRP | S_IWOTH
+    path.chmod(path.stat().st_mode & ~write)
+    yield
+    path.chmod(path.stat().st_mode | write)
+
+
+@pytest.fixture()
+def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:
+    with make_ro(tmp_path):
+        yield tmp_path
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have read only folders")
+@pytest.mark.skipif(
+    sys.platform != "win32" and os.geteuid() == 0,
+    reason="Cannot make a read only file (that the current user: root can't read)",
+)
+async def test_ro_folder(lock_type: type[BaseFileLock], tmp_path_ro: Path) -> None:
+    lock = lock_type(str(tmp_path_ro / "a"))
+    with pytest.raises(PermissionError, match="Permission denied"):
+        await lock.acquire()
+
+
+@pytest.fixture()
+def tmp_file_ro(tmp_path: Path) -> Iterator[Path]:
+    filename = tmp_path / "a"
+    filename.write_text("")
+    with make_ro(filename):
+        yield filename
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+@pytest.mark.skipif(
+    sys.platform != "win32" and os.geteuid() == 0,
+    reason="Cannot make a read only file (that the current user: root can't read)",
+)
+async def test_ro_file(lock_type: type[BaseFileLock], tmp_file_ro: Path) -> None:
+    lock = lock_type(str(tmp_file_ro))
+    with pytest.raises(PermissionError, match="Permission denied"):
+        await lock.acquire()
+
+
+WindowsOnly = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+@pytest.mark.parametrize(
+    ("expected_error", "match", "bad_lock_file"),
+    [
+        pytest.param(FileNotFoundError, "No such file or directory:", "", id="blank_filename"),
+        pytest.param(ValueError, "embedded null (byte|character)", "\0", id="null_byte"),
+        # Should be PermissionError on Windows
+        pytest.param(PermissionError, "Permission denied:", ".", id="current_directory")
+        if sys.platform == "win32"
+        else (
+            # Should be IsADirectoryError on MacOS and Linux
+            pytest.param(IsADirectoryError, "Is a directory", ".", id="current_directory")
+            if sys.platform in ["darwin", "linux"]
+            else
+            # Should be some type of OSError at least on other operating systems
+            pytest.param(OSError, None, ".", id="current_directory")
+        ),
+    ]
+    + [pytest.param(OSError, "Invalid argument", i, id=f"invalid_{i}", marks=WindowsOnly) for i in '<>:"|?*\a']
+    + [pytest.param(PermissionError, "Permission denied:", i, id=f"permission_{i}", marks=WindowsOnly) for i in "/\\"],
+)
+async def test_bad_lock_file(
+    lock_type: type[BaseFileLock],
+    expected_error: type[Exception],
+    match: str,
+    bad_lock_file: str,
+) -> None:
+    lock = lock_type(bad_lock_file)
+
+    with pytest.raises(expected_error, match=match):
+        await lock.acquire()
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_nested_context_manager(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # lock is not released before the most outer with statement that locked the lock, is left
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    async with lock as lock_1:
+        assert lock.is_locked
+        assert lock is lock_1
+
+        async with lock as lock_2:
+            assert lock.is_locked
+            assert lock is lock_2
+
+            async with lock as lock_3:
+                assert lock.is_locked
+                assert lock is lock_3
+
+            assert lock.is_locked
+        assert lock.is_locked
+    assert not lock.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_nested_acquire(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # lock is not released before the most outer with statement that locked the lock, is left
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    async with await lock.acquire() as lock_1:
+        assert lock.is_locked
+        assert lock is lock_1
+
+        async with await lock.acquire() as lock_2:
+            assert lock.is_locked
+            assert lock is lock_2
+
+            async with await lock.acquire() as lock_3:
+                assert lock.is_locked
+                assert lock is lock_3
+
+            assert lock.is_locked
+        assert lock.is_locked
+    assert not lock.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_nested_forced_release(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # acquires the lock using a with-statement and releases the lock before leaving the with-statement
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    async with lock:
+        assert lock.is_locked
+
+        await lock.acquire()
+        assert lock.is_locked
+
+        lock.release(force=True)
+        assert not lock.is_locked
+    assert not lock.is_locked
+
+
+_ExcInfoType = Union[Tuple[Type[BaseException], BaseException, TracebackType], Tuple[None, None, None]]
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_timeout(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # raises Timeout error when the lock cannot be acquired
+    lock_path = tmp_path / "a"
+    lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
+
+    # acquire lock 1
+    await lock_1.acquire()
+    assert lock_1.is_locked
+    assert not lock_2.is_locked
+
+    # try to acquire lock 2
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_2.acquire(timeout=0.1)
+    assert not lock_2.is_locked
+    assert lock_1.is_locked
+
+    # release lock 1
+    lock_1.release()
+    assert not lock_1.is_locked
+    assert not lock_2.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_non_blocking(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # raises Timeout error when the lock cannot be acquired
+    lock_path = tmp_path / "a"
+    lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
+
+    # acquire lock 1
+    await lock_1.acquire()
+    assert lock_1.is_locked
+    assert not lock_2.is_locked
+
+    # try to acquire lock 2
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_2.acquire(blocking=False)
+    assert not lock_2.is_locked
+    assert lock_1.is_locked
+
+    # release lock 1
+    lock_1.release()
+    assert not lock_1.is_locked
+    assert not lock_2.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_default_timeout(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # test if the default timeout parameter works
+    lock_path = tmp_path / "a"
+    lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path), timeout=0.1)
+    assert lock_2.timeout == 0.1
+
+    # acquire lock 1
+    await lock_1.acquire()
+    assert lock_1.is_locked
+    assert not lock_2.is_locked
+
+    # try to acquire lock 2
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_2.acquire()
+    assert not lock_2.is_locked
+    assert lock_1.is_locked
+
+    lock_2.timeout = 0
+    assert lock_2.timeout == 0
+
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_2.acquire()
+    assert not lock_2.is_locked
+    assert lock_1.is_locked
+
+    # release lock 1
+    lock_1.release()
+    assert not lock_1.is_locked
+    assert not lock_2.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_context_release_on_exc(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # lock is released when an exception is thrown in a with-statement
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    try:
+        async with lock as lock_1:
+            assert lock is lock_1
+            assert lock.is_locked
+            raise ValueError  # noqa: TRY301
+    except ValueError:
+        assert not lock.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_acquire_release_on_exc(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # lock is released when an exception is thrown in a acquire statement
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    try:
+        async with await lock.acquire() as lock_1:
+            assert lock is lock_1
+            assert lock.is_locked
+            raise ValueError  # noqa: TRY301
+    except ValueError:
+        assert not lock.is_locked
+
+
+@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="del() does not trigger GC in PyPy")
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_del(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    # lock is released when the object is deleted
+    lock_path = tmp_path / "a"
+    lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
+
+    # acquire lock 1
+    await lock_1.acquire()
+    assert lock_1.is_locked
+    assert not lock_2.is_locked
+
+    # try to acquire lock 2
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_2.acquire(timeout=0.1)
+
+    # delete lock 1 and try to acquire lock 2 again
+    del lock_1
+
+    await lock_2.acquire()
+    assert lock_2.is_locked
+
+    lock_2.release()
+
+
+async def test_cleanup_soft_lock(tmp_path: Path) -> None:
+    # tests if the lock file is removed after use
+    lock_path = tmp_path / "a"
+
+    async with SoftFileLock(lock_path):
+        assert lock_path.exists()
+    assert not lock_path.exists()
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_poll_intervall_deprecated(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    with pytest.deprecated_call(match="use poll_interval instead of poll_intervall") as checker:
+        await lock.acquire(poll_intervall=0.05)  # the deprecation warning will be captured by the checker
+        frame_info = getframeinfo(stack()[0][0])  # get frame info of current file and lineno (+1 than the above lineno)
+        for warning in checker:
+            if warning.filename == frame_info.filename and warning.lineno + 1 == frame_info.lineno:  # pragma: no cover
+                break
+        else:  # pragma: no cover
+            pytest.fail("No warnings of stacklevel=2 matching.")
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+async def test_context_decorator(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    @lock
+    def decorated_method() -> None:
+        assert lock.is_locked
+
+    assert not lock.is_locked
+    decorated_method()
+    assert not lock.is_locked
+
+
+async def test_lock_mode(tmp_path: Path) -> None:
+    # test file lock permissions are independent of umask
+    lock_path = tmp_path / "a.lock"
+    lock = FileLock(str(lock_path), mode=0o666)
+
+    # set umask so permissions can be anticipated
+    initial_umask = os.umask(0o022)
+    try:
+        await lock.acquire()
+        assert lock.is_locked
+
+        mode = filemode(lock_path.stat().st_mode)
+        assert mode == "-rw-rw-rw-"
+    finally:
+        os.umask(initial_umask)
+
+    lock.release()
+
+
+async def test_lock_mode_soft(tmp_path: Path) -> None:
+    # test soft lock permissions are dependent of umask
+    lock_path = tmp_path / "a.lock"
+    lock = SoftFileLock(str(lock_path), mode=0o666)
+
+    # set umask so permissions can be anticipated
+    initial_umask = os.umask(0o022)
+    try:
+        await lock.acquire()
+        assert lock.is_locked
+
+        mode = filemode(lock_path.stat().st_mode)
+        if sys.platform == "win32":
+            assert mode == "-rw-rw-rw-"
+        else:
+            assert mode == "-rw-r--r--"
+    finally:
+        os.umask(initial_umask)
+
+    lock.release()
+
+
+async def test_umask(tmp_path: Path) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock = FileLock(str(lock_path), mode=0o666)
+
+    initial_umask = os.umask(0)
+    os.umask(initial_umask)
+
+    await lock.acquire()
+    assert lock.is_locked
+
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    assert initial_umask == current_umask
+
+    lock.release()
+
+
+async def test_umask_soft(tmp_path: Path) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock = SoftFileLock(str(lock_path), mode=0o666)
+
+    initial_umask = os.umask(0)
+    os.umask(initial_umask)
+
+    await lock.acquire()
+    assert lock.is_locked
+
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    assert initial_umask == current_umask
+
+    lock.release()
+
+
+async def test_wrong_platform(tmp_path: Path) -> None:
+    assert not inspect.isabstract(UnixFileLock)
+    assert not inspect.isabstract(WindowsFileLock)
+    assert inspect.isabstract(BaseFileLock)
+
+    lock_type = UnixFileLock if sys.platform == "win32" else WindowsFileLock
+    lock = lock_type(tmp_path / "lockfile")
+
+    with pytest.raises(NotImplementedError):
+        await lock.acquire()
+    with pytest.raises(NotImplementedError):
+        lock._release()  # noqa: SLF001
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="flock not run on windows")
+async def test_flock_not_implemented_unix(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("fcntl.flock", side_effect=OSError(ENOSYS, "mock error"))
+    with pytest.raises(NotImplementedError):
+        async with FileLock(tmp_path / "a.lock"):
+            pass
+
+
+async def test_soft_errors(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("os.open", side_effect=OSError(ENOSYS, "mock error"))
+    with pytest.raises(OSError, match="mock error"):
+        await SoftFileLock(tmp_path / "a.lock").acquire()


### PR DESCRIPTION
## Introduce async support to `filelock`

With this, you can now use filelock with your friendly neighborhood async event loop implementations.

### Async context manager usage
```python
from filelock.asyncio import FileLock

async def safe_write():
    lock = FileLock("foo.txt.lock")
    async with lock:
        with open("foo.txt", "w") as f:
            f.write("bar")
```

### Explicit `acquire`/`release` usage

```python
from filelock.asyncio import FileLock

async def safe_write():
    lock = FileLock("foo.txt.lock", timeout=4.2)
    try:
        await lock.acquire()
        with open("foo.txt", "w") as f:
            f.write("bar")
    finally:
        lock.release()
```
