### PR TITLE
Use a metaclass to implement the singleton pattern

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 import warnings
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import local
 from typing import TYPE_CHECKING, Any
@@ -77,12 +77,8 @@ class ThreadLocalFileContext(FileLockContext, local):
     """A thread local version of the ``FileLockContext`` class."""
 
 
-class BaseFileLock(ABC, contextlib.ContextDecorator):
-    """Abstract base class for a file lock object."""
-
-    _instances: WeakValueDictionary[str, Self]
-
-    def __new__(  # noqa: PLR0913
+class FileLockMeta(ABCMeta):
+    def __call__(
         cls,
         lock_file: str | os.PathLike[str],
         timeout: float = -1,  # noqa: ARG003
@@ -92,18 +88,52 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
         blocking: bool = True,  # noqa: ARG003
         is_singleton: bool = False,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ARG003, ANN401
-    ) -> Self:
-        """Create a new lock object or if specified return the singleton instance for the lock file."""
-        if not is_singleton:
-            return super().__new__(cls)
+    ) -> BaseFileLock:
+        if is_singleton:
+            instance = cls._instances.get(str(lock_file))
+            if instance:
+                params_to_check = {
+                    "thread_local": (thread_local, instance.is_thread_local()),
+                    "timeout": (timeout, instance.timeout),
+                    "mode": (mode, instance.mode),
+                    "blocking": (blocking, instance.blocking),
+                }
 
-        instance = cls._instances.get(str(lock_file))
-        if not instance:
-            self = super().__new__(cls)
-            cls._instances[str(lock_file)] = self
-            return self
+                non_matching_params = {
+                    name: (passed_param, set_param)
+                    for name, (passed_param, set_param) in params_to_check.items()
+                    if passed_param != set_param
+                }
+                if not non_matching_params:
+                    return instance
+
+                # parameters do not match; raise error
+                msg = "Singleton lock instances cannot be initialized with differing arguments"
+                msg += "\nNon-matching arguments: "
+                for param_name, (passed_param, set_param) in non_matching_params.items():
+                    msg += f"\n\t{param_name} (existing lock has {set_param} but {passed_param} was passed)"
+                raise ValueError(msg)
+
+        instance = super().__call__(
+            lock_file=lock_file,
+            timeout=timeout,
+            mode=mode,
+            thread_local=thread_local,
+            blocking=blocking,
+            is_singleton=is_singleton,
+            **kwargs,
+        )
+
+        if is_singleton:
+            cls._instances[str(lock_file)] = instance
 
         return instance  # type: ignore[return-value] # https://github.com/python/mypy/issues/15322
+
+
+class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
+    """Abstract base class for a file lock object."""
+
+    _instances: WeakValueDictionary[str, Self]
 
     def __init_subclass__(cls, **kwargs: dict[str, Any]) -> None:
         """Setup unique state for lock subclasses."""
@@ -136,34 +166,6 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
             to pass the same object around.
 
         """
-        if is_singleton and hasattr(self, "_context"):
-            # test whether other parameters match existing instance.
-            if not self.is_singleton:
-                msg = "__init__ should only be called on initialized object if it is a singleton"
-                raise RuntimeError(msg)
-
-            params_to_check = {
-                "thread_local": (thread_local, self.is_thread_local()),
-                "timeout": (timeout, self.timeout),
-                "mode": (mode, self.mode),
-                "blocking": (blocking, self.blocking),
-            }
-
-            non_matching_params = {
-                name: (passed_param, set_param)
-                for name, (passed_param, set_param) in params_to_check.items()
-                if passed_param != set_param
-            }
-            if not non_matching_params:
-                return  # bypass initialization because object is already initialized
-
-            # parameters do not match; raise error
-            msg = "Singleton lock instances cannot be initialized with differing arguments"
-            msg += "\nNon-matching arguments: "
-            for param_name, (passed_param, set_param) in non_matching_params.items():
-                msg += f"\n\t{param_name} (existing lock has {set_param} but {passed_param} was passed)"
-            raise ValueError(msg)
-
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
 
@@ -175,7 +177,8 @@ class BaseFileLock(ABC, contextlib.ContextDecorator):
             "mode": mode,
             "blocking": blocking,
         }
-        self._context: FileLockContext = (ThreadLocalFileContext if thread_local else FileLockContext)(**kwargs)
+        context_cls = ThreadLocalFileContext if thread_local else FileLockContext
+        self._context: FileLockContext = context_cls(**kwargs)
 
     def is_thread_local(self) -> bool:
         """:return: a flag indicating if this lock is thread local or not"""

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -177,8 +177,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             "mode": mode,
             "blocking": blocking,
         }
-        context_cls = ThreadLocalFileContext if thread_local else FileLockContext
-        self._context: FileLockContext = context_cls(**kwargs)
+        self._context: FileLockContext = (ThreadLocalFileContext if thread_local else FileLockContext)(**kwargs)
 
     def is_thread_local(self) -> bool:
         """:return: a flag indicating if this lock is thread local or not"""

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -78,16 +78,16 @@ class ThreadLocalFileContext(FileLockContext, local):
 
 
 class FileLockMeta(ABCMeta):
-    def __call__(
+    def __call__(  # noqa: PLR0913
         cls,
         lock_file: str | os.PathLike[str],
-        timeout: float = -1,  # noqa: ARG003
-        mode: int = 0o644,  # noqa: ARG003
-        thread_local: bool = True,  # noqa: FBT001, FBT002, ARG003
+        timeout: float = -1,
+        mode: int = 0o644,
+        thread_local: bool = True,  # noqa: FBT001, FBT002
         *,
-        blocking: bool = True,  # noqa: ARG003
+        blocking: bool = True,
         is_singleton: bool = False,
-        **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ARG003, ANN401
+        **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> BaseFileLock:
         if is_singleton:
             instance = cls._instances.get(str(lock_file))

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -9,7 +9,7 @@ import os
 import time
 from dataclasses import dataclass
 from threading import local
-from typing import TYPE_CHECKING, Any, Callable, NoReturn
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, cast
 
 from ._api import BaseFileLock, FileLockContext, FileLockMeta
 from ._error import Timeout
@@ -68,7 +68,7 @@ class AsyncAcquireReturnProxy:
 
 
 class AsyncFileLockMeta(FileLockMeta):
-    def __call__(  # noqa: PLR0913
+    def __call__(  # type: ignore[override] # noqa: PLR0913
         cls,  # noqa: N805
         lock_file: str | os.PathLike[str],
         timeout: float = -1,
@@ -84,7 +84,7 @@ class AsyncFileLockMeta(FileLockMeta):
         if thread_local and run_in_executor:
             msg = "run_in_executor is not supported when thread_local is True"
             raise ValueError(msg)
-        return super().__call__(
+        instance = super().__call__(
             lock_file=lock_file,
             timeout=timeout,
             mode=mode,
@@ -95,6 +95,7 @@ class AsyncFileLockMeta(FileLockMeta):
             run_in_executor=run_in_executor,
             executor=executor,
         )
+        return cast(BaseAsyncFileLock, instance)
 
 
 class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -68,14 +68,14 @@ class AsyncAcquireReturnProxy:
 
 
 class AsyncFileLockMeta(FileLockMeta):
-    def __call__(
-        cls,
+    def __call__(  # noqa: PLR0913
+        cls,  # noqa: N805
         lock_file: str | os.PathLike[str],
-        timeout: float = -1,  # noqa: ARG003
-        mode: int = 0o644,  # noqa: ARG003
-        thread_local: bool = False,  # noqa: FBT001, FBT002, ARG003
+        timeout: float = -1,
+        mode: int = 0o644,
+        thread_local: bool = False,  # noqa: FBT001, FBT002
         *,
-        blocking: bool = True,  # noqa: ARG003
+        blocking: bool = True,
         is_singleton: bool = False,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -81,6 +81,9 @@ class AsyncFileLockMeta(FileLockMeta):
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
     ) -> BaseAsyncFileLock:
+        if thread_local and run_in_executor:
+            msg = "run_in_executor is not supported when thread_local is True"
+            raise ValueError(msg)
         return super().__call__(
             lock_file=lock_file,
             timeout=timeout,
@@ -131,9 +134,6 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         """
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
-        if thread_local and run_in_executor:
-            msg = "run_in_executor is not supported when thread_local is True"
-            raise ValueError(msg)
 
         # Create the context. Note that external code should not work with the context directly and should instead use
         # properties of this class.

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -785,3 +785,20 @@ def test_singleton_instance_tracking_is_unique_per_subclass(lock_type: type[Base
     assert isinstance(Lock1._instances, WeakValueDictionary)  # noqa: SLF001
     assert isinstance(Lock2._instances, WeakValueDictionary)  # noqa: SLF001
     assert Lock1._instances is not Lock2._instances  # noqa: SLF001
+
+
+def test_singleton_locks_when_inheriting_init_is_called_once(tmp_path: Path) -> None:
+
+    init_calls = 0
+
+    class MyFileLock(FileLock):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            nonlocal init_calls
+            init_calls += 1
+
+    lock_path = tmp_path / "a"
+    MyFileLock(str(lock_path), is_singleton=True)
+    MyFileLock(str(lock_path), is_singleton=True)
+
+    assert init_calls == 1

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -800,7 +800,5 @@ def test_singleton_locks_when_inheriting_init_is_called_once(tmp_path: Path) -> 
     lock1 = MyFileLock(str(lock_path), is_singleton=True)
     lock2 = MyFileLock(str(lock_path), is_singleton=True)
 
+    assert lock1 is lock2
     assert init_calls == 1
-
-    del lock1
-    del lock2

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -788,11 +788,10 @@ def test_singleton_instance_tracking_is_unique_per_subclass(lock_type: type[Base
 
 
 def test_singleton_locks_when_inheriting_init_is_called_once(tmp_path: Path) -> None:
-
     init_calls = 0
 
     class MyFileLock(FileLock):
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
             super().__init__(*args, **kwargs)
             nonlocal init_calls
             init_calls += 1

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -798,7 +798,10 @@ def test_singleton_locks_when_inheriting_init_is_called_once(tmp_path: Path) -> 
             init_calls += 1
 
     lock_path = tmp_path / "a"
-    MyFileLock(str(lock_path), is_singleton=True)
-    MyFileLock(str(lock_path), is_singleton=True)
+    lock1 = MyFileLock(str(lock_path), is_singleton=True)
+    lock2 = MyFileLock(str(lock_path), is_singleton=True)
 
     assert init_calls == 1
+
+    del lock1
+    del lock2


### PR DESCRIPTION
## Reason

More correct implementation of the `singleton` pattern.

There is a problem with the current implementation: class's `__init__` to be called again whenever `lock_class(is_singleton=True)` is called, which is at least not obvious (also, it'll lead to the re-initializing instance's internal objects, e.g.: [virtualenv/util/lock.py](https://github.com/pypa/virtualenv/blob/429d6a2319c1bf917452ca418bf041fe0daa130d/src/virtualenv/util/lock.py#L16))

## What was done in this PR

- added classes `FileLockMeta`/`AsyncFileLockMeta` used as metaclasses for `BaseFileLock`/`BaseAsyncFileLock`
- added a test that checks that in the case of a singleton, the `__init__` method is called only once

### Related PRs

- tox-dev/filelock#338
- tox-dev/filelock#334