### PR TITLE
Raise error on incompatible singleton timeout and mode args

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -82,8 +82,8 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
     def __new__(  # noqa: PLR0913
         cls,
         lock_file: str | os.PathLike[str],
-        timeout: float = -1,  # noqa: ARG003
-        mode: int = 0o644,  # noqa: ARG003
+        timeout: float = -1,
+        mode: int = 0o644,
         thread_local: bool = True,  # noqa: ARG003, FBT001, FBT002
         *,
         is_singleton: bool = False,
@@ -97,6 +97,9 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         if not instance:
             instance = super().__new__(cls)
             cls._instances[str(lock_file)] = instance
+        elif timeout != instance.timeout or mode != instance.mode:
+            msg = "Singleton lock instances cannot be initialized with differing arguments"
+            raise ValueError(msg)
 
         return instance  # type: ignore[return-value] # https://github.com/python/mypy/issues/15322
 
@@ -168,6 +171,11 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
 
         """
         self._context.timeout = float(value)
+
+    @property
+    def mode(self) -> int:
+        """:return: the file permissions for the lockfile"""
+        return self._context.mode
 
     @abstractmethod
     def _acquire(self) -> None:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -675,6 +675,17 @@ def test_singleton_locks_are_distinct_per_lock_file(lock_type: type[BaseFileLock
     assert lock_1 is not lock_2
 
 
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_singleton_locks_must_be_initialized_with_the__same_args(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path), is_singleton=True)  # noqa: F841
+
+    with pytest.raises(ValueError, match="Singleton lock instances cannot be initialized with differing arguments"):
+        lock_type(str(lock_path), timeout=10, is_singleton=True)
+    with pytest.raises(ValueError, match="Singleton lock instances cannot be initialized with differing arguments"):
+        lock_type(str(lock_path), mode=0, is_singleton=True)
+
+
 @pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="del() does not trigger GC in PyPy")
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_singleton_locks_are_deleted_when_no_external_references_exist(

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -676,7 +676,7 @@ def test_singleton_locks_are_distinct_per_lock_file(lock_type: type[BaseFileLock
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_singleton_locks_must_be_initialized_with_the__same_args(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+def test_singleton_locks_must_be_initialized_with_the_same_args(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path), is_singleton=True)  # noqa: F841
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 
 [testenv:fix]
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically
-base_python = python3.12
+base_python = python3.10
 skip_install = true
 deps =
     pre-commit>=3.5

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 
 [testenv:fix]
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically
-base_python = python3.10
+base_python = python3.12
 skip_install = true
 deps =
     pre-commit>=3.5


### PR DESCRIPTION
Re: https://github.com/tox-dev/filelock/pull/283#issuecomment-2018116737.

This is a breaking change for singleton locks that subclass and implement their own context management.