### PR TITLE
Test Python 3.13

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -46,6 +47,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
+          allow-prereleases: true
       - name: Pick environment to run
         run: |
           import os; import platform; import sys; from pathlib import Path

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ requires =
     tox>=4.2
 env_list =
     fix
+    py313
     py312
     py311
     py310


### PR DESCRIPTION
The Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc1 **will work** with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).

I added the 3.13 classifier but pyproject-fmt removed it :) Do you want to wait until 3.13.0 final to add the classifier, or is now good?