### PR TITLE
Fix `TypeError: _CountedFileLock.__init__() got an unexpected keyword argument 'timeout'`

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -116,7 +116,7 @@ class FileLockMeta(ABCMeta):
                 raise ValueError(msg)
 
         # Workaround to make `__init__`'s params optional in subclasses
-        # E.g. virtualenv changes the `__init__` signature of the `BaseFileLock` class
+        # E.g. virtualenv changes the signature of the `__init__` method in the `BaseFileLock` class descendant
         # (https://github.com/tox-dev/filelock/pull/340)
 
         all_params = {
@@ -131,6 +131,8 @@ class FileLockMeta(ABCMeta):
 
         present_params = set(inspect.signature(cls.__init__).parameters)
         init_params = {key: value for key, value in all_params.items() if key in present_params}
+        # The `lock_file` parameter is required
+        init_params["lock_file"] = lock_file
 
         instance = super().__call__(**init_params)
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -129,7 +129,7 @@ class FileLockMeta(ABCMeta):
             **kwargs,
         }
 
-        present_params = set(inspect.signature(cls.__init__).parameters)
+        present_params = set(inspect.signature(cls.__init__).parameters)  # type: ignore[misc]
         init_params = {key: value for key, value in all_params.items() if key in present_params}
         # The `lock_file` parameter is required
         init_params["lock_file"] = lock_file

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from virtualenv import cli_run
+from virtualenv import cli_run  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from pathlib import Path


### PR DESCRIPTION
## Reason

Fixed an issue with the `BaseFileLock` subclass when the `__init__` method signature changes

### Issues

- tox-dev/filelock/issues/343

### Related PRs

- tox-dev/filelock#344
- tox-dev/filelock#340