### PR TITLE
Add logging for OSError exceptions

### DIFF
--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from contextlib import suppress
@@ -9,6 +10,8 @@ from typing import cast
 
 from ._api import BaseFileLock
 from ._util import ensure_directory_exists
+
+_LOGGER = logging.getLogger("filelock")
 
 #: a flag to indicate if the fcntl API is available
 has_fcntl = False
@@ -45,6 +48,7 @@ else:  # pragma: win32 no cover
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except OSError as exception:
+                _LOGGER.debug("Failed to acquire lock: %s", exception)
                 os.close(fd)
                 if exception.errno == ENOSYS:  # NotImplemented error
                     msg = "FileSystem does not appear to support flock; use SoftFileLock instead"

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -49,9 +49,7 @@ if sys.platform == "win32":  # pragma: win32 cover
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
             os.close(fd)
 
-            with suppress(
-                OSError
-            ):  # Probably another instance of the application hat acquired the file lock.
+            with suppress(OSError):  # Probably another instance of the application hat acquired the file lock.
                 Path(self.lock_file).unlink()
 
 else:  # pragma: win32 no cover


### PR DESCRIPTION
Hey, I had some issues with a library using filelock. My process was stucking all the time, it took me some time and printing messages in filelock to figure out that the issue was related to my mounted NFS storage. I think it would be helpful to have a log when `fcntl.flock` fails, so the user know where the issue is coming from. 

I added the two logging messages for Windows and Unix.
