### PR TITLE
Allow users to subclass FileLock with custom keyword arguments

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -87,6 +87,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         thread_local: bool = True,  # noqa: ARG003, FBT001, FBT002
         *,
         is_singleton: bool = False,
+        **kwargs: dict[str, Any],  # capture remaining kwargs for subclasses  # noqa: ARG003
     ) -> Self:
         """Create a new lock object or if specified return the singleton instance for the lock file."""
         if not is_singleton:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -614,6 +614,21 @@ def test_lock_can_be_non_thread_local(
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_subclass_compatibility(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    class MyFileLock(lock_type):
+        def __init__(
+            self,
+            *args,  # noqa: ANN002
+            my_param: int = 0,
+            **kwargs,  # noqa: ANN003
+        ) -> None:
+            pass
+
+    lock_path = tmp_path / "a"
+    MyFileLock(str(lock_path), my_param=1)
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_singleton_and_non_singleton_locks_are_distinct(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path = tmp_path / "a"
     lock_1 = lock_type(str(lock_path), is_singleton=False)


### PR DESCRIPTION
Without this patch:
```
=============================================== FAILURES ===============================================
______________________________ test_subclass_compatibility[UnixFileLock] _______________________________

lock_type = <class 'filelock._unix.UnixFileLock'>

    @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
    def test_subclass_compatibility(lock_type):
        class MyFileLock(lock_type):
            def __init__(self, *args, my_param=None, **kwargs):
                pass
    
>       MyFileLock(my_param=1)
E       TypeError: BaseFileLock.__new__() got an unexpected keyword argument 'my_param'

tests/test_filelock.py:622: TypeError
______________________________ test_subclass_compatibility[SoftFileLock] _______________________________

lock_type = <class 'filelock._soft.SoftFileLock'>

    @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
    def test_subclass_compatibility(lock_type):
        class MyFileLock(lock_type):
            def __init__(self, *args, my_param=None, **kwargs):
                pass
    
>       MyFileLock(my_param=1)
E       TypeError: BaseFileLock.__new__() got an unexpected keyword argument 'my_param'

tests/test_filelock.py:622: TypeError
======================================= short test summary info ========================================
```

Resolves the unstated issues in the comment: https://github.com/tox-dev/filelock/issues/282#issuecomment-1784361082