### PR TITLE
Update SECURITY.md to reflect Python 3.7 support dropoff

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.7 +   | :white_check_mark: |
-| < 3.7   | :x:                |
+| 3.8 +   | :white_check_mark: |
+| < 3.8   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Resolves #301.

From reading the [GitHub docs](https://docs.github.com/en/code-security/getting-started/securing-your-repository#setting-a-security-policy), it looks like we just need to update the version numbers in .github/SECURITY.md.