### PR TITLE
Pass `file_lock` as positional argument

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -120,7 +120,6 @@ class FileLockMeta(ABCMeta):
         # (https://github.com/tox-dev/filelock/pull/340)
 
         all_params = {
-            "lock_file": lock_file,
             "timeout": timeout,
             "mode": mode,
             "thread_local": thread_local,
@@ -129,12 +128,10 @@ class FileLockMeta(ABCMeta):
             **kwargs,
         }
 
-        present_params = set(inspect.signature(cls.__init__).parameters)  # type: ignore[misc]
+        present_params = inspect.signature(cls.__init__).parameters  # type: ignore[misc]
         init_params = {key: value for key, value in all_params.items() if key in present_params}
-        # The `lock_file` parameter is required
-        init_params["lock_file"] = lock_file
 
-        instance = super().__call__(**init_params)
+        instance = super().__call__(lock_file, **init_params)
 
         if is_singleton:
             cls._instances[str(lock_file)] = instance  # type: ignore[attr-defined]

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -802,3 +802,13 @@ def test_singleton_locks_when_inheriting_init_is_called_once(tmp_path: Path) -> 
 
     assert lock1 is lock2
     assert init_calls == 1
+
+
+def test_file_lock_positional_argument(tmp_path: Path) -> None:
+    class FilePathLock(FileLock):
+        def __init__(self, file_path: str) -> None:
+            super().__init__(file_path + ".lock")
+
+    lock_path = tmp_path / "a"
+    lock = FilePathLock(str(lock_path))
+    assert lock.lock_file == str(lock_path) + ".lock"


### PR DESCRIPTION
## Reason

Make it possible to pass `file_lock` under a different name in the signature of the `__init__` method of descendant classes

fixes [tox-dev/filelock/issues/346](https://github.com/tox-dev/filelock/issues/346)

### Related PRs

- tox-dev/filelock#345
