### PR TITLE
Support reentrant locking on lock file path via optional singleton instance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,0 @@
-### [TITLE]
-
-#### Description
-
-[A brief description of what has changed]
-
-#### Action Items
-
-[An optional checklist of action items]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+### [TITLE]
+
+#### Description
+
+[A brief description of what has changed]
+
+#### Action Items
+
+[An optional checklist of action items]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.1"
+    rev: "v0.1.3"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 23.10.0
+    rev: 23.10.1
     hooks:
       - id: black
   - repo: https://github.com/tox-dev/tox-ini-fmt
@@ -19,10 +19,10 @@ repos:
       - id: tox-ini-fmt
         args: ["-p", "fix"]
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "1.2.0"
+    rev: "1.3.0"
     hooks:
       - id: pyproject-fmt
-        additional_dependencies: ["tox>=4.8"]
+        additional_dependencies: ["tox>=4.11.3"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.3"
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,26 +6,26 @@ This page lists the steps needed to set up a development environment and contrib
 
 2. Install initial dependencies in a virtual environment:
 
-    ```shell
-    python -m venv venv
-    source venv/bin/activate
-    python -m pip install --upgrade pip 'tox>=4.2'
-    ```
+   ```shell
+   python -m venv venv
+   source venv/bin/activate
+   python -m pip install --upgrade pip 'tox>=4.2'
+   ```
 
 3. Run tests
 
-    ```shell
-    tox run
-    ```
+   ```shell
+   tox run
+   ```
 
-    or for a specific python version
+   or for a specific python version
 
-    ```shell
-    tox run -f py311
-    ```
+   ```shell
+   tox run -f py311
+   ```
 
 4. Running other tox commands (ex. linting)
 
-    ```shell
-    tox -e fix
-    ```
+   ```shell
+   tox -e fix
+   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+This page lists the steps needed to set up a development environment and contribute to the project.
+
+1. Fork and clone this repo
+
+2. Install initial dependencies in a virtual environment:
+
+    ```shell
+    python -m venv venv
+    source venv/bin/activate
+    python -m pip install --upgrade pip 'tox>=4.2'
+    ```
+
+3. Run tests
+
+    ```shell
+    tox run
+    ```
+
+    or for a specific python version
+
+    ```shell
+    tox run -f py311
+    ```
+
+4. Running other tox commands (ex. linting)
+
+    ```shell
+    tox -e fix
+    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 This page lists the steps needed to set up a development environment and contribute to the project.
 
-1. Fork and clone this repo
+1. Fork and clone this repo.
 
-2. Install `tox` via `pipx`: https://tox.wiki/en/4.11.3/installation.html#via-pipx
+2. [Install tox](https://tox.wiki/en/latest/installation.html#via-pipx).
 
-3. Run tests
+3. Run tests:
 
    ```shell
    tox run
@@ -18,7 +18,7 @@ This page lists the steps needed to set up a development environment and contrib
    tox run -f py311
    ```
 
-4. Running other tox commands (ex. linting)
+4. Running other tox commands (ex. linting):
 
    ```shell
    tox -e fix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,7 @@ This page lists the steps needed to set up a development environment and contrib
 
 1. Fork and clone this repo
 
-2. Install initial dependencies in a virtual environment:
-
-   ```shell
-   python -m venv venv
-   source venv/bin/activate
-   python -m pip install --upgrade pip 'tox>=4.2'
-   ```
+2. Install `tox` via `pipx`: https://tox.wiki/en/4.11.3/installation.html#via-pipx
 
 3. Run tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ This page lists the steps needed to set up a development environment and contrib
    tox run -f py311
    ```
 
-4. Running other tox commands (ex. linting):
+4. Running other tox commands (eg. linting):
 
    ```shell
    tox -e fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,21 +39,21 @@ dynamic = [
   "version",
 ]
 optional-dependencies.docs = [
-  "furo>=2023.7.26",
-  "sphinx>=7.1.2",
+  "furo>=2023.9.10",
+  "sphinx>=7.2.6",
   "sphinx-autodoc-typehints!=1.23.4,>=1.24",
 ]
 optional-dependencies.testing = [
   "covdefaults>=2.3",
-  "coverage>=7.3",
-  "diff-cover>=7.7",
-  "pytest>=7.4",
+  "coverage>=7.3.2",
+  "diff-cover>=8",
+  "pytest>=7.4.3",
   "pytest-cov>=4.1",
-  "pytest-mock>=3.11.1",
-  "pytest-timeout>=2.1",
+  "pytest-mock>=3.12",
+  "pytest-timeout>=2.2",
 ]
 optional-dependencies.typing = [
-  'typing-extensions>=4.7.1; python_version < "3.11"',
+  'typing-extensions>=4.8; python_version < "3.11"',
 ]
 urls.Documentation = "https://py-filelock.readthedocs.io"
 urls.Homepage = "https://github.com/tox-dev/py-filelock"

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -32,7 +32,7 @@ else:  # pragma: win32 no cover # noqa: PLR5501
         if warnings is not None:
             warnings.warn("only soft file lock is available", stacklevel=2)
 
-if TYPE_CHECKING:  # noqa: SIM108
+if TYPE_CHECKING:
     FileLock = SoftFileLock
 else:
     #: Alias for the lock, which should be used for the current platform.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -87,7 +87,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         **kwargs: Mapping[str, Any],  # noqa: ARG003
     ) -> BaseFileLock:
         """
-        Create a new instance of the class or if specified return an existing instance for the same lock file.
+        Create a new lock object or if specified return the singleton instance for the lock file.
 
         :param lock_file: path to the file
         :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -82,17 +82,20 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
     def __new__(  # noqa: PYI034
         cls,
         lock_file: str | os.PathLike[str],
+        is_singleton: bool = False,  # noqa: FBT001, FBT002
         *args: Sequence[Any],  # noqa: ARG003
-        **kwargs: Mapping[str, Any],
+        **kwargs: Mapping[str, Any],  # noqa: ARG003
     ) -> BaseFileLock:
         """
         Create a new instance of the class or if specified return an existing instance for the same lock file.
 
         :param lock_file: path to the file
+        :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per
+        lock file.
         :param args: additional positional arguments
         :param kwargs: additional keyword arguments
         """
-        if not kwargs.get("is_singleton", False):
+        if not is_singleton:
             return super().__new__(cls)
 
         instance = cls._instances.get(str(lock_file))

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -8,14 +8,13 @@ import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from threading import local
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Mapping, Sequence
 from weakref import WeakValueDictionary
 
 from ._error import Timeout
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Mapping, Sequence
     from types import TracebackType
 
     if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
@@ -78,9 +77,14 @@ class ThreadLocalFileContext(FileLockContext, local):
 class BaseFileLock(ABC, contextlib.ContextDecorator):
     """Abstract base class for a file lock object."""
 
-    _instances: ClassVar[WeakValueDictionary] = WeakValueDictionary()
+    _instances: ClassVar[WeakValueDictionary[str, BaseFileLock]] = WeakValueDictionary()
 
-    def __new__(cls, lock_file: str | os.PathLike[str], *args: Sequence, **kwargs: Mapping) -> Self:  # noqa: ARG003
+    def __new__(  # noqa: PYI034
+        cls,
+        lock_file: str | os.PathLike[str],
+        *args: Sequence[Any],  # noqa: ARG003
+        **kwargs: Mapping[str, Any],
+    ) -> BaseFileLock:
         """
         Create a new instance of the class or if specified return an existing instance for the same lock file.
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -88,7 +88,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         :param args: additional positional arguments
         :param kwargs: additional keyword arguments
         """
-        if not kwargs.get("singleton_per_lock_file", False):
+        if not kwargs.get("is_singleton", False):
             return super().__new__(cls)
 
         instance = cls._instances.get(str(lock_file))
@@ -104,7 +104,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         timeout: float = -1,
         mode: int = 0o644,
         thread_local: bool = True,  # noqa: FBT001, FBT002
-        singleton_per_lock_file: bool = False,  # noqa: FBT001, FBT002
+        is_singleton: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
         """
         Create a new lock object.
@@ -116,12 +116,12 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         :param mode: file permissions for the lockfile.
         :param thread_local: Whether this object's internal context should be thread local or not.
         If this is set to ``False`` then the lock will be reentrant across threads.
-        :param singleton_per_lock_file: If this is set to ``True`` then only one instance of this class will be created
+        :param is_singleton: If this is set to ``True`` then only one instance of this class will be created
         per lock file. This is useful if you want to use the lock object for reentrant locking without needing
         to pass the same object around.
         """
         self._is_thread_local = thread_local
-        self._singleton_per_lock_file = singleton_per_lock_file
+        self._is_singleton = is_singleton
 
         # Create the context. Note that external code should not work with the context directly  and should instead use
         # properties of this class.
@@ -136,9 +136,10 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         """:return: a flag indicating if this lock is thread local or not"""
         return self._is_thread_local
 
-    def is_singleton_per_lock_file(self) -> bool:
-        """:return: a flag indicating if this lock is singleton per lock file or not"""
-        return self._singleton_per_lock_file
+    @property
+    def is_singleton(self) -> bool:
+        """:return: a flag indicating if this lock is singleton or not"""
+        return self._is_singleton
 
     @property
     def lock_file(self) -> str:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -614,7 +614,7 @@ def test_lock_can_be_non_thread_local(
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_lock_singleton_and_non_singleton_locks_are_distinct(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+def test_singleton_and_non_singleton_locks_are_distinct(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path = tmp_path / "a"
     lock_1 = lock_type(str(lock_path), singleton_per_lock_file=False)
     assert lock_1.is_singleton_per_lock_file() is False
@@ -625,7 +625,7 @@ def test_lock_singleton_and_non_singleton_locks_are_distinct(lock_type: type[Bas
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_lock_singleton_locks_are_the_same(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+def test_singleton_locks_are_the_same(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path = tmp_path / "a"
     lock_1 = lock_type(str(lock_path), singleton_per_lock_file=True)
 
@@ -634,7 +634,7 @@ def test_lock_singleton_locks_are_the_same(lock_type: type[BaseFileLock], tmp_pa
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_lock_singleton_locks_are_distinct_per_lock_file(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+def test_singleton_locks_are_distinct_per_lock_file(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path_1 = tmp_path / "a"
     lock_1 = lock_type(str(lock_path_1), singleton_per_lock_file=True)
 
@@ -642,3 +642,16 @@ def test_lock_singleton_locks_are_distinct_per_lock_file(lock_type: type[BaseFil
     lock_2 = lock_type(str(lock_path_2), singleton_per_lock_file=True)
 
     assert lock_1 is not lock_2
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_singleton_locks_are_deleted_when_no_external_references_exist(
+    lock_type: type[BaseFileLock],
+    tmp_path: Path,
+) -> None:
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path), singleton_per_lock_file=True)
+
+    assert lock_type._instances[str(lock_path)] == lock  # noqa: SLF001
+    del lock
+    assert lock_type._instances == {}  # noqa: SLF001

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -616,40 +616,41 @@ def test_lock_can_be_non_thread_local(
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_singleton_and_non_singleton_locks_are_distinct(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path = tmp_path / "a"
-    lock_1 = lock_type(str(lock_path), singleton_per_lock_file=False)
-    assert lock_1.is_singleton_per_lock_file() is False
+    lock_1 = lock_type(str(lock_path), is_singleton=False)
+    assert lock_1.is_singleton is False
 
-    lock_2 = lock_type(str(lock_path), singleton_per_lock_file=True)
-    assert lock_2.is_singleton_per_lock_file() is True
+    lock_2 = lock_type(str(lock_path), is_singleton=True)
+    assert lock_2.is_singleton is True
     assert lock_2 is not lock_1
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_singleton_locks_are_the_same(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path = tmp_path / "a"
-    lock_1 = lock_type(str(lock_path), singleton_per_lock_file=True)
+    lock_1 = lock_type(str(lock_path), is_singleton=True)
 
-    lock_2 = lock_type(str(lock_path), singleton_per_lock_file=True)
+    lock_2 = lock_type(str(lock_path), is_singleton=True)
     assert lock_2 is lock_1
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_singleton_locks_are_distinct_per_lock_file(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path_1 = tmp_path / "a"
-    lock_1 = lock_type(str(lock_path_1), singleton_per_lock_file=True)
+    lock_1 = lock_type(str(lock_path_1), is_singleton=True)
 
     lock_path_2 = tmp_path / "b"
-    lock_2 = lock_type(str(lock_path_2), singleton_per_lock_file=True)
+    lock_2 = lock_type(str(lock_path_2), is_singleton=True)
     assert lock_1 is not lock_2
 
 
+@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="del() does not trigger GC in PyPy")
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_singleton_locks_are_deleted_when_no_external_references_exist(
     lock_type: type[BaseFileLock],
     tmp_path: Path,
 ) -> None:
     lock_path = tmp_path / "a"
-    lock = lock_type(str(lock_path), singleton_per_lock_file=True)
+    lock = lock_type(str(lock_path), is_singleton=True)
 
     assert lock_type._instances == {str(lock_path): lock}  # noqa: SLF001
     del lock

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -640,7 +640,6 @@ def test_singleton_locks_are_distinct_per_lock_file(lock_type: type[BaseFileLock
 
     lock_path_2 = tmp_path / "b"
     lock_2 = lock_type(str(lock_path_2), singleton_per_lock_file=True)
-
     assert lock_1 is not lock_2
 
 
@@ -652,6 +651,6 @@ def test_singleton_locks_are_deleted_when_no_external_references_exist(
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path), singleton_per_lock_file=True)
 
-    assert lock_type._instances[str(lock_path)] == lock  # noqa: SLF001
+    assert lock_type._instances == {str(lock_path): lock}  # noqa: SLF001
     del lock
     assert lock_type._instances == {}  # noqa: SLF001

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -611,3 +611,34 @@ def test_lock_can_be_non_thread_local(
     assert lock.lock_counter == 2
 
     lock.release(force=True)
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_lock_singleton_and_non_singleton_locks_are_distinct(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path), singleton_per_lock_file=False)
+    assert lock_1.is_singleton_per_lock_file() is False
+
+    lock_2 = lock_type(str(lock_path), singleton_per_lock_file=True)
+    assert lock_2.is_singleton_per_lock_file() is True
+    assert lock_2 is not lock_1
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_lock_singleton_locks_are_the_same(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path), singleton_per_lock_file=True)
+
+    lock_2 = lock_type(str(lock_path), singleton_per_lock_file=True)
+    assert lock_2 is lock_1
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_lock_singleton_locks_are_distinct_per_lock_file(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path_1 = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path_1), singleton_per_lock_file=True)
+
+    lock_path_2 = tmp_path / "b"
+    lock_2 = lock_type(str(lock_path_2), singleton_per_lock_file=True)
+
+    assert lock_1 is not lock_2

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ description = format the code base to adhere to our styles, and complain about w
 base_python = python3.10
 skip_install = true
 deps =
-    pre-commit>=3.3.3
+    pre-commit>=3.5
 commands =
     pre-commit run --all-files --show-diff-on-failure
     python -c 'import pathlib; print("hint: run \{\} install to add checks as pre-commit hook".format(pathlib.Path(r"{envdir}") / "bin" / "pre-commit"))'
@@ -46,7 +46,7 @@ commands =
 [testenv:type]
 description = run type check on code base
 deps =
-    mypy==1.5
+    mypy==1.6.1
 set_env =
     {tty:MYPY_FORCE_COLOR = 1}
 commands =
@@ -58,8 +58,8 @@ description = combine coverage files and generate diff (against DIFF_AGAINST def
 skip_install = true
 deps =
     covdefaults>=2.3
-    coverage[toml]>=7.3
-    diff-cover>=7.7
+    coverage[toml]>=7.3.2
+    diff-cover>=8
 extras =
 parallel_show_output = true
 pass_env =
@@ -91,7 +91,7 @@ commands =
 description = check that the long description is valid (need for PyPI)
 skip_install = true
 deps =
-    build[virtualenv]>=0.10
+    build[virtualenv]>=1.0.3
     twine>=4.0.2
 extras =
 commands =


### PR DESCRIPTION
#### Description

Re: #282.


- When `_singleton_per_lock_file` is set instantiating a new lock with the same lock path will return the existing instance of the lock. This means you can reacquire the lock without passing the lock object around
- Otherwise a new lock object is returned every time (default behavior for backwards compatibility)

Based on the `flock` docs (and likely similar for windows/soft cases)

> If a process uses [open(2)](https://man7.org/linux/man-pages/man2/open.2.html) (or similar) to obtain more than one
       file descriptor for the same file, these file descriptors are
       treated independently by flock().  An attempt to lock the file
       using one of these file descriptors may be denied by a lock that
       the calling process has already placed via another file
       descriptor.

(https://man7.org/linux/man-pages/man2/flock.2.html)

a Python solution seems most general and easy here. If anyone has time to dig into different OS file locking mechanisms and see if there is a native solution that would likely be preferable.


#### Action Items

- [x] docs updates?
- [ ] concurrency? If the use case fro non-thread-local locks is to create the lock on the main thread, share it with threads, then cleanup the lock when they complete then this should be safe as the threads will only ever read the instance from the class instances dictionary. If supporting hand-off of the lock to thread processes is within the thread-local options then we should acquire a global lock around the instances dictionary for safety (at the cost of speed)
