### PR TITLE
[BugFix] fix permission denied error when lock file is placed in `/tmp`

### DIFF
--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -35,7 +35,9 @@ else:  # pragma: win32 no cover
 
         def _acquire(self) -> None:
             ensure_directory_exists(self.lock_file)
-            open_flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+            open_flags = os.O_RDWR | os.O_TRUNC
+            if not os.path.exists(self.lock_file):
+                open_flags |= os.O_CREAT
             fd = os.open(self.lock_file, open_flags, self._context.mode)
             with suppress(PermissionError):  # This locked is not owned by this UID
                 os.fchmod(fd, self._context.mode)

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -4,6 +4,7 @@ import os
 import sys
 from contextlib import suppress
 from errno import ENOSYS
+from pathlib import Path
 from typing import cast
 
 from ._api import BaseFileLock
@@ -36,7 +37,7 @@ else:  # pragma: win32 no cover
         def _acquire(self) -> None:
             ensure_directory_exists(self.lock_file)
             open_flags = os.O_RDWR | os.O_TRUNC
-            if not os.path.exists(self.lock_file):
+            if not Path(self.lock_file).exists():
                 open_flags |= os.O_CREAT
             fd = os.open(self.lock_file, open_flags, self._context.mode)
             with suppress(PermissionError):  # This locked is not owned by this UID


### PR DESCRIPTION
When you put the lock file in a directory with sticky bit (like `/tmp`), you will get a permission denied error if you use a lock file created by someone else.

Work around this issue by excluding `os.O_CREAT` from `open_flags` if the lock file already exists.

cf. https://github.com/vllm-project/vllm/pull/3599#issuecomment-2017125950

#### sample code

```py
# sample.py
import filelock
with filelock.FileLock("tmp/a.lock", mode=0o666):
    pass
```

```sh
# create tmp file with sticky bit
$ mkdir tmp
$ sudo chmod 1777 tmp
$ sudo chown root:root tmp

# add lock file by another user
$ touch tmp/a.lock
$ sudo chmod 666 tmp/a.lock 
$ sudo chown 1111:1111 tmp/a.lock

# run sample code
$ python sample.py 
Traceback (most recent call last):
  File "/workspaces/filelock/sample.py", line 4, in <module>
    with filelock.FileLock(lock_path, mode=0o666):
  File "/workspaces/filelock/src/filelock/_api.py", line 301, in __enter__
    self.acquire()
  File "/workspaces/filelock/src/filelock/_api.py", line 257, in acquire
    self._acquire()
  File "/workspaces/filelock/src/filelock/_unix.py", line 41, in _acquire
    fd = os.open(self.lock_file, open_flags, self._context.mode)
PermissionError: [Errno 13] Permission denied: 'tmp/a.lock'
```