### PR TITLE
asyncio support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ optional-dependencies.testing = [
   "coverage>=7.3.2",
   "diff-cover>=8.0.1",
   "pytest>=7.4.3",
+  "pytest-asyncio",
   "pytest-cov>=4.1",
   "pytest-mock>=3.12",
   "pytest-timeout>=2.2",
-  "pytest-asyncio",
 ]
 optional-dependencies.typing = [
   "typing-extensions>=4.8; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ optional-dependencies.testing = [
   "coverage>=7.3.2",
   "diff-cover>=8.0.1",
   "pytest>=7.4.3",
-  "pytest-asyncio",
+  "pytest-asyncio>=0.21",
   "pytest-cov>=4.1",
   "pytest-mock>=3.12",
   "pytest-timeout>=2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ optional-dependencies.testing = [
   "pytest-cov>=4.1",
   "pytest-mock>=3.12",
   "pytest-timeout>=2.2",
+  "pytest-asyncio",
 ]
 optional-dependencies.typing = [
   "typing-extensions>=4.8; python_version<'3.11'",

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -17,7 +17,13 @@ from ._error import Timeout
 from ._soft import SoftFileLock
 from ._unix import UnixFileLock, has_fcntl
 from ._windows import WindowsFileLock
-from .asyncio import AsyncAcquireReturnProxy, BaseAsyncFileLock, AsyncSoftFileLock, AsyncUnixFileLock, AsyncWindowsFileLock
+from .asyncio import (
+    AsyncAcquireReturnProxy,
+    AsyncSoftFileLock,
+    AsyncUnixFileLock,
+    AsyncWindowsFileLock,
+    BaseAsyncFileLock,
+)
 from .version import version
 
 #: version of the project as a string
@@ -48,19 +54,17 @@ else:
 
 __all__ = [
     "AcquireReturnProxy",
+    "AsyncAcquireReturnProxy",
+    "AsyncFileLock",
+    "AsyncSoftFileLock",
+    "AsyncUnixFileLock",
+    "AsyncWindowsFileLock",
+    "BaseAsyncFileLock",
     "BaseFileLock",
     "FileLock",
     "SoftFileLock",
     "Timeout",
     "UnixFileLock",
     "WindowsFileLock",
-
-    "AsyncAcquireReturnProxy",
-    "BaseAsyncFileLock",
-    "AsyncFileLock",
-    "AsyncSoftFileLock",
-    "AsyncUnixFileLock",
-    "AsyncWindowsFileLock",
-
     "__version__",
 ]

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -17,6 +17,7 @@ from ._error import Timeout
 from ._soft import SoftFileLock
 from ._unix import UnixFileLock, has_fcntl
 from ._windows import WindowsFileLock
+from .asyncio import AsyncAcquireReturnProxy, BaseAsyncFileLock, AsyncSoftFileLock, AsyncUnixFileLock, AsyncWindowsFileLock
 from .version import version
 
 #: version of the project as a string
@@ -25,19 +26,24 @@ __version__: str = version
 
 if sys.platform == "win32":  # pragma: win32 cover
     _FileLock: type[BaseFileLock] = WindowsFileLock
+    _AsyncFileLock: type[BaseAsyncFileLock] = AsyncWindowsFileLock
 else:  # pragma: win32 no cover # noqa: PLR5501
     if has_fcntl:
         _FileLock: type[BaseFileLock] = UnixFileLock
+        _AsyncFileLock: type[BaseAsyncFileLock] = AsyncUnixFileLock
     else:
         _FileLock = SoftFileLock
+        _AsyncFileLock = AsyncSoftFileLock
         if warnings is not None:
             warnings.warn("only soft file lock is available", stacklevel=2)
 
 if TYPE_CHECKING:
     FileLock = SoftFileLock
+    AsyncFileLock = AsyncSoftFileLock
 else:
     #: Alias for the lock, which should be used for the current platform.
     FileLock = _FileLock
+    AsyncFileLock = _AsyncFileLock
 
 
 __all__ = [
@@ -48,5 +54,13 @@ __all__ = [
     "Timeout",
     "UnixFileLock",
     "WindowsFileLock",
+
+    "AsyncAcquireReturnProxy",
+    "BaseAsyncFileLock",
+    "AsyncFileLock",
+    "AsyncSoftFileLock",
+    "AsyncUnixFileLock",
+    "AsyncWindowsFileLock",
+
     "__version__",
 ]

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -91,7 +91,7 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         *,
         blocking: bool = True,  # noqa: ARG003
         is_singleton: bool = False,
-        **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ARG003
+        **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ARG003, ANN401
     ) -> Self:
         """Create a new lock object or if specified return the singleton instance for the lock file."""
         if not is_singleton:

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -1,6 +1,4 @@
-"""
-An asyncio-based implementation of the file lock.
-"""
+"""An asyncio-based implementation of the file lock."""
 
 from __future__ import annotations
 
@@ -108,7 +106,8 @@ class BaseAsyncFileLock(BaseFileLock):
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
         if thread_local and run_in_executor:
-            raise ValueError("run_in_executor is not supported when thread_local is True")
+            msg = "run_in_executor is not supported when thread_local is True"
+            raise ValueError(msg)
 
         # Create the context. Note that external code should not work with the context directly and should instead use
         # properties of this class.
@@ -127,12 +126,12 @@ class BaseAsyncFileLock(BaseFileLock):
 
     @property
     def run_in_executor(self) -> bool:
-        """::return: whether run in executor"""
+        """::return: whether run in executor."""
         return self._context.run_in_executor
 
     @property
     def executor(self) -> futures.Executor | None:
-        """::return: the executor"""
+        """::return: the executor."""
         return self._context.executor
 
     @executor.setter
@@ -148,7 +147,7 @@ class BaseAsyncFileLock(BaseFileLock):
 
     @property
     def loop(self) -> asyncio.AbstractEventLoop | None:
-        """::return: the event loop"""
+        """::return: the event loop."""
         return self._context.loop
 
     async def acquire(  # type: ignore[override]
@@ -249,7 +248,7 @@ class BaseAsyncFileLock(BaseFileLock):
                 await self._run_internal_method(self._release)
                 self._context.lock_counter = 0
                 _LOGGER.debug("Lock %s released on %s", lock_id, lock_filename)
-    
+
     async def _run_internal_method(self, method: Callable[[], Any]) -> None:
         if asyncio.iscoroutinefunction(method):
             await method()

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -7,7 +7,6 @@ import contextlib
 import logging
 import os
 import time
-import warnings
 from dataclasses import dataclass
 from threading import local
 from typing import TYPE_CHECKING, Any, Callable, NoReturn
@@ -155,7 +154,6 @@ class BaseAsyncFileLock(BaseFileLock):
         timeout: float | None = None,
         poll_interval: float = 0.05,
         *,
-        poll_intervall: float | None = None,
         blocking: bool | None = None,
     ) -> AsyncAcquireReturnProxy:
         """
@@ -165,7 +163,6 @@ class BaseAsyncFileLock(BaseFileLock):
             :attr:`~BaseFileLock.timeout` is and if ``timeout < 0``, there is no timeout and
             this method will block until the lock could be acquired
         :param poll_interval: interval of trying to acquire the lock file
-        :param poll_intervall: deprecated, kept for backwards compatibility, use ``poll_interval`` instead
         :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on the
          first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
         :raises Timeout: if fails to acquire lock within the timeout period
@@ -184,11 +181,6 @@ class BaseAsyncFileLock(BaseFileLock):
             finally:
                 lock.release()
 
-        .. versionchanged:: 2.0.0
-
-            This method returns now a *proxy* object instead of *self*,
-            so that it can be used in a with statement without side effects.
-
         """
         # Use the default timeout, if no timeout is provided.
         if timeout is None:
@@ -196,11 +188,6 @@ class BaseAsyncFileLock(BaseFileLock):
 
         if blocking is None:
             blocking = self._context.blocking
-
-        if poll_intervall is not None:  # pragma: no cover
-            msg = "use poll_interval instead of poll_intervall"
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
-            poll_interval = poll_intervall
 
         # Increment the number right at the beginning. We can still undo it, if something fails.
         self._context.lock_counter += 1

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -230,7 +230,7 @@ class BaseAsyncFileLock(BaseFileLock):
             raise
         return AsyncAcquireReturnProxy(lock=self)
 
-    async def release(self, force: bool = False) -> None:  # type: ignore[override]
+    async def release(self, force: bool = False) -> None:  # type: ignore[override]  # noqa: FBT001, FBT002
         """
         Releases the file lock. Please note, that the lock is only completely released, if the lock counter is 0.
         Also note, that the lock file itself is not automatically deleted.

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -148,7 +148,7 @@ class BaseAsyncFileLock(BaseFileLock):
         """
         Try to acquire the file lock.
 
-        :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default :attr:`~timeout` is and
+        :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default :attr:`~BaseFileLock.timeout` is and
          if ``timeout < 0``, there is no timeout and this method will block until the lock could be acquired
         :param poll_interval: interval of trying to acquire the lock file
         :param poll_intervall: deprecated, kept for backwards compatibility, use ``poll_interval`` instead

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path, PurePath
+
+import pytest
+
+from filelock import BaseAsyncFileLock, AsyncFileLock, AsyncSoftFileLock, Timeout
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.parametrize("path_type", [str, PurePath, Path])
+@pytest.mark.parametrize("filename", ["a", "new/b", "new2/new3/c"])
+@pytest.mark.asyncio
+async def test_simple(
+    lock_type: type[BaseAsyncFileLock],
+    path_type: type[str | Path],
+    filename: str,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    # test lock creation by passing a `str`
+    lock_path = tmp_path / filename
+    lock = lock_type(path_type(lock_path))
+    async with lock as locked:
+        assert lock.is_locked
+        assert lock is locked
+    assert not lock.is_locked
+
+    assert caplog.messages == [
+        f"Attempting to acquire lock {id(lock)} on {lock_path}",
+        f"Lock {id(lock)} acquired on {lock_path}",
+        f"Attempting to release lock {id(lock)} on {lock_path}",
+        f"Lock {id(lock)} released on {lock_path}",
+    ]
+    assert [r.levelno for r in caplog.records] == [logging.DEBUG, logging.DEBUG, logging.DEBUG, logging.DEBUG]
+    assert [r.name for r in caplog.records] == ["filelock", "filelock", "filelock", "filelock"]
+    assert logging.getLogger("filelock").level == logging.NOTSET
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.parametrize("path_type", [str, PurePath, Path])
+@pytest.mark.parametrize("filename", ["a", "new/b", "new2/new3/c"])
+@pytest.mark.asyncio
+async def test_acquire(
+    lock_type: type[BaseAsyncFileLock],
+    path_type: type[str | Path],
+    filename: str,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    # test lock creation by passing a `str`
+    lock_path = tmp_path / filename
+    lock = lock_type(path_type(lock_path))
+    async with await lock.acquire() as locked:
+        assert lock.is_locked
+        assert lock is locked
+    assert not lock.is_locked
+
+    assert caplog.messages == [
+        f"Attempting to acquire lock {id(lock)} on {lock_path}",
+        f"Lock {id(lock)} acquired on {lock_path}",
+        f"Attempting to release lock {id(lock)} on {lock_path}",
+        f"Lock {id(lock)} released on {lock_path}",
+    ]
+    assert [r.levelno for r in caplog.records] == [logging.DEBUG, logging.DEBUG, logging.DEBUG, logging.DEBUG]
+    assert [r.name for r in caplog.records] == ["filelock", "filelock", "filelock", "filelock"]
+    assert logging.getLogger("filelock").level == logging.NOTSET
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
+    # raises Timeout error when the lock cannot be acquired
+    lock_path = tmp_path / "a"
+    lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
+    lock_3 = lock_type(str(lock_path), blocking=False)
+    lock_4 = lock_type(str(lock_path), timeout=0)
+    lock_5 = lock_type(str(lock_path), blocking=False, timeout=-1)
+
+    # acquire lock 1
+    await lock_1.acquire()
+    assert lock_1.is_locked
+    assert not lock_2.is_locked
+    assert not lock_3.is_locked
+    assert not lock_4.is_locked
+    assert not lock_5.is_locked
+
+    # try to acquire lock 2
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_2.acquire(blocking=False)
+    assert not lock_2.is_locked
+    assert lock_1.is_locked
+
+    # try to acquire pre-parametrized `blocking=False` lock 3 with `acquire`
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_3.acquire()
+    assert not lock_3.is_locked
+    assert lock_1.is_locked
+
+    # try to acquire pre-parametrized `blocking=False` lock 3 with context manager
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        async with lock_3:
+            pass
+    assert not lock_3.is_locked
+    assert lock_1.is_locked
+
+    # try to acquire pre-parametrized `timeout=0` lock 4 with `acquire`
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_4.acquire()
+    assert not lock_4.is_locked
+    assert lock_1.is_locked
+
+    # try to acquire pre-parametrized `timeout=0` lock 4 with context manager
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        async with lock_4:
+            pass
+    assert not lock_4.is_locked
+    assert lock_1.is_locked
+
+    # blocking precedence over timeout
+    # try to acquire pre-parametrized `timeout=-1,blocking=False` lock 5 with `acquire`
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        await lock_5.acquire()
+    assert not lock_5.is_locked
+    assert lock_1.is_locked
+
+    # try to acquire pre-parametrized `timeout=-1,blocking=False` lock 5 with context manager
+    with pytest.raises(Timeout, match="The file lock '.*' could not be acquired."):
+        async with lock_5:
+            pass
+    assert not lock_5.is_locked
+    assert lock_1.is_locked
+
+    # release lock 1
+    await lock_1.release()
+    assert not lock_1.is_locked
+    assert not lock_2.is_locked
+    assert not lock_3.is_locked
+    assert not lock_4.is_locked
+    assert not lock_5.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.parametrize("thread_local", [True, False])
+@pytest.mark.asyncio
+async def test_non_executor(lock_type: type[BaseAsyncFileLock], thread_local: bool, tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path), thread_local=thread_local, run_in_executor=False)
+    async with lock as locked:
+        assert lock.is_locked
+        assert lock is locked
+    assert not lock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_coroutine_function(tmp_path: Path) -> None:
+    acquired = released = False
+
+    class AioFileLock(BaseAsyncFileLock):
+        async def _acquire(self) -> None:  # type: ignore[override]
+            nonlocal acquired
+            acquired = True
+            self._context.lock_file_fd = 1
+        
+        async def _release(self) -> None:  # type: ignore[override]
+            nonlocal released
+            released = True
+            self._context.lock_file_fd = None
+    
+    lock = AioFileLock(str(tmp_path / "a"))
+    await lock.acquire()
+    assert acquired and not released
+    await lock.release()
+    assert acquired and released

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -5,13 +5,13 @@ from pathlib import Path, PurePath
 
 import pytest
 
-from filelock import BaseAsyncFileLock, AsyncFileLock, AsyncSoftFileLock, Timeout
+from filelock import AsyncFileLock, AsyncSoftFileLock, BaseAsyncFileLock, Timeout
 
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.parametrize("path_type", [str, PurePath, Path])
 @pytest.mark.parametrize("filename", ["a", "new/b", "new2/new3/c"])
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_simple(
     lock_type: type[BaseAsyncFileLock],
     path_type: type[str | Path],
@@ -43,7 +43,7 @@ async def test_simple(
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.parametrize("path_type", [str, PurePath, Path])
 @pytest.mark.parametrize("filename", ["a", "new/b", "new2/new3/c"])
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_acquire(
     lock_type: type[BaseAsyncFileLock],
     path_type: type[str | Path],
@@ -73,7 +73,7 @@ async def test_acquire(
 
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
     # raises Timeout error when the lock cannot be acquired
     lock_path = tmp_path / "a"
@@ -147,7 +147,7 @@ async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) 
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.parametrize("thread_local", [True, False])
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_non_executor(lock_type: type[BaseAsyncFileLock], thread_local: bool, tmp_path: Path) -> None:
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path), thread_local=thread_local, run_in_executor=False)
@@ -157,7 +157,7 @@ async def test_non_executor(lock_type: type[BaseAsyncFileLock], thread_local: bo
     assert not lock.is_locked
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_coroutine_function(tmp_path: Path) -> None:
     acquired = released = False
 
@@ -166,14 +166,16 @@ async def test_coroutine_function(tmp_path: Path) -> None:
             nonlocal acquired
             acquired = True
             self._context.lock_file_fd = 1
-        
+
         async def _release(self) -> None:  # type: ignore[override]
             nonlocal released
             released = True
             self._context.lock_file_fd = None
-    
+
     lock = AioFileLock(str(tmp_path / "a"))
     await lock.acquire()
-    assert acquired and not released
+    assert acquired
+    assert not released
     await lock.release()
-    assert acquired and released
+    assert acquired
+    assert released


### PR DESCRIPTION
Add asyncio support for `filelock`
-------------

Usage:

```py
import asyncio
from filelock import AsyncFileLock

async def main() -> None:
    lock = AsyncFileLock("test.lock")
    async with lock:
        print("Lock acquired")
        await asyncio.sleep(1)

asyncio.run(main())
```

The default asynchronous approach in this implementation is to execute `_acquire` and `_release` in the thread pool.
Please ask if this is how you would like to see it implemented. If you think this is feasible, I will make further modifications and add tests for it.