### PR TITLE
Read/Write File Lock

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,3 +4,7 @@ API
 .. automodule:: filelock
     :members:
     :show-inheritance:
+
+.. automodule:: filelock.read_write
+    :members:
+    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ autosectionlabel_prefix_document = True
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpicky = True
-nitpick_ignore = [("py_class", "filelock.asyncio.AsyncReleasable"), ("py_class", "filelock._api.Releasable")]
+nitpick_ignore = [("py:class", "filelock.asyncio.AsyncReleasable"), ("py:class", "filelock._api.Releasable")]
 extlinks = {
     "issue": ("https://github.com/tox-dev/py-filelock/issues/%s", "issue #%s"),
     "pr": ("https://github.com/tox-dev/py-filelock/issues/%s", "PR #%s"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ autosectionlabel_prefix_document = True
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpicky = True
-nitpick_ignore = [("py:class", "filelock.asyncio.AsyncReleasable"), ("py:class", "filelock._api.Releasable")]
+nitpick_ignore = []
 extlinks = {
     "issue": ("https://github.com/tox-dev/py-filelock/issues/%s", "issue #%s"),
     "pr": ("https://github.com/tox-dev/py-filelock/issues/%s", "PR #%s"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ autosectionlabel_prefix_document = True
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpicky = True
-nitpick_ignore = []
+nitpick_ignore = [("py_class", "filelock.asyncio.AsyncReleasable"), ("py_class", "filelock._api.Releasable")]
 extlinks = {
     "issue": ("https://github.com/tox-dev/py-filelock/issues/%s", "issue #%s"),
     "pr": ("https://github.com/tox-dev/py-filelock/issues/%s", "PR #%s"),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -191,8 +191,19 @@ cases.
 Asyncio support
 ---------------
 
-This library currently does not support asyncio. We'd recommend adding an asyncio variant though if someone can make a
-pull request for it, `see here <https://github.com/tox-dev/py-filelock/issues/99>`_.
+This library supports asyncio. See :class:`AsyncFileLock <filelock.AsyncFileLock>`.
+
+Read/write FileLock
+-------------------
+
+An implementation of a read/write FileLock is also available: and :class:`ReadWriteFileLockWrapper <filelock.read_write.ReadWriteFileLockWrapper>` and
+:class:`AsyncReadWriteFileLockWrapper <filelock.read_write.AsyncReadWriteFileLockWrapper>`.
+
+Multiple readers can hold the lock at the same time, but a writer is guaranteed to hold the lock exclusively across both readers and writers.
+
+The lock is writer-preferring on a best effort basis (there are no guarantees).
+
+Currently, this FileLock type is implemented only for Unix.
 
 FileLocks and threads
 ---------------------

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -12,14 +12,14 @@ import sys
 import warnings
 from typing import TYPE_CHECKING
 
-from ._api import AcquireReturnProxy, BaseFileLock, Releasable
+from ._api import AcquireReturnProxy, BaseFileLock, LockProtocol
 from ._error import Timeout
 from ._soft import SoftFileLock
 from ._unix import UnixFileLock, has_fcntl
 from ._windows import WindowsFileLock
 from .asyncio import (
     AsyncAcquireReturnProxy,
-    AsyncReleasable,
+    AsyncLockProtocol,
     AsyncSoftFileLock,
     AsyncUnixFileLock,
     AsyncWindowsFileLock,
@@ -57,14 +57,14 @@ __all__ = [
     "AcquireReturnProxy",
     "AsyncAcquireReturnProxy",
     "AsyncFileLock",
-    "AsyncReleasable",
+    "AsyncLockProtocol",
     "AsyncSoftFileLock",
     "AsyncUnixFileLock",
     "AsyncWindowsFileLock",
     "BaseAsyncFileLock",
     "BaseFileLock",
     "FileLock",
-    "Releasable",
+    "LockProtocol",
     "SoftFileLock",
     "Timeout",
     "UnixFileLock",

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -12,13 +12,14 @@ import sys
 import warnings
 from typing import TYPE_CHECKING
 
-from ._api import AcquireReturnProxy, BaseFileLock
+from ._api import AcquireReturnProxy, BaseFileLock, Releasable
 from ._error import Timeout
 from ._soft import SoftFileLock
 from ._unix import UnixFileLock, has_fcntl
 from ._windows import WindowsFileLock
 from .asyncio import (
     AsyncAcquireReturnProxy,
+    AsyncReleasable,
     AsyncSoftFileLock,
     AsyncUnixFileLock,
     AsyncWindowsFileLock,
@@ -56,12 +57,14 @@ __all__ = [
     "AcquireReturnProxy",
     "AsyncAcquireReturnProxy",
     "AsyncFileLock",
+    "AsyncReleasable",
     "AsyncSoftFileLock",
     "AsyncUnixFileLock",
     "AsyncWindowsFileLock",
     "BaseAsyncFileLock",
     "BaseFileLock",
     "FileLock",
+    "Releasable",
     "SoftFileLock",
     "Timeout",
     "UnixFileLock",

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -6,10 +6,10 @@ import logging
 import os
 import time
 import warnings
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import local
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 from weakref import WeakValueDictionary
 
 from ._error import Timeout
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger("filelock")
 
 
-class Releasable(ABC):
-    """Interface for objects implementing ```release``` method."""
+class Releasable(Protocol):
+    """Protocol for objects implementing ```release``` method."""
 
     @abstractmethod
     def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
@@ -147,7 +147,7 @@ class FileLockMeta(ABCMeta):
         return cast(BaseFileLock, instance)
 
 
-class BaseFileLock(contextlib.ContextDecorator, Releasable, metaclass=FileLockMeta):
+class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     """Abstract base class for a file lock object."""
 
     _instances: WeakValueDictionary[str, BaseFileLock]

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger("filelock")
 
+DEFAULT_POLL_INTERVAL = 0.05
+
 
 class LockProtocol(Protocol):
     """Protocol for objects implementing ```acquire``` and ```release``` methods."""
@@ -34,7 +36,7 @@ class LockProtocol(Protocol):
     def acquire(
         self,
         timeout: float | None = None,
-        poll_interval: float = 0.05,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
         *,
         poll_intervall: float | None = None,
         blocking: bool | None = None,
@@ -289,7 +291,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     def acquire(
         self,
         timeout: float | None = None,
-        poll_interval: float = 0.05,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
         *,
         poll_intervall: float | None = None,
         blocking: bool | None = None,

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -27,8 +27,18 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger("filelock")
 
 
-class Releasable(Protocol):
-    """Protocol for objects implementing ```release``` method."""
+class LockProtocol(Protocol):
+    """Protocol for objects implementing ```acquire``` and ```release``` methods."""
+
+    @abstractmethod
+    def acquire(
+        self,
+        timeout: float | None = None,
+        poll_interval: float = 0.05,
+        *,
+        poll_intervall: float | None = None,
+        blocking: bool | None = None,
+    ) -> AcquireReturnProxy: ...
 
     @abstractmethod
     def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
@@ -41,10 +51,10 @@ class Releasable(Protocol):
 class AcquireReturnProxy:
     """A context-aware object that will release the lock file when exiting."""
 
-    def __init__(self, lock: Releasable) -> None:
+    def __init__(self, lock: LockProtocol) -> None:
         self.lock = lock
 
-    def __enter__(self) -> Releasable:
+    def __enter__(self) -> LockProtocol:
         return self.lock
 
     def __exit__(

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -30,7 +30,7 @@ DEFAULT_POLL_INTERVAL = 0.05
 
 
 class LockProtocol(Protocol):
-    """Protocol for objects implementing ```acquire``` and ```release``` methods."""
+    """Protocol for objects implementing ``acquire`` and ``release`` methods."""
 
     @abstractmethod
     def acquire(

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -25,7 +25,7 @@ if sys.platform == "win32":  # pragma: win32 cover
 
     class NonExclusiveUnixFileLock(UnixFileLock):
         """Uses the :func:`fcntl.flock` to non-exclusively lock the lock file on unix systems."""
-        ...
+
 
 else:  # pragma: win32 no cover
     try:
@@ -37,6 +37,7 @@ else:  # pragma: win32 no cover
 
     class UnixFileLock(BaseFileLock):
         """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
+
         _fcntl_mode: int = fcntl.LOCK_EX
 
         def _acquire(self) -> None:
@@ -68,11 +69,12 @@ else:  # pragma: win32 no cover
 
     class NonExclusiveUnixFileLock(UnixFileLock):
         """Uses the :func:`fcntl.flock` to non-exclusively lock the lock file on unix systems."""
+
         _fcntl_mode = fcntl.LOCK_SH
 
 
 __all__ = [
-    "UnixFileLock",
     "NonExclusiveUnixFileLock",
+    "UnixFileLock",
     "has_fcntl",
 ]

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -33,7 +33,7 @@ _LOGGER = logging.getLogger("filelock")
 
 
 class AsyncLockProtocol(Protocol):
-    """Protocol for async objects implementing ```acquire``` and ```release``` methods."""
+    """Protocol for async objects implementing ``acquire`` and ``release`` methods."""
 
     @abstractmethod
     async def acquire(

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from threading import local
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, Protocol, cast
 
-from ._api import BaseFileLock, FileLockContext, FileLockMeta
+from ._api import DEFAULT_POLL_INTERVAL, BaseFileLock, FileLockContext, FileLockMeta
 from ._error import Timeout
 from ._soft import SoftFileLock
 from ._unix import NonExclusiveUnixFileLock, UnixFileLock
@@ -39,7 +39,7 @@ class AsyncLockProtocol(Protocol):
     async def acquire(
         self,
         timeout: float | None = None,
-        poll_interval: float = 0.05,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
         *,
         blocking: bool | None = None,
     ) -> AsyncAcquireReturnProxy: ...
@@ -198,7 +198,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     async def acquire(  # type: ignore[override]
         self,
         timeout: float | None = None,
-        poll_interval: float = 0.05,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
         *,
         blocking: bool | None = None,
     ) -> AsyncAcquireReturnProxy:

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -7,10 +7,10 @@ import contextlib
 import logging
 import os
 import time
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from dataclasses import dataclass
 from threading import local
-from typing import TYPE_CHECKING, Any, Callable, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, Protocol, cast
 
 from ._api import BaseFileLock, FileLockContext, FileLockMeta
 from ._error import Timeout
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger("filelock")
 
 
-class AsyncReleasable(ABC):
+class AsyncReleasable(Protocol):
     """Interface for async objects implementing ```release``` method."""
 
     @abstractmethod
@@ -107,7 +107,7 @@ class AsyncFileLockMeta(FileLockMeta):
         return cast(BaseAsyncFileLock, instance)
 
 
-class BaseAsyncFileLock(BaseFileLock, AsyncReleasable, metaclass=AsyncFileLockMeta):
+class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     """Base class for asynchronous file locks."""
 
     def __init__(  # noqa: PLR0913
@@ -330,19 +330,19 @@ class BaseAsyncFileLock(BaseFileLock, AsyncReleasable, metaclass=AsyncFileLockMe
                 loop.create_task(self.release(force=True))
 
 
-class AsyncSoftFileLock(SoftFileLock, BaseAsyncFileLock):  # type: ignore[misc]
+class AsyncSoftFileLock(SoftFileLock, BaseAsyncFileLock):
     """Simply watches the existence of the lock file."""
 
 
-class AsyncUnixFileLock(UnixFileLock, BaseAsyncFileLock):  # type: ignore[misc]
+class AsyncUnixFileLock(UnixFileLock, BaseAsyncFileLock):
     """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
 
 
-class AsyncNonExclusiveUnixFileLock(NonExclusiveUnixFileLock, BaseAsyncFileLock):  # type: ignore[misc]
+class AsyncNonExclusiveUnixFileLock(NonExclusiveUnixFileLock, BaseAsyncFileLock):
     """Uses the :func:`fcntl.flock` to non-exclusively lock the lock file on unix systems."""
 
 
-class AsyncWindowsFileLock(WindowsFileLock, BaseAsyncFileLock):  # type: ignore[misc]
+class AsyncWindowsFileLock(WindowsFileLock, BaseAsyncFileLock):
     """Uses the :func:`msvcrt.locking` to hard lock the lock file on windows systems."""
 
 

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, NoReturn, cast
 from ._api import BaseFileLock, FileLockContext, FileLockMeta
 from ._error import Timeout
 from ._soft import SoftFileLock
-from ._unix import UnixFileLock
+from ._unix import NonExclusiveUnixFileLock, UnixFileLock
 from ._windows import WindowsFileLock
 
 if TYPE_CHECKING:
@@ -329,12 +329,17 @@ class AsyncUnixFileLock(UnixFileLock, BaseAsyncFileLock):
     """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
 
 
+class AsyncNonExclusiveUnixFileLock(NonExclusiveUnixFileLock, BaseAsyncFileLock):
+    """Uses the :func:`fcntl.flock` to non-exclusively lock the lock file on unix systems."""
+
+
 class AsyncWindowsFileLock(WindowsFileLock, BaseAsyncFileLock):
     """Uses the :func:`msvcrt.locking` to hard lock the lock file on windows systems."""
 
 
 __all__ = [
     "AsyncAcquireReturnProxy",
+    "AsyncNonExclusiveUnixFileLock",
     "AsyncSoftFileLock",
     "AsyncUnixFileLock",
     "AsyncWindowsFileLock",

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING
 
 from filelock._unix import NonExclusiveUnixFileLock, UnixFileLock, has_fcntl
 
-from ._api import BaseReadWriteFileLock, _DisabledReadWriteFileLock
+from ._api import BaseReadWriteFileLock, ReadWriteMode, _DisabledReadWriteFileLock
+from ._wrapper import BaseReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
 
 if TYPE_CHECKING:
     from filelock._api import BaseFileLock
@@ -19,11 +20,18 @@ if has_fcntl:
         _read_write_file_lock_cls = UnixReadWriteFileLock
 
     ReadWriteFileLock = UnixReadWriteFileLock
+    ReadWriteFileLockWrapper = UnixReadWriteFileLockWrapper
+    has_read_write_file_lock = True
 else:
     ReadWriteFileLock = _DisabledReadWriteFileLock
+    ReadWriteFileLockWrapper = _DisabledReadWriteFileLockWrapper
+    has_read_write_file_lock = True
 
 
 __all__ = [
     "BaseReadWriteFileLock",
+    "ReadWriteFileLockWrapper",
     "ReadWriteFileLock",
+    "ReadWriteMode",
+    "has_read_write_file_lock",
 ]

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -1,10 +1,4 @@
-"""
-Read/write file lock.
-
-.. autodata:: filelock.__version__
-   :no-value:
-
-"""
+"""Read/write file lock."""
 
 from __future__ import annotations
 

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from filelock._unix import NonExclusiveUnixFileLock, UnixFileLock, has_fcntl
 
 from ._api import BaseReadWriteFileLock, _DisabledReadWriteFileLock
-from ._wrapper import BaseReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
 
 if TYPE_CHECKING:
     from filelock._api import BaseFileLock
@@ -20,15 +19,11 @@ if has_fcntl:
         _read_write_file_lock_cls = UnixReadWriteFileLock
 
     ReadWriteFileLock = UnixReadWriteFileLock
-    ReadWriteFileLockWrapper = UnixReadWriteFileLockWrapper
 else:
     ReadWriteFileLock = _DisabledReadWriteFileLock
-    ReadWriteFileLockWrapper = _DisabledReadWriteFileLockWrapper
 
 
 __all__ = [
     "BaseReadWriteFileLock",
-    "BaseReadWriteFileLockWrapper",
     "ReadWriteFileLock",
-    "ReadWriteFileLockWrapper",
 ]

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -22,6 +22,9 @@ from filelock.read_write.asyncio import (
 if TYPE_CHECKING:
     from filelock._api import BaseFileLock
 
+ReadWriteFileLock: type[BaseReadWriteFileLock]
+ReadWriteFileLockWrapper: type[BaseReadWriteFileLockWrapper]
+
 if has_fcntl:
 
     class UnixReadWriteFileLock(BaseReadWriteFileLock):

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -1,0 +1,26 @@
+from .._unix import has_fcntl, NonExclusiveUnixFileLock, UnixFileLock
+from ._api import BaseReadWriteFileLock, _DisabledReadWriteFileLock
+from ._wrapper import BaseReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
+
+
+if has_fcntl:
+    class UnixReadWriteFileLock(BaseReadWriteFileLock):
+        _shared_file_lock_cls: Type[BaseFileLock] = NonExclusiveUnixFileLock
+        _exclusive_file_lock_cls: Type[BaseFileLock] = UnixFileLock
+
+    class UnixReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
+        _read_write_file_lock_cls = UnixReadWriteFileLock
+
+    ReadWriteFileLock = UnixReadWriteFileLock
+    ReadWriteFileLockWrapper = UnixReadWriteFileLockWrapper
+else:
+    ReadWriteFileLock = _DisabledReadWriteFileLock
+    ReadWriteFileLockWrapper = _DisabledReadWriteFileLockWrapper
+
+
+__all__ = [
+    "BaseReadWriteFileLock",
+    "BaseReadWriteFileLockWrapper",
+    "ReadWriteFileLock",
+    "ReadWriteFileLockWrapper",
+]

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -22,30 +22,25 @@ if TYPE_CHECKING:
 ReadWriteFileLock: type[BaseReadWriteFileLock]
 ReadWriteFileLockWrapper: type[BaseReadWriteFileLockWrapper]
 
-if has_fcntl:
 
-    class UnixReadWriteFileLock(BaseReadWriteFileLock):
-        """Unix implementation of a read/write FileLock."""
+class UnixReadWriteFileLock(BaseReadWriteFileLock):
+    """Unix implementation of a read/write FileLock."""
 
-        _shared_file_lock_cls: type[BaseFileLock] = NonExclusiveUnixFileLock
-        _exclusive_file_lock_cls: type[BaseFileLock] = UnixFileLock
+    _shared_file_lock_cls: type[BaseFileLock] = NonExclusiveUnixFileLock
+    _exclusive_file_lock_cls: type[BaseFileLock] = UnixFileLock
 
-    class UnixReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
-        """Wrapper for a Unix implementation of a read/write FileLock."""
 
-        _read_write_file_lock_cls = UnixReadWriteFileLock
+class UnixReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
+    """Wrapper for a Unix implementation of a read/write FileLock."""
 
+    _read_write_file_lock_cls = UnixReadWriteFileLock
+
+
+if has_fcntl:  # pragma: win32 no cover
     ReadWriteFileLock = UnixReadWriteFileLock
     ReadWriteFileLockWrapper = UnixReadWriteFileLockWrapper
     has_read_write_file_lock = True
-else:
-
-    class UnixReadWriteFileLock(BaseReadWriteFileLock):
-        """Unix implementation of a read/write FileLock."""
-
-    class UnixReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
-        """Wrapper for a Unix implementation of a read/write FileLock."""
-
+else:  # pragma: win32 cover
     ReadWriteFileLock = _DisabledReadWriteFileLock
     ReadWriteFileLockWrapper = _DisabledReadWriteFileLockWrapper
     has_read_write_file_lock = False

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -1,3 +1,11 @@
+"""
+Read/write file lock.
+
+.. autodata:: filelock.__version__
+   :no-value:
+
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -17,6 +17,9 @@ from filelock.read_write.asyncio import (
     AsyncReadWriteFileLock,
     AsyncReadWriteFileLockWrapper,
     BaseAsyncReadWriteFileLock,
+    BaseAsyncReadWriteFileLockWrapper,
+    UnixAsyncReadWriteFileLock,
+    UnixAsyncReadWriteFileLockWrapper,
 )
 
 if TYPE_CHECKING:
@@ -28,16 +31,27 @@ ReadWriteFileLockWrapper: type[BaseReadWriteFileLockWrapper]
 if has_fcntl:
 
     class UnixReadWriteFileLock(BaseReadWriteFileLock):
+        """Unix implementation of a read/write FileLock."""
+
         _shared_file_lock_cls: type[BaseFileLock] = NonExclusiveUnixFileLock
         _exclusive_file_lock_cls: type[BaseFileLock] = UnixFileLock
 
     class UnixReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
+        """Wrapper for a Unix implementation of a read/write FileLock."""
+
         _read_write_file_lock_cls = UnixReadWriteFileLock
 
     ReadWriteFileLock = UnixReadWriteFileLock
     ReadWriteFileLockWrapper = UnixReadWriteFileLockWrapper
     has_read_write_file_lock = True
 else:
+
+    class UnixReadWriteFileLock(BaseReadWriteFileLock):
+        """Unix implementation of a read/write FileLock."""
+
+    class UnixReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
+        """Wrapper for a Unix implementation of a read/write FileLock."""
+
     ReadWriteFileLock = _DisabledReadWriteFileLock
     ReadWriteFileLockWrapper = _DisabledReadWriteFileLockWrapper
     has_read_write_file_lock = False
@@ -47,9 +61,15 @@ __all__ = [
     "AsyncReadWriteFileLock",
     "AsyncReadWriteFileLockWrapper",
     "BaseAsyncReadWriteFileLock",
+    "BaseAsyncReadWriteFileLockWrapper",
     "BaseReadWriteFileLock",
+    "BaseReadWriteFileLockWrapper",
     "ReadWriteFileLock",
     "ReadWriteFileLockWrapper",
     "ReadWriteMode",
+    "UnixAsyncReadWriteFileLock",
+    "UnixAsyncReadWriteFileLockWrapper",
+    "UnixReadWriteFileLock",
+    "UnixReadWriteFileLockWrapper",
     "has_read_write_file_lock",
 ]

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import Type
+
 from filelock._unix import NonExclusiveUnixFileLock, UnixFileLock, has_fcntl
 
+from .._api import BaseFileLock
 from ._api import BaseReadWriteFileLock, _DisabledReadWriteFileLock
 from ._wrapper import BaseReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
 

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -30,8 +30,8 @@ else:
 
 __all__ = [
     "BaseReadWriteFileLock",
-    "ReadWriteFileLockWrapper",
     "ReadWriteFileLock",
+    "ReadWriteFileLockWrapper",
     "ReadWriteMode",
     "has_read_write_file_lock",
 ]

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from filelock._unix import NonExclusiveUnixFileLock, UnixFileLock, has_fcntl
-
-from ._api import BaseReadWriteFileLock, ReadWriteMode, _DisabledReadWriteFileLock
-from ._wrapper import BaseReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
+from filelock.read_write._api import BaseReadWriteFileLock, ReadWriteMode, _DisabledReadWriteFileLock
+from filelock.read_write._wrapper import BaseReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
+from filelock.read_write.asyncio import (
+    AsyncReadWriteFileLock,
+    AsyncReadWriteFileLockWrapper,
+    BaseAsyncReadWriteFileLock,
+)
 
 if TYPE_CHECKING:
     from filelock._api import BaseFileLock
@@ -33,10 +37,13 @@ if has_fcntl:
 else:
     ReadWriteFileLock = _DisabledReadWriteFileLock
     ReadWriteFileLockWrapper = _DisabledReadWriteFileLockWrapper
-    has_read_write_file_lock = True
+    has_read_write_file_lock = False
 
 
 __all__ = [
+    "AsyncReadWriteFileLock",
+    "AsyncReadWriteFileLockWrapper",
+    "BaseAsyncReadWriteFileLock",
     "BaseReadWriteFileLock",
     "ReadWriteFileLock",
     "ReadWriteFileLockWrapper",

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
-from typing import Type
+from typing import TYPE_CHECKING
 
 from filelock._unix import NonExclusiveUnixFileLock, UnixFileLock, has_fcntl
 
-from .._api import BaseFileLock
 from ._api import BaseReadWriteFileLock, _DisabledReadWriteFileLock
 from ._wrapper import BaseReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
+
+if TYPE_CHECKING:
+    from filelock._api import BaseFileLock
 
 if has_fcntl:
 
     class UnixReadWriteFileLock(BaseReadWriteFileLock):
-        _shared_file_lock_cls: Type[BaseFileLock] = NonExclusiveUnixFileLock
-        _exclusive_file_lock_cls: Type[BaseFileLock] = UnixFileLock
+        _shared_file_lock_cls: type[BaseFileLock] = NonExclusiveUnixFileLock
+        _exclusive_file_lock_cls: type[BaseFileLock] = UnixFileLock
 
     class UnixReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
         _read_write_file_lock_cls = UnixReadWriteFileLock

--- a/src/filelock/read_write/__init__.py
+++ b/src/filelock/read_write/__init__.py
@@ -1,9 +1,12 @@
-from .._unix import has_fcntl, NonExclusiveUnixFileLock, UnixFileLock
+from __future__ import annotations
+
+from filelock._unix import NonExclusiveUnixFileLock, UnixFileLock, has_fcntl
+
 from ._api import BaseReadWriteFileLock, _DisabledReadWriteFileLock
 from ._wrapper import BaseReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
 
-
 if has_fcntl:
+
     class UnixReadWriteFileLock(BaseReadWriteFileLock):
         _shared_file_lock_cls: Type[BaseFileLock] = NonExclusiveUnixFileLock
         _exclusive_file_lock_cls: Type[BaseFileLock] = UnixFileLock

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
+import os
 import contextlib
 from abc import ABC
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import os
-
-    from filelock._api import BaseFileLock
+from .._api import AcquireReturnProxy, BaseFileLock
 
 if TYPE_CHECKING:
     import sys

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import os
 import contextlib
 from abc import ABC
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .._api import AcquireReturnProxy, BaseFileLock
+from filelock._api import AcquireReturnProxy, BaseFileLock
 
 if TYPE_CHECKING:
+    import os
     import sys
     from types import TracebackType
 

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -264,4 +264,5 @@ class _DisabledReadWriteFileLock(BaseReadWriteFileLock):
 
 __all__ = [
     "BaseReadWriteFileLock",
+    "ReadWriteMode",
 ]

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -117,8 +117,6 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, metaclass=ABCMeta):
     def timeout(self) -> float:
         """
         :return: the default timeout value, in seconds
-
-        .. versionadded:: 2.0.0
         """
         return self._inner_lock.timeout
 
@@ -159,10 +157,6 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, metaclass=ABCMeta):
         """
 
         :return: A boolean indicating if the lock file is holding the lock currently.
-
-        .. versionchanged:: 2.0.0
-
-            This was previously a method and is now a property.
         """
         return self._inner_lock.is_locked
 
@@ -203,11 +197,6 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, metaclass=ABCMeta):
                 pass
             finally:
                 lock.release()
-
-        .. versionchanged:: 2.0.0
-
-            This method returns now a *proxy* object instead of *self*,
-            so that it can be used in a with statement without side effects.
 
         """
         with self._outer_lock:

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from filelock._api import AcquireReturnProxy, BaseFileLock
+from filelock._api import AcquireReturnProxy, BaseFileLock, Releasable
 
 if TYPE_CHECKING:
     import os
@@ -25,7 +25,7 @@ class ReadWriteMode(Enum):
     WRITE = "write"
 
 
-class BaseReadWriteFileLock(contextlib.ContextDecorator, ABC):
+class BaseReadWriteFileLock(contextlib.ContextDecorator, Releasable, ABC):
     """Abstract base class for a writer-preferring read/write file lock object."""
 
     _shared_file_lock_cls: type[BaseFileLock]
@@ -258,7 +258,7 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, ABC):
 
 
 class _DisabledReadWriteFileLock(BaseReadWriteFileLock):
-    def __new__(cls) -> None:
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003
         msg = "ReadWriteFileLock is unavailable."
         raise NotImplementedError(msg)
 

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import contextlib
+import time
 from abc import ABC
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
-import time
+
 from filelock._api import AcquireReturnProxy, BaseFileLock
 
 if TYPE_CHECKING:

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from filelock._api import AcquireReturnProxy, BaseFileLock, LockProtocol
+from filelock._api import DEFAULT_POLL_INTERVAL, AcquireReturnProxy, BaseFileLock, LockProtocol
 
 if TYPE_CHECKING:
     import os
@@ -171,7 +171,7 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, LockProtocol, ABC):
     def acquire(
         self,
         timeout: float | None = None,
-        poll_interval: float = 0.05,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
         *,
         poll_intervall: float | None = None,
         blocking: bool | None = None,

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -65,7 +65,7 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, ABC):
         """
         if read_write_mode == ReadWriteMode.READ:
             file_lock_cls = self._shared_file_lock_cls
-        elif read_write_mode == ReadWriteMode.WRITE:
+        else:
             file_lock_cls = self._exclusive_file_lock_cls
 
         if not lock_file_inner:
@@ -203,7 +203,7 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, ABC):
             with self._outer_lock:
                 self._inner_lock.acquire()
             return AcquireReturnProxy(lock=self)
-        if self.read_write_mode == ReadWriteMode.WRITE:
+        else:
             self._outer_lock.acquire()
             with self._inner_lock:
                 # Just acquire.
@@ -221,7 +221,7 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, ABC):
         """
         if self.read_write_mode == ReadWriteMode.READ:
             self._inner_lock.release(force=force)
-        elif self.read_write_mode == ReadWriteMode.WRITE:
+        else:
             self._outer_lock.release(force=force)
 
     def __enter__(self) -> Self:

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -73,16 +73,12 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, ABC):
         if not lock_file_inner:
             if not lock_file:
                 msg = "If lock_file is unspecified, both lock_file_inner and lock_file_outer must be specified."
-                raise ValueError(
-                    msg
-                )
+                raise ValueError(msg)
             lock_file_inner = Path(lock_file).with_suffix(".inner")
         if not lock_file_outer:
             if not lock_file:
                 msg = "If lock_file is unspecified, both lock_file_inner and lock_file_outer must be specified."
-                raise ValueError(
-                    msg
-                )
+                raise ValueError(msg)
             lock_file_outer = Path(lock_file).with_suffix(".outer")
 
         # is_singleton is always disabled, as I don't believe it will work
@@ -209,12 +205,13 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, ABC):
             with self._outer_lock:
                 self._inner_lock.acquire()
             return AcquireReturnProxy(lock=self)
-        elif self.read_write_mode == ReadWriteMode.WRITE:
+        if self.read_write_mode == ReadWriteMode.WRITE:
             self._outer_lock.acquire()
             with self._inner_lock:
                 # Just acquire.
                 pass
             return AcquireReturnProxy(lock=self)
+        return None
 
     def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
         """

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -203,12 +203,11 @@ class BaseReadWriteFileLock(contextlib.ContextDecorator, ABC):
             with self._outer_lock:
                 self._inner_lock.acquire()
             return AcquireReturnProxy(lock=self)
-        else:
-            self._outer_lock.acquire()
-            with self._inner_lock:
-                # Just acquire.
-                pass
-            return AcquireReturnProxy(lock=self)
+        self._outer_lock.acquire()
+        with self._inner_lock:
+            # Just acquire.
+            pass
+        return AcquireReturnProxy(lock=self)
         return None
 
     def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -6,7 +6,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from filelock._api import AcquireReturnProxy
+from .._api import BaseFileLock
 
 if TYPE_CHECKING:
     import os

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -1,0 +1,265 @@
+import contextlib
+import os
+from abc import ABCMeta, abstractmethod
+from typing import Type
+from enum import Enum
+from filelock._api import AcquireReturnProxy
+from pathlib import Path
+
+if TYPE_CHECKING:
+    import sys
+    from types import TracebackType
+
+    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+        from typing import Self
+    else:  # pragma: no cover (<py311)
+        from typing_extensions import Self
+
+
+class ReadWriteMode(Enum):
+    READ = "read"
+    WRITE = "write"
+
+
+class BaseReadWriteFileLock(contextlib.ContextDecorator, metaclass=ABCMeta):
+    """Abstract base class for a writer-preferring read/write file lock object."""
+
+    _shared_file_lock_cls: Type[BaseFileLock]
+    _exclusive_file_lock_cls: Type[BaseFileLock]
+
+    def __init__(  # noqa: PLR0913
+        self,
+        read_write_mode: ReadWriteMode,
+        lock_file: str | os.PathLike[str] | None = None,
+        timeout: float = -1,
+        mode: int = 0o644,
+        thread_local: bool = True,  # noqa: FBT001, FBT002
+        *,
+        blocking: bool = True,
+        lock_file_inner: str | os.PathLike[str] | None = None,
+        lock_file_outer: str | os.PathLike[str] | None = None,
+    ) -> None:
+        """
+        Create a new writer-preferring read/write lock object. Multiple READers can hold the lock
+        at the same time, but a WRITEr is guaranteed to hold the lock exclusively across both
+        readers and writers.
+
+        This object will use two lock files to ensure writers have priority over readers.
+
+        :param read_write_mode: whether this object should be in WRITE mode or READ mode.
+        :param lock_file: path to the file. Note that two files will be created: ``{lock_file}.inner`` and ``{lock_file}.outer``. \
+            If not specified, ``lock_file_inner`` and ``lock_file_outer`` must both be specified.
+        :param timeout: default timeout when acquiring the lock, in seconds. It will be used as fallback value in \
+            the acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it \
+            to a negative value. A timeout of 0 means that there is exactly one attempt to acquire the file lock.
+        :param mode: file permissions for the lockfile
+        :param thread_local: Whether this object's internal context should be thread local or not. If this is set to \
+            ``False`` then the lock will be reentrant across threads.
+        :param blocking: whether the lock should be blocking or not
+        :param lock_file_inner: path to the inner lock file. Can be left unspecified if ``lock_file`` is specified.
+        :param lock_file_outer: path to the outer lock file Can be left unspecified if ``lock_file`` is specified.
+
+        """
+        if read_write_mode == ReadWriteMode.READ:
+          file_lock_cls = self._shared_file_lock_cls
+        elif read_write_mode == ReadWriteMode.WRITE:
+          file_lock_cls = self._exclusive_file_lock_cls
+
+        if not lock_file_inner:
+            if not lock_file:
+                raise ValueError("If lock_file is unspecified, both lock_file_inner and lock_file_outer must be specified.")
+            lock_file_inner = Path(lock_file).with_suffix(".inner") 
+        if not lock_file_outer:
+            if not lock_file:
+                raise ValueError("If lock_file is unspecified, both lock_file_inner and lock_file_outer must be specified.")
+            lock_file_outer = Path(lock_file).with_suffix(".outer") 
+
+        # is_singleton is always disabled, as I don't believe it will work
+        # correctly with this setup.
+        self._inner_lock = file_lock_cls(
+            lock_file_inner,
+            timeout=timeout,
+            mode=mode,
+            thread_local=thread_local,
+            blocking=blocking,
+            is_singleton=False,
+        )
+        self._outer_lock = file_lock_cls(
+            lock_file_outer,
+            timeout=timeout,
+            mode=mode,
+            thread_local=thread_local,
+            blocking=blocking,
+            is_singleton=False,
+        )
+        self.read_write_mode = read_write_mode
+
+    def is_thread_local(self) -> bool:
+        """:return: a flag indicating if this lock is thread local or not"""
+        return self._inner_lock.is_thread_local()
+
+    @property
+    def is_singleton(self) -> bool:
+        """:return: a flag indicating if this lock is singleton or not"""
+        return self._inner_lock.is_singleton
+
+    @property
+    def lock_file_inner(self) -> str:
+        """:return: path to the lock file"""
+        return self._inner_lock.lock_file
+
+    @property
+    def lock_file_outer(self) -> str:
+        """:return: path to the lock file"""
+        return self._outer_lock.lock_file
+
+    @property
+    def timeout(self) -> float:
+        """
+        :return: the default timeout value, in seconds
+
+        .. versionadded:: 2.0.0
+        """
+        return self._inner_lock.timeout
+
+    @timeout.setter
+    def timeout(self, value: float | str) -> None:
+        """
+        Change the default timeout value.
+
+        :param value: the new value, in seconds
+
+        """
+        self._inner_lock.timeout = float(value)
+        self._outer_lock.timeout = float(value)
+
+    @property
+    def blocking(self) -> bool:
+        """:return: whether the locking is blocking or not"""
+        return self._inner_lock.blocking
+
+    @blocking.setter
+    def blocking(self, value: bool) -> None:
+        """
+        Change the default blocking value.
+
+        :param value: the new value as bool
+
+        """
+        self._inner_lock.blocking = value
+        self._outer_lock.blocking = value
+
+    @property
+    def mode(self) -> int:
+        """:return: the file permissions for the lockfile"""
+        return self._inner_lock.mode
+
+    @property
+    def is_locked(self) -> bool:
+        """
+
+        :return: A boolean indicating if the lock file is holding the lock currently.
+
+        .. versionchanged:: 2.0.0
+
+            This was previously a method and is now a property.
+        """
+        return self._inner_lock.is_locked
+
+    @property
+    def lock_counter(self) -> int:
+        """:return: The number of times this lock has been acquired (but not yet released)."""
+        return self._inner_lock.lock_counter + self._inner_lock_shared.lock_counter
+
+    def acquire(
+        self,
+        timeout: float | None = None,
+        poll_interval: float = 0.05,
+        *,
+        poll_intervall: float | None = None,
+        blocking: bool | None = None,
+    ) -> AcquireReturnProxy:
+        """
+        Try to acquire the file lock.
+
+        :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default :attr:`~timeout` is and
+         if ``timeout < 0``, there is no timeout and this method will block until the lock could be acquired
+        :param poll_interval: interval of trying to acquire the lock file
+        :param poll_intervall: deprecated, kept for backwards compatibility, use ``poll_interval`` instead
+        :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on the
+         first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
+        :raises Timeout: if fails to acquire lock within the timeout period
+        :return: a context object that will unlock the file when the context is exited
+
+        .. code-block:: python
+
+            # You can use this method in the context manager (recommended)
+            with lock.acquire():
+                pass
+
+            # Or use an equivalent try-finally construct:
+            lock.acquire()
+            try:
+                pass
+            finally:
+                lock.release()
+
+        .. versionchanged:: 2.0.0
+
+            This method returns now a *proxy* object instead of *self*,
+            so that it can be used in a with statement without side effects.
+
+        """
+        with self._outer_lock:
+          self._inner_lock.acquire()
+        return AcquireReturnProxy(lock=self)
+
+    def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
+        """
+        Releases the file lock. Please note, that the lock is only completely released, if the lock counter is 0.
+        Also note, that the lock file itself is not automatically deleted.
+
+        :param force: If true, the lock counter is ignored and the lock is released in every case/
+
+        """
+        self._inner_lock.release(force=force)
+
+    def __enter__(self) -> Self:
+        """
+        Acquire the lock.
+
+        :return: the lock object
+
+        """
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """
+        Release the lock.
+
+        :param exc_type: the exception type if raised
+        :param exc_value: the exception value if raised
+        :param traceback: the exception traceback if raised
+
+        """
+        self.release()
+
+    def __del__(self) -> None:
+        """Called when the lock object is deleted."""
+        self.release(force=True)
+
+
+class _DisabledReadWriteFileLock(BaseReadWriteFileLock):
+    def __new__(cls):
+        raise NotImplementedError("ReadWriteFileLock is unavailable.")
+
+
+__all__ = [
+    "BaseReadWriteFileLock",
+]

--- a/src/filelock/read_write/_api.py
+++ b/src/filelock/read_write/_api.py
@@ -6,10 +6,10 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .._api import BaseFileLock
-
 if TYPE_CHECKING:
     import os
+
+    from filelock._api import BaseFileLock
 
 if TYPE_CHECKING:
     import sys

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -20,24 +20,24 @@ class BaseReadWriteFileLockWrapper(metaclass=ABCMeta):
 
         See filelock.read_write.ReadWriteFileLock for description of the parameters.
         """
-      self.read_lock = self._read_write_file_lock_cls(
-          lock_file_inner=lock_file_inner,
-          lock_file_outer=lock_file_outer,
-          read_write_mode=ReadWriteMode.READ,
-          timeout=timeout,
-          mode=mode,
-          thread_local=thread_local,
-          blocking=blocking,
-      )
-      self.write_lock = self._read_write_file_lock_cls(
-          lock_file_inner=lock_file_inner,
-          lock_file_outer=lock_file_outer,
-          read_write_mode=ReadWriteMode.WRITE,
-          timeout=timeout,
-          mode=mode,
-          thread_local=thread_local,
-          blocking=blocking,
-      )
+        self.read_lock = self._read_write_file_lock_cls(
+            lock_file_inner=lock_file_inner,
+            lock_file_outer=lock_file_outer,
+            read_write_mode=ReadWriteMode.READ,
+            timeout=timeout,
+            mode=mode,
+            thread_local=thread_local,
+            blocking=blocking,
+        )
+        self.write_lock = self._read_write_file_lock_cls(
+            lock_file_inner=lock_file_inner,
+            lock_file_outer=lock_file_outer,
+            read_write_mode=ReadWriteMode.WRITE,
+            timeout=timeout,
+            mode=mode,
+            thread_local=thread_local,
+            blocking=blocking,
+        )
 
     def __call__(self, read_write_mode: ReadWriteMode):
         """Get read/write lock object with the specified ``read_write_mode``.

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -10,6 +10,12 @@ if TYPE_CHECKING:
 
 
 class BaseReadWriteFileLockWrapper(ABC):
+    """
+    Convenience wrapper for read/write locks.
+
+    Provides `.read()` and `.write()` methods to easily access a read or write lock.
+    """
+
     _read_write_file_lock_cls: type[BaseReadWriteFileLock]
 
     def __init__(  # noqa: PLR0913
@@ -26,7 +32,7 @@ class BaseReadWriteFileLockWrapper(ABC):
         """
         Convenience wrapper for read/write locks.
 
-        See filelock.read_write.ReadWriteFileLock for description of the parameters.
+        See ReadWriteFileLock for description of the parameters.
         """
         self.read_lock = self._read_write_file_lock_cls(
             lock_file=lock_file,

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -50,8 +50,7 @@ class BaseReadWriteFileLockWrapper(ABC):
         """
         if read_write_mode == ReadWriteMode.READ:
             return self.read_lock
-        else:
-            return self.write_lock
+        return self.write_lock
 
     def read(self):
         """

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -17,7 +17,6 @@ class BaseReadWriteFileLockWrapper(ABC):
         lock_file: str | os.PathLike[str] | None = None,
         timeout: float = -1,
         mode: int = 0o644,
-        thread_local: bool = True,  # noqa: FBT001, FBT002
         *,
         blocking: bool = True,
         lock_file_inner: str | os.PathLike[str] | None = None,
@@ -35,7 +34,6 @@ class BaseReadWriteFileLockWrapper(ABC):
             read_write_mode=ReadWriteMode.READ,
             timeout=timeout,
             mode=mode,
-            thread_local=thread_local,
             blocking=blocking,
         )
         self.write_lock = self._read_write_file_lock_cls(
@@ -45,7 +43,6 @@ class BaseReadWriteFileLockWrapper(ABC):
             read_write_mode=ReadWriteMode.WRITE,
             timeout=timeout,
             mode=mode,
-            thread_local=thread_local,
             blocking=blocking,
         )
 

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -94,7 +94,17 @@ class BaseReadWriteFileLockWrapper(ABC):
 
 
 class _DisabledReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
-    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003
+    def __init__(  # noqa: PLR0913
+        self,
+        lock_file: str | os.PathLike[str] | None = None,
+        timeout: float = -1,
+        mode: int = 0o644,
+        thread_local: bool = True,  # noqa: FBT001, FBT002
+        *,
+        blocking: bool = True,
+        lock_file_inner: str | os.PathLike[str] | None = None,
+        lock_file_outer: str | os.PathLike[str] | None = None,
+    ) -> None:
         msg = "ReadWriteFileLock is unavailable."
         raise NotImplementedError(msg)
 

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING
 
-from ._api import ReadWriteMode, BaseReadWriteFileLock
+from ._api import BaseReadWriteFileLock, ReadWriteMode
 
 if TYPE_CHECKING:
     import os

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -78,7 +78,7 @@ class BaseReadWriteFileLockWrapper(ABC):
 
 
 class _DisabledReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
-    def __new__(cls) -> None:
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003
         msg = "ReadWriteFileLock is unavailable."
         raise NotImplementedError(msg)
 

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -1,0 +1,61 @@
+from abc import ABCMeta
+
+
+class BaseReadWriteFileLockWrapper(metaclass=ABCMeta):
+    _read_write_file_lock_cls: Type[BaseReadWriteFileLock]
+
+    def __init__(  # noqa: PLR0913
+        self,
+        lock_file: str | os.PathLike[str] | None = None,
+        timeout: float = -1,
+        mode: int = 0o644,
+        thread_local: bool = True,  # noqa: FBT001, FBT002
+        *,
+        blocking: bool = True,
+        lock_file_inner: str | os.PathLike[str] | None = None,
+        lock_file_outer: str | os.PathLike[str] | None = None,
+    ) -> None:
+        """
+        Convinience wrapper for read/write locks.
+
+        See filelock.read_write.ReadWriteFileLock for description of the parameters.
+        """
+      self.read_lock = self._read_write_file_lock_cls(
+          lock_file_inner=lock_file_inner,
+          lock_file_outer=lock_file_outer,
+          read_write_mode=ReadWriteMode.READ,
+          timeout=timeout,
+          mode=mode,
+          thread_local=thread_local,
+          blocking=blocking,
+      )
+      self.write_lock = self._read_write_file_lock_cls(
+          lock_file_inner=lock_file_inner,
+          lock_file_outer=lock_file_outer,
+          read_write_mode=ReadWriteMode.WRITE,
+          timeout=timeout,
+          mode=mode,
+          thread_local=thread_local,
+          blocking=blocking,
+      )
+    
+    def __call__(self, read_write_mode: ReadWriteMode):
+        """Get read/write lock object with the specified ``read_write_mode``.
+
+        :param read_write_mode: whether this object should be in WRITE mode or READ mode.
+        :return: a lock object in specified ``read_write_mode``.
+        """
+        if read_write_mode == ReadWriteMode.READ:
+            return self.read_lock
+        elif read_write_mode == ReadWriteMode.WRITE:
+            return self.write_lock
+
+
+class _DisabledReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
+    def __new__(cls):
+        raise NotImplementedError("ReadWriteFileLock is unavailable.")
+
+
+__all__ = [
+    "BaseReadWriteFileLockWrapper",
+]

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
-import os
+
 from abc import ABC
-from typing import Type
+from typing import TYPE_CHECKING
 
 from ._api import ReadWriteMode
 
+if TYPE_CHECKING:
+    import os
+
 
 class BaseReadWriteFileLockWrapper(ABC):
-    _read_write_file_lock_cls: Type[BaseReadWriteFileLock]
+    _read_write_file_lock_cls: type[BaseReadWriteFileLock]
 
     def __init__(  # noqa: PLR0913
         self,

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -17,6 +17,7 @@ class BaseReadWriteFileLockWrapper(ABC):
         lock_file: str | os.PathLike[str] | None = None,
         timeout: float = -1,
         mode: int = 0o644,
+        thread_local: bool = True,  # noqa: FBT001, FBT002
         *,
         blocking: bool = True,
         lock_file_inner: str | os.PathLike[str] | None = None,
@@ -34,6 +35,7 @@ class BaseReadWriteFileLockWrapper(ABC):
             read_write_mode=ReadWriteMode.READ,
             timeout=timeout,
             mode=mode,
+            thread_local=thread_local,
             blocking=blocking,
         )
         self.write_lock = self._read_write_file_lock_cls(
@@ -43,6 +45,7 @@ class BaseReadWriteFileLockWrapper(ABC):
             read_write_mode=ReadWriteMode.WRITE,
             timeout=timeout,
             mode=mode,
+            thread_local=thread_local,
             blocking=blocking,
         )
 

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -1,7 +1,9 @@
-from abc import ABCMeta
+from __future__ import annotations
+
+from abc import ABC
 
 
-class BaseReadWriteFileLockWrapper(metaclass=ABCMeta):
+class BaseReadWriteFileLockWrapper(ABC):
     _read_write_file_lock_cls: Type[BaseReadWriteFileLock]
 
     def __init__(  # noqa: PLR0913
@@ -40,20 +42,23 @@ class BaseReadWriteFileLockWrapper(metaclass=ABCMeta):
         )
 
     def __call__(self, read_write_mode: ReadWriteMode):
-        """Get read/write lock object with the specified ``read_write_mode``.
+        """
+        Get read/write lock object with the specified ``read_write_mode``.
 
         :param read_write_mode: whether this object should be in WRITE mode or READ mode.
         :return: a lock object in specified ``read_write_mode``.
         """
         if read_write_mode == ReadWriteMode.READ:
             return self.read_lock
-        elif read_write_mode == ReadWriteMode.WRITE:
+        if read_write_mode == ReadWriteMode.WRITE:
             return self.write_lock
+        return None
 
 
 class _DisabledReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
     def __new__(cls):
-        raise NotImplementedError("ReadWriteFileLock is unavailable.")
+        msg = "ReadWriteFileLock is unavailable."
+        raise NotImplementedError(msg)
 
 
 __all__ = [

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING
 
-from ._api import ReadWriteMode
+from ._api import ReadWriteMode, BaseReadWriteFileLock
 
 if TYPE_CHECKING:
     import os
@@ -29,6 +29,7 @@ class BaseReadWriteFileLockWrapper(ABC):
         See filelock.read_write.ReadWriteFileLock for description of the parameters.
         """
         self.read_lock = self._read_write_file_lock_cls(
+            lock_file=lock_file,
             lock_file_inner=lock_file_inner,
             lock_file_outer=lock_file_outer,
             read_write_mode=ReadWriteMode.READ,
@@ -38,6 +39,7 @@ class BaseReadWriteFileLockWrapper(ABC):
             blocking=blocking,
         )
         self.write_lock = self._read_write_file_lock_cls(
+            lock_file=lock_file,
             lock_file_inner=lock_file_inner,
             lock_file_outer=lock_file_outer,
             read_write_mode=ReadWriteMode.WRITE,
@@ -47,7 +49,7 @@ class BaseReadWriteFileLockWrapper(ABC):
             blocking=blocking,
         )
 
-    def __call__(self, read_write_mode: ReadWriteMode):
+    def __call__(self, read_write_mode: ReadWriteMode) -> BaseReadWriteFileLock:
         """
         Get read/write lock object with the specified ``read_write_mode``.
 
@@ -58,21 +60,21 @@ class BaseReadWriteFileLockWrapper(ABC):
             return self.read_lock
         return self.write_lock
 
-    def read(self):
+    def read(self) -> BaseReadWriteFileLock:
         """
         Get read/write lock object in READ mode.
 
         :return: a lock object in READ mode.
         """
-        return self.__call__(ReadWriteMode.READ)
+        return self(ReadWriteMode.READ)
 
-    def write(self):
+    def write(self) -> BaseReadWriteFileLock:
         """
         Get read/write lock object in WRITE mode.
 
         :return: a lock object in WRITE mode.
         """
-        return self.__call__(ReadWriteMode.WRITE)
+        return self(ReadWriteMode.WRITE)
 
 
 class _DisabledReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -38,7 +38,7 @@ class BaseReadWriteFileLockWrapper(metaclass=ABCMeta):
           thread_local=thread_local,
           blocking=blocking,
       )
-    
+
     def __call__(self, read_write_mode: ReadWriteMode):
         """Get read/write lock object with the specified ``read_write_mode``.
 

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
-
+import os
 from abc import ABC
+from typing import Type
+
+from ._api import ReadWriteMode
 
 
 class BaseReadWriteFileLockWrapper(ABC):
@@ -18,7 +21,7 @@ class BaseReadWriteFileLockWrapper(ABC):
         lock_file_outer: str | os.PathLike[str] | None = None,
     ) -> None:
         """
-        Convinience wrapper for read/write locks.
+        Convenience wrapper for read/write locks.
 
         See filelock.read_write.ReadWriteFileLock for description of the parameters.
         """
@@ -70,7 +73,7 @@ class BaseReadWriteFileLockWrapper(ABC):
 
 
 class _DisabledReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
-    def __new__(cls):
+    def __new__(cls) -> None:
         msg = "ReadWriteFileLock is unavailable."
         raise NotImplementedError(msg)
 

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -50,9 +50,24 @@ class BaseReadWriteFileLockWrapper(ABC):
         """
         if read_write_mode == ReadWriteMode.READ:
             return self.read_lock
-        if read_write_mode == ReadWriteMode.WRITE:
+        else:
             return self.write_lock
-        return None
+
+    def read(self):
+        """
+        Get read/write lock object in READ mode.
+
+        :return: a lock object in READ mode.
+        """
+        return self.__call__(ReadWriteMode.READ)
+
+    def write(self):
+        """
+        Get read/write lock object in WRITE mode.
+
+        :return: a lock object in WRITE mode.
+        """
+        return self.__call__(ReadWriteMode.WRITE)
 
 
 class _DisabledReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):

--- a/src/filelock/read_write/_wrapper.py
+++ b/src/filelock/read_write/_wrapper.py
@@ -14,6 +14,16 @@ class BaseReadWriteFileLockWrapper(ABC):
     Convenience wrapper for read/write locks.
 
     Provides `.read()` and `.write()` methods to easily access a read or write lock.
+
+    .. code-block:: python
+
+        # Acquire a non-exclusive reader lock
+        with lock.read():
+            pass
+
+        # Acquire an exclusive writer lock
+        with lock.write():
+            pass
     """
 
     _read_write_file_lock_cls: type[BaseReadWriteFileLock]

--- a/src/filelock/read_write/asyncio/__init__.py
+++ b/src/filelock/read_write/asyncio/__init__.py
@@ -28,15 +28,26 @@ AsyncReadWriteFileLockWrapper: type[BaseAsyncReadWriteFileLockWrapper]
 if has_fcntl:
 
     class UnixAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):
+        """Unix implementation of an async read/write FileLock."""
+
         _shared_file_lock_cls: type[BaseAsyncFileLock] = AsyncNonExclusiveUnixFileLock
         _exclusive_file_lock_cls: type[BaseAsyncFileLock] = AsyncUnixFileLock
 
-    class UnixReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
+    class UnixAsyncReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
+        """Wrapper for a Unix implementation of an async read/write FileLock."""
+
         _read_write_file_lock_cls = UnixAsyncReadWriteFileLock
 
     AsyncReadWriteFileLock = UnixAsyncReadWriteFileLock
-    AsyncReadWriteFileLockWrapper = UnixReadWriteFileLockWrapper
+    AsyncReadWriteFileLockWrapper = UnixAsyncReadWriteFileLockWrapper
 else:
+
+    class UnixAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):
+        """Unix implementation of an async read/write FileLock."""
+
+    class UnixAsyncReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
+        """Wrapper for a Unix implementation of an async read/write FileLock."""
+
     AsyncReadWriteFileLock = _DisabledAsyncReadWriteFileLock
     AsyncReadWriteFileLockWrapper = _DisabledAsyncReadWriteFileLockWrapper
 
@@ -45,4 +56,7 @@ __all__ = [
     "AsyncReadWriteFileLock",
     "AsyncReadWriteFileLockWrapper",
     "BaseAsyncReadWriteFileLock",
+    "BaseAsyncReadWriteFileLockWrapper",
+    "UnixAsyncReadWriteFileLock",
+    "UnixAsyncReadWriteFileLockWrapper",
 ]

--- a/src/filelock/read_write/asyncio/__init__.py
+++ b/src/filelock/read_write/asyncio/__init__.py
@@ -1,10 +1,4 @@
-"""
-Async read/write file lock.
-
-.. autodata:: filelock.__version__
-   :no-value:
-
-"""
+"""Async read/write file lock."""
 
 from __future__ import annotations
 

--- a/src/filelock/read_write/asyncio/__init__.py
+++ b/src/filelock/read_write/asyncio/__init__.py
@@ -19,29 +19,24 @@ if TYPE_CHECKING:
 AsyncReadWriteFileLock: type[BaseAsyncReadWriteFileLock]
 AsyncReadWriteFileLockWrapper: type[BaseAsyncReadWriteFileLockWrapper]
 
-if has_fcntl:
 
-    class UnixAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):
-        """Unix implementation of an async read/write FileLock."""
+class UnixAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):
+    """Unix implementation of an async read/write FileLock."""
 
-        _shared_file_lock_cls: type[BaseAsyncFileLock] = AsyncNonExclusiveUnixFileLock
-        _exclusive_file_lock_cls: type[BaseAsyncFileLock] = AsyncUnixFileLock
+    _shared_file_lock_cls: type[BaseAsyncFileLock] = AsyncNonExclusiveUnixFileLock
+    _exclusive_file_lock_cls: type[BaseAsyncFileLock] = AsyncUnixFileLock
 
-    class UnixAsyncReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
-        """Wrapper for a Unix implementation of an async read/write FileLock."""
 
-        _read_write_file_lock_cls = UnixAsyncReadWriteFileLock
+class UnixAsyncReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
+    """Wrapper for a Unix implementation of an async read/write FileLock."""
 
+    _read_write_file_lock_cls = UnixAsyncReadWriteFileLock
+
+
+if has_fcntl:  # pragma: win32 no cover
     AsyncReadWriteFileLock = UnixAsyncReadWriteFileLock
     AsyncReadWriteFileLockWrapper = UnixAsyncReadWriteFileLockWrapper
-else:
-
-    class UnixAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):
-        """Unix implementation of an async read/write FileLock."""
-
-    class UnixAsyncReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
-        """Wrapper for a Unix implementation of an async read/write FileLock."""
-
+else:  # pragma: win32 cover
     AsyncReadWriteFileLock = _DisabledAsyncReadWriteFileLock
     AsyncReadWriteFileLockWrapper = _DisabledAsyncReadWriteFileLockWrapper
 

--- a/src/filelock/read_write/asyncio/__init__.py
+++ b/src/filelock/read_write/asyncio/__init__.py
@@ -21,6 +21,10 @@ from filelock.read_write.asyncio._wrapper import (
 if TYPE_CHECKING:
     from filelock.asyncio import BaseAsyncFileLock
 
+
+AsyncReadWriteFileLock: type[BaseAsyncReadWriteFileLock]
+AsyncReadWriteFileLockWrapper: type[BaseAsyncReadWriteFileLockWrapper]
+
 if has_fcntl:
 
     class UnixAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):

--- a/src/filelock/read_write/asyncio/__init__.py
+++ b/src/filelock/read_write/asyncio/__init__.py
@@ -1,0 +1,44 @@
+"""
+Async read/write file lock.
+
+.. autodata:: filelock.__version__
+   :no-value:
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from filelock._unix import has_fcntl
+from filelock.asyncio import AsyncNonExclusiveUnixFileLock, AsyncUnixFileLock
+from filelock.read_write.asyncio._api import BaseAsyncReadWriteFileLock, _DisabledAsyncReadWriteFileLock
+from filelock.read_write.asyncio._wrapper import (
+    BaseAsyncReadWriteFileLockWrapper,
+    _DisabledAsyncReadWriteFileLockWrapper,
+)
+
+if TYPE_CHECKING:
+    from filelock.asyncio import BaseAsyncFileLock
+
+if has_fcntl:
+
+    class UnixAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):
+        _shared_file_lock_cls: type[BaseAsyncFileLock] = AsyncNonExclusiveUnixFileLock
+        _exclusive_file_lock_cls: type[BaseAsyncFileLock] = AsyncUnixFileLock
+
+    class UnixReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
+        _read_write_file_lock_cls = UnixAsyncReadWriteFileLock
+
+    AsyncReadWriteFileLock = UnixAsyncReadWriteFileLock
+    AsyncReadWriteFileLockWrapper = UnixReadWriteFileLockWrapper
+else:
+    AsyncReadWriteFileLock = _DisabledAsyncReadWriteFileLock
+    AsyncReadWriteFileLockWrapper = _DisabledAsyncReadWriteFileLockWrapper
+
+
+__all__ = [
+    "AsyncReadWriteFileLock",
+    "AsyncReadWriteFileLockWrapper",
+    "BaseAsyncReadWriteFileLock",
+]

--- a/src/filelock/read_write/asyncio/_api.py
+++ b/src/filelock/read_write/asyncio/_api.py
@@ -36,7 +36,6 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock):
         timeout: float = -1,
         mode: int = 0o644,
         *,
-        thread_local: bool = True,
         blocking: bool = True,
         lock_file_inner: str | os.PathLike[str] | None = None,
         lock_file_outer: str | os.PathLike[str] | None = None,
@@ -48,6 +47,8 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock):
 
         This object will use two lock files to ensure writers have priority over readers.
 
+        Note that this lock is always thread-local, to allow for non-exclusive access.
+
         :param read_write_mode: whether this object should be in WRITE mode or READ mode.
         :param lock_file: path to the file. Note that two files will be created: \
             ``{lock_file}.inner`` and ``{lock_file}.outer``. \
@@ -56,8 +57,6 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock):
             the acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it \
             to a negative value. A timeout of 0 means that there is exactly one attempt to acquire the file lock.
         :param mode: file permissions for the lockfile
-        :param thread_local: Whether this object's internal context should be thread local or not. If this is set to \
-            ``False`` then the lock will be reentrant across threads.
         :param blocking: whether the lock should be blocking or not
         :param lock_file_inner: path to the inner lock file. Can be left unspecified if ``lock_file`` is specified.
         :param lock_file_outer: path to the outer lock file Can be left unspecified if ``lock_file`` is specified.
@@ -67,7 +66,7 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock):
             lock_file=lock_file,
             timeout=timeout,
             mode=mode,
-            thread_local=thread_local,
+            thread_local=True,
             blocking=blocking,
             lock_file_inner=lock_file_inner,
             lock_file_outer=lock_file_outer,
@@ -78,7 +77,7 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock):
                 self.lock_file_inner,
                 timeout=self._inner_lock.timeout,
                 mode=self._inner_lock.mode,
-                thread_local=self._inner_lock.is_thread_local(),
+                thread_local=True,
                 blocking=self._inner_lock.blocking,
                 is_singleton=False,
             )
@@ -87,7 +86,7 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock):
                 self.lock_file_inner,
                 timeout=self._inner_lock.timeout,
                 mode=self._inner_lock.mode,
-                thread_local=self._inner_lock.is_thread_local(),
+                thread_local=True,
                 blocking=self._inner_lock.blocking,
                 is_singleton=False,
             )
@@ -97,7 +96,7 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock):
             self.lock_file_outer,
             timeout=self._outer_lock.timeout,
             mode=self._outer_lock.mode,
-            thread_local=self._outer_lock.is_thread_local(),
+            thread_local=True,
             blocking=self._outer_lock.blocking,
             is_singleton=False,
         )

--- a/src/filelock/read_write/asyncio/_api.py
+++ b/src/filelock/read_write/asyncio/_api.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn, cast
 
+from filelock._api import DEFAULT_POLL_INTERVAL
 from filelock.asyncio import AsyncAcquireReturnProxy, AsyncLockProtocol, BaseAsyncFileLock
 from filelock.read_write._api import BaseReadWriteFileLock, ReadWriteMode
 
@@ -119,7 +120,7 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock, AsyncLockProtocol):
     async def acquire(  # type: ignore[override]
         self,
         timeout: float | None = None,
-        poll_interval: float = 0.05,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
         *,
         blocking: bool | None = None,
     ) -> AsyncAcquireReturnProxy:

--- a/src/filelock/read_write/asyncio/_api.py
+++ b/src/filelock/read_write/asyncio/_api.py
@@ -151,8 +151,8 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock, AsyncLockProtocol):
 
         """
         start_time = time.monotonic()
-        inner_lock = cast(AsyncLockProtocol, self._inner_lock)
-        outer_lock = cast(AsyncLockProtocol, self._outer_lock)
+        inner_lock = cast("AsyncLockProtocol", self._inner_lock)
+        outer_lock = cast("AsyncLockProtocol", self._outer_lock)
 
         # Writers or readers must first acquire the outer lock to verify no writer is active or pending.
         await outer_lock.acquire(timeout=timeout, poll_interval=poll_interval, blocking=blocking)
@@ -182,8 +182,8 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock, AsyncLockProtocol):
         :param force: If true, the lock counter is ignored and the lock is released in every case/
 
         """
-        inner_lock = cast(AsyncLockProtocol, self._inner_lock)
-        outer_lock = cast(AsyncLockProtocol, self._outer_lock)
+        inner_lock = cast("AsyncLockProtocol", self._inner_lock)
+        outer_lock = cast("AsyncLockProtocol", self._outer_lock)
 
         await inner_lock.release(force=force)
         if self.read_write_mode == ReadWriteMode.WRITE:

--- a/src/filelock/read_write/asyncio/_api.py
+++ b/src/filelock/read_write/asyncio/_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn, cast
@@ -9,7 +10,6 @@ from filelock.asyncio import AsyncAcquireReturnProxy, AsyncLockProtocol, BaseAsy
 from filelock.read_write._api import BaseReadWriteFileLock, ReadWriteMode
 
 if TYPE_CHECKING:
-    import asyncio
     import os
     import sys
     from concurrent import futures

--- a/src/filelock/read_write/asyncio/_api.py
+++ b/src/filelock/read_write/asyncio/_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn, cast

--- a/src/filelock/read_write/asyncio/_api.py
+++ b/src/filelock/read_write/asyncio/_api.py
@@ -127,7 +127,7 @@ class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock, AsyncReleasable):
         Try to acquire the file lock.
 
         :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default
-            :attr:`~BaseFileLock.timeout` is and if ``timeout < 0``, there is no timeout and
+            :attr:`filelock.BaseFileLock.timeout` is and if ``timeout < 0``, there is no timeout and
             this method will block until the lock could be acquired
         :param poll_interval: interval of trying to acquire the lock file
         :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on the
@@ -237,5 +237,4 @@ class _DisabledAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):
 
 __all__ = [
     "BaseAsyncReadWriteFileLock",
-    "_DisabledAsyncReadWriteFileLock",
 ]

--- a/src/filelock/read_write/asyncio/_api.py
+++ b/src/filelock/read_write/asyncio/_api.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from filelock.asyncio import AsyncAcquireReturnProxy, BaseAsyncFileLock
+from filelock.read_write._api import BaseReadWriteFileLock, ReadWriteMode
+
+if TYPE_CHECKING:
+    import os
+    import sys
+    from types import TracebackType
+
+    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+        from typing import Self
+    else:  # pragma: no cover (<py311)
+        from typing_extensions import Self
+
+
+class BaseAsyncReadWriteFileLock(BaseReadWriteFileLock):
+    """
+    An asynchronous, writer-preferring read/write file lock.
+
+    Readers share the lock in READ mode (multiple readers at once).
+    Writers get an exclusive lock in WRITE mode and block both readers and other writers.
+    Writers have priority: if a writer arrives, new readers must wait until the writer finishes.
+    """
+
+    _shared_file_lock_cls: type[BaseAsyncFileLock]
+    _exclusive_file_lock_cls: type[BaseAsyncFileLock]
+
+    def __init__(  # noqa: PLR0913
+        self,
+        read_write_mode: ReadWriteMode,
+        lock_file: str | os.PathLike[str] | None = None,
+        timeout: float = -1,
+        mode: int = 0o644,
+        *,
+        thread_local: bool = True,
+        blocking: bool = True,
+        lock_file_inner: str | os.PathLike[str] | None = None,
+        lock_file_outer: str | os.PathLike[str] | None = None,
+    ) -> None:
+        """
+        Create a new async writer-preferring read/write lock object. Multiple READers can hold the lock
+        at the same time, but a WRITEr is guaranteed to hold the lock exclusively across both
+        readers and writers.
+
+        This object will use two lock files to ensure writers have priority over readers.
+
+        :param read_write_mode: whether this object should be in WRITE mode or READ mode.
+        :param lock_file: path to the file. Note that two files will be created: \
+            ``{lock_file}.inner`` and ``{lock_file}.outer``. \
+            If not specified, ``lock_file_inner`` and ``lock_file_outer`` must both be specified.
+        :param timeout: default timeout when acquiring the lock, in seconds. It will be used as fallback value in \
+            the acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it \
+            to a negative value. A timeout of 0 means that there is exactly one attempt to acquire the file lock.
+        :param mode: file permissions for the lockfile
+        :param thread_local: Whether this object's internal context should be thread local or not. If this is set to \
+            ``False`` then the lock will be reentrant across threads.
+        :param blocking: whether the lock should be blocking or not
+        :param lock_file_inner: path to the inner lock file. Can be left unspecified if ``lock_file`` is specified.
+        :param lock_file_outer: path to the outer lock file Can be left unspecified if ``lock_file`` is specified.
+        """
+        super().__init__(
+            read_write_mode=read_write_mode,
+            lock_file=lock_file,
+            timeout=timeout,
+            mode=mode,
+            thread_local=thread_local,
+            blocking=blocking,
+            lock_file_inner=lock_file_inner,
+            lock_file_outer=lock_file_outer,
+        )
+
+        self._inner_lock = (
+            self._shared_file_lock_cls(
+                self.lock_file_inner,
+                timeout=self._inner_lock.timeout,
+                mode=self._inner_lock.mode,
+                thread_local=self._inner_lock.is_thread_local(),
+                blocking=self._inner_lock.blocking,
+                is_singleton=False,
+            )
+            if self.read_write_mode == ReadWriteMode.READ
+            else self._exclusive_file_lock_cls(
+                self.lock_file_inner,
+                timeout=self._inner_lock.timeout,
+                mode=self._inner_lock.mode,
+                thread_local=self._inner_lock.is_thread_local(),
+                blocking=self._inner_lock.blocking,
+                is_singleton=False,
+            )
+        )
+
+        self._outer_lock = self._exclusive_file_lock_cls(
+            self.lock_file_outer,
+            timeout=self._outer_lock.timeout,
+            mode=self._outer_lock.mode,
+            thread_local=self._outer_lock.is_thread_local(),
+            blocking=self._outer_lock.blocking,
+            is_singleton=False,
+        )
+
+    async def acquire(
+        self,
+        timeout: float | None = None,
+        poll_interval: float = 0.05,
+        *,
+        blocking: bool | None = None,
+    ) -> AsyncAcquireReturnProxy:
+        """
+        Try to acquire the file lock.
+
+        :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default
+            :attr:`~BaseFileLock.timeout` is and if ``timeout < 0``, there is no timeout and
+            this method will block until the lock could be acquired
+        :param poll_interval: interval of trying to acquire the lock file
+        :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on the
+         first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
+        :raises Timeout: if fails to acquire lock within the timeout period
+        :return: a context object that will unlock the file when the context is exited
+
+        .. code-block:: python
+
+            # You can use this method in the context manager (recommended)
+            with lock.acquire():
+                pass
+
+            # Or use an equivalent try-finally construct:
+            lock.acquire()
+            try:
+                pass
+            finally:
+                lock.release()
+
+        """
+        start_time = time.monotonic()
+        # Writers or readers must first acquire the outer lock to verify no writer is active or pending.
+        await self._outer_lock.acquire(timeout=timeout, poll_interval=poll_interval, blocking=blocking)
+        dur = time.monotonic() - start_time
+        if timeout is not None:
+            timeout -= dur
+
+        if self.read_write_mode == ReadWriteMode.READ:
+            try:
+                # Acquire the inner lock for reading.
+                await self._inner_lock.acquire(timeout=timeout, poll_interval=poll_interval, blocking=blocking)
+            finally:
+                # Release outer lock once the inner lock is acquired, allowing other readers in.
+                await self._outer_lock.release()
+        else:
+            # In write mode, hold both locks:
+            # - Outer lock prevents new readers from starting.
+            # - Inner lock ensures exclusive write access.
+            await self._inner_lock.acquire(timeout=timeout, poll_interval=poll_interval, blocking=blocking)
+        return AsyncAcquireReturnProxy(lock=self)
+
+    async def release(self, *, force: bool = False) -> None:
+        """
+        Releases the file lock. Please note, that the lock is only completely released, if the lock counter is 0.
+        Also note, that the lock file itself is not automatically deleted.
+
+        :param force: If true, the lock counter is ignored and the lock is released in every case/
+
+        """
+        await self._inner_lock.release(force=force)
+        if self.read_write_mode == ReadWriteMode.WRITE:
+            await self._outer_lock.release(force=force)
+
+    async def __aenter__(self) -> Self:
+        """
+        Acquire the lock.
+
+        :return: the lock object
+
+        """
+        await self.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """
+        Release the lock.
+
+        :param exc_type: the exception type if raised
+        :param exc_value: the exception value if raised
+        :param traceback: the exception traceback if raised
+
+        """
+        await self.release()
+
+    def __enter__(self) -> None:
+        """
+        Replace old __enter__ method to avoid using it.
+
+        NOTE: DO NOT USE `with` FOR ASYNCIO LOCKS, USE `async with` INSTEAD.
+
+        :return: none
+        :rtype: NoReturn
+        """
+        msg = "Do not use `with` for asyncio locks, use `async with` instead."
+        raise NotImplementedError(msg)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        pass
+
+
+class _DisabledAsyncReadWriteFileLock(BaseAsyncReadWriteFileLock):
+    def __new__(cls) -> None:
+        msg = "AsyncReadWriteFileLock is unavailable."
+        raise NotImplementedError(msg)
+
+
+__all__ = [
+    "BaseAsyncReadWriteFileLock",
+    "_DisabledAsyncReadWriteFileLock",
+]

--- a/src/filelock/read_write/asyncio/_wrapper.py
+++ b/src/filelock/read_write/asyncio/_wrapper.py
@@ -18,6 +18,16 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
     Convenience wrapper class for async read/write locks.
 
     Provides `.read()` and `.write()` methods to easily access a read or write lock.
+
+    .. code-block:: python
+
+        # Acquire a non-exclusive reader lock
+        async with lock.read():
+            pass
+
+        # Acquire an exclusive writer lock
+        async with lock.write():
+            pass
     """
 
     _read_write_file_lock_cls: type[BaseAsyncReadWriteFileLock]

--- a/src/filelock/read_write/asyncio/_wrapper.py
+++ b/src/filelock/read_write/asyncio/_wrapper.py
@@ -26,7 +26,6 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
         lock_file: str | os.PathLike[str] | None = None,
         timeout: float = -1,
         mode: int = 0o644,
-        thread_local: bool = True,  # noqa: FBT001, FBT002
         *,
         blocking: bool = True,
         lock_file_inner: str | os.PathLike[str] | None = None,
@@ -43,7 +42,6 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
             read_write_mode=ReadWriteMode.READ,
             timeout=timeout,
             mode=mode,
-            thread_local=thread_local,
             blocking=blocking,
             loop=loop,
             run_in_executor=run_in_executor,
@@ -56,7 +54,6 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
             read_write_mode=ReadWriteMode.WRITE,
             timeout=timeout,
             mode=mode,
-            thread_local=thread_local,
             blocking=blocking,
             loop=loop,
             run_in_executor=run_in_executor,

--- a/src/filelock/read_write/asyncio/_wrapper.py
+++ b/src/filelock/read_write/asyncio/_wrapper.py
@@ -76,7 +76,20 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
 
 
 class _DisabledAsyncReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
-    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003
+    def __init__(  # noqa: PLR0913
+        self,
+        lock_file: str | os.PathLike[str] | None = None,
+        timeout: float = -1,
+        mode: int = 0o644,
+        thread_local: bool = False,  # noqa: FBT001, FBT002
+        *,
+        blocking: bool = True,
+        lock_file_inner: str | os.PathLike[str] | None = None,
+        lock_file_outer: str | os.PathLike[str] | None = None,
+        loop: asyncio.AbstractEventLoop | None = None,
+        run_in_executor: bool = True,
+        executor: futures.Executor | None = None,
+    ) -> None:
         msg = "AsyncReadWriteFileLock is unavailable."
         raise NotImplementedError(msg)
 

--- a/src/filelock/read_write/asyncio/_wrapper.py
+++ b/src/filelock/read_write/asyncio/_wrapper.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
     """
     Convenience wrapper class for async read/write locks.
+
     Provides `.read()` and `.write()` methods to easily access a read or write lock.
     """
 

--- a/src/filelock/read_write/asyncio/_wrapper.py
+++ b/src/filelock/read_write/asyncio/_wrapper.py
@@ -26,6 +26,7 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
         lock_file: str | os.PathLike[str] | None = None,
         timeout: float = -1,
         mode: int = 0o644,
+        thread_local: bool = False,  # noqa: FBT001, FBT002
         *,
         blocking: bool = True,
         lock_file_inner: str | os.PathLike[str] | None = None,
@@ -42,6 +43,7 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
             read_write_mode=ReadWriteMode.READ,
             timeout=timeout,
             mode=mode,
+            thread_local=thread_local,
             blocking=blocking,
             loop=loop,
             run_in_executor=run_in_executor,
@@ -54,6 +56,7 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
             read_write_mode=ReadWriteMode.WRITE,
             timeout=timeout,
             mode=mode,
+            thread_local=thread_local,
             blocking=blocking,
             loop=loop,
             run_in_executor=run_in_executor,

--- a/src/filelock/read_write/asyncio/_wrapper.py
+++ b/src/filelock/read_write/asyncio/_wrapper.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from filelock.read_write._api import ReadWriteMode
+from filelock.read_write._wrapper import BaseReadWriteFileLockWrapper
+
+if TYPE_CHECKING:
+    import asyncio
+    import os
+    from concurrent import futures
+
+    from ._api import BaseAsyncReadWriteFileLock
+
+
+class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
+    """
+    Convenience wrapper class for async read/write locks.
+    Provides `.read()` and `.write()` methods to easily access a read or write lock.
+    """
+
+    _read_write_file_lock_cls: type[BaseAsyncReadWriteFileLock]
+
+    def __init__(  # noqa: PLR0913
+        self,
+        lock_file: str | os.PathLike[str] | None = None,
+        timeout: float = -1,
+        mode: int = 0o644,
+        thread_local: bool = True,  # noqa: FBT001, FBT002
+        *,
+        blocking: bool = True,
+        lock_file_inner: str | os.PathLike[str] | None = None,
+        lock_file_outer: str | os.PathLike[str] | None = None,
+        loop: asyncio.AbstractEventLoop | None = None,
+        run_in_executor: bool = True,
+        executor: futures.Executor | None = None,
+    ) -> None:
+        """See documentation of BaseAsyncReadWriteFileLock for parameter descriptions."""
+        self.read_lock = self._read_write_file_lock_cls(
+            lock_file=lock_file,
+            lock_file_inner=lock_file_inner,
+            lock_file_outer=lock_file_outer,
+            read_write_mode=ReadWriteMode.READ,
+            timeout=timeout,
+            mode=mode,
+            thread_local=thread_local,
+            blocking=blocking,
+            loop=loop,
+            run_in_executor=run_in_executor,
+            executor=executor,
+        )
+        self.write_lock = self._read_write_file_lock_cls(
+            lock_file=lock_file,
+            lock_file_inner=lock_file_inner,
+            lock_file_outer=lock_file_outer,
+            read_write_mode=ReadWriteMode.WRITE,
+            timeout=timeout,
+            mode=mode,
+            thread_local=thread_local,
+            blocking=blocking,
+            loop=loop,
+            run_in_executor=run_in_executor,
+            executor=executor,
+        )
+
+
+class _DisabledAsyncReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
+    def __new__(cls) -> None:
+        msg = "AsyncReadWriteFileLock is unavailable."
+        raise NotImplementedError(msg)
+
+
+__all__ = [
+    "BaseAsyncReadWriteFileLockWrapper",
+]

--- a/src/filelock/read_write/asyncio/_wrapper.py
+++ b/src/filelock/read_write/asyncio/_wrapper.py
@@ -65,7 +65,7 @@ class BaseAsyncReadWriteFileLockWrapper(BaseReadWriteFileLockWrapper):
 
 
 class _DisabledAsyncReadWriteFileLockWrapper(BaseAsyncReadWriteFileLockWrapper):
-    def __new__(cls) -> None:
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003
         msg = "AsyncReadWriteFileLock is unavailable."
         raise NotImplementedError(msg)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
-from typing import Union, Tuple, Type
+from __future__ import annotations
+
 from types import TracebackType
+from typing import Tuple, Type, Union
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+from typing import Union, Tuple, Type
+from types import TracebackType
+
+import pytest
+
+_ExcInfoType = Union[Tuple[Type[BaseException], BaseException, TracebackType], Tuple[None, None, None]]
+
+
+class ExThread(threading.Thread):
+    def __init__(self, target: Callable[[], None], name: str) -> None:
+        super().__init__(target=target, name=name)
+        self.ex: _ExcInfoType | None = None
+
+    def run(self) -> None:
+        try:
+            super().run()
+        except Exception:  # noqa: BLE001 # pragma: no cover
+            self.ex = sys.exc_info()  # pragma: no cover
+
+    def join(self, timeout: float | None = None) -> None:
+        super().join(timeout=timeout)
+        if self.ex is not None:
+            raise RuntimeError from self.ex[1]  # pragma: no cover
+
+
+@pytest.fixture
+def ex_thread_cls():
+    return ExThread

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from types import TracebackType
 from typing import Tuple, Type, Union
-
+import threading
 import pytest
 
 _ExcInfoType = Union[Tuple[Type[BaseException], BaseException, TracebackType], Tuple[None, None, None]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import threading
 from types import TracebackType
-from typing import Tuple, Type, Union, Callable
+from typing import Callable, Tuple, Type, Union
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import sys
 from types import TracebackType
 from typing import Tuple, Type, Union
-import sys
 
 import pytest
 
@@ -27,5 +27,5 @@ class ExThread(threading.Thread):
 
 
 @pytest.fixture
-def ex_thread_cls() -> Type[ExThread]:
+def ex_thread_cls() -> type[ExThread]:
     return ExThread

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import TracebackType
 from typing import Tuple, Type, Union
+import sys
 
 import pytest
 
@@ -26,5 +27,5 @@ class ExThread(threading.Thread):
 
 
 @pytest.fixture
-def ex_thread_cls():
+def ex_thread_cls() -> Type[ExThread]:
     return ExThread

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import threading
 from types import TracebackType
-from typing import Tuple, Type, Union
+from typing import Tuple, Type, Union, Callable
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import sys
+import threading
 from types import TracebackType
 from typing import Tuple, Type, Union
-import threading
+
 import pytest
 
 _ExcInfoType = Union[Tuple[Type[BaseException], BaseException, TracebackType], Tuple[None, None, None]]

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -11,8 +11,7 @@ from errno import ENOSYS
 from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
-from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Iterator
 from uuid import uuid4
 from weakref import WeakValueDictionary
 
@@ -219,7 +218,9 @@ def test_nested_contruct(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
+def test_threaded_shared_lock_obj(
+    lock_type: type[BaseFileLock], tmp_path: Path, ex_thread_cls: threading.Thread
+) -> None:
     # Runs 100 threads, which need the filelock. The lock must be acquired if at least one thread required it and
     # released, as soon as all threads stopped.
     lock_path = tmp_path / "a"
@@ -241,7 +242,9 @@ def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path,
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 @pytest.mark.skipif(hasattr(sys, "pypy_version_info") and sys.platform == "win32", reason="deadlocks randomly")
-def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
+def test_threaded_lock_different_lock_obj(
+    lock_type: type[BaseFileLock], tmp_path: Path, ex_thread_cls: threading.Thread
+) -> None:
     # Runs multiple threads, which acquire the same lock file with a different FileLock object. When thread group 1
     # acquired the lock, thread group 2 must not hold their lock.
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -218,28 +218,8 @@ def test_nested_contruct(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     assert not lock_1.is_locked
 
 
-_ExcInfoType = Union[Tuple[Type[BaseException], BaseException, TracebackType], Tuple[None, None, None]]
-
-
-class ExThread(threading.Thread):
-    def __init__(self, target: Callable[[], None], name: str) -> None:
-        super().__init__(target=target, name=name)
-        self.ex: _ExcInfoType | None = None
-
-    def run(self) -> None:
-        try:
-            super().run()
-        except Exception:  # noqa: BLE001 # pragma: no cover
-            self.ex = sys.exc_info()  # pragma: no cover
-
-    def join(self, timeout: float | None = None) -> None:
-        super().join(timeout=timeout)
-        if self.ex is not None:
-            raise RuntimeError from self.ex[1]  # pragma: no cover
-
-
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
     # Runs 100 threads, which need the filelock. The lock must be acquired if at least one thread required it and
     # released, as soon as all threads stopped.
     lock_path = tmp_path / "a"
@@ -250,7 +230,7 @@ def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path)
             with lock:
                 assert lock.is_locked
 
-    threads = [ExThread(target=thread_work, name=f"t{i}") for i in range(100)]
+    threads = [ex_thread_cls(target=thread_work, name=f"t{i}") for i in range(100)]
     for thread in threads:
         thread.start()
     for thread in threads:
@@ -261,7 +241,7 @@ def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path)
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 @pytest.mark.skipif(hasattr(sys, "pypy_version_info") and sys.platform == "win32", reason="deadlocks randomly")
-def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
     # Runs multiple threads, which acquire the same lock file with a different FileLock object. When thread group 1
     # acquired the lock, thread group 2 must not hold their lock.
 
@@ -279,7 +259,7 @@ def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_pat
 
     lock_path = tmp_path / "a"
     lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
-    threads = [(ExThread(t_1, f"t1_{i}"), ExThread(t_2, f"t2_{i}")) for i in range(10)]
+    threads = [(ex_thread_cls(t_1, f"t1_{i}"), ex_thread_cls(t_2, f"t2_{i}")) for i in range(10)]
 
     for thread_1, thread_2 in threads:
         thread_1.start()

--- a/tests/test_read_write_filelock.py
+++ b/tests/test_read_write_filelock.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import asyncio
+import random
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 from typing import TYPE_CHECKING
 
 import pytest
 
+from filelock import Timeout
 from filelock.read_write import (
-    BaseReadWriteFileLockWrapper,
+    AsyncReadWriteFileLockWrapper,
     ReadWriteFileLockWrapper,
     ReadWriteMode,
     has_read_write_file_lock,
@@ -17,17 +21,254 @@ from filelock.read_write import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+if not has_read_write_file_lock:
+    pytest.skip(reason="ReadWriteFileLock is not available", allow_module_level=True)
 
-@pytest.mark.skipif(not has_read_write_file_lock, reason="ReadWriteFileLock is not available")
-@pytest.mark.parametrize("lock_wrapper_type", [ReadWriteFileLockWrapper])
-def test_threaded_read_write_lock(
-    lock_wrapper_type: type[BaseReadWriteFileLockWrapper], tmp_path: Path, ex_thread_cls: threading.Thread
-) -> None:
+
+def test_basic_read_lock(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    with rw_wrapper.read() as lock:
+        assert lock.is_locked
+        assert lock.read_write_mode == ReadWriteMode.READ
+    assert not lock.is_locked
+
+
+def test_basic_write_lock(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    with rw_wrapper.write() as lock:
+        assert lock.is_locked
+        assert lock.read_write_mode == ReadWriteMode.WRITE
+    assert not lock.is_locked
+
+
+def test_reentrant_read_lock(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    lock = rw_wrapper.read()
+    with lock:
+        assert lock.is_locked
+        with lock:
+            assert lock.is_locked
+        assert lock.is_locked
+    assert not lock.is_locked
+
+
+def test_reentrant_write_lock(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    lock = rw_wrapper.write()
+    with lock:
+        assert lock.is_locked
+        with lock:
+            assert lock.is_locked
+        assert lock.is_locked
+    assert not lock.is_locked
+
+
+def test_multiple_readers_shared_lock(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    lock1 = rw_wrapper.read()
+    lock2 = rw_wrapper.read()
+
+    with lock1:
+        assert lock1.is_locked
+        # Acquiring another read lock should not block
+        with lock2:
+            assert lock2.is_locked
+        assert lock1.is_locked
+    assert not lock1.is_locked
+    assert not lock2.is_locked
+
+
+def test_writer_excludes_readers(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    rlock = rw_wrapper.read()
+    wlock = rw_wrapper.write()
+
+    with wlock:
+        assert wlock.is_locked
+        # Attempting to acquire a read lock now should block or time out
+        start = time.perf_counter()
+        with pytest.raises((Timeout, Exception)):
+            rlock.acquire(timeout=0.1, blocking=False)
+        end = time.perf_counter()
+        assert (end - start) < 1.0  # ensure it didn't block too long
+    assert not wlock.is_locked
+
+
+def test_readers_blocked_by_writer_priority(tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
+    """
+    Once a writer is waiting for the lock, new readers should not enter.
+    This ensures writer preference.
+    """
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    rlock = rw_wrapper.read()
+    wlock = rw_wrapper.write()
+
+    # Acquire read lock first
+    with rlock:
+        # Start a writer in another thread and ensure it wants the lock
+        def writer() -> None:
+            with wlock:
+                pass
+
+        t = ex_thread_cls(target=writer, name="writer")
+        t.start()
+
+        # Give some time for writer to start and attempt acquire
+        time.sleep(0.1)
+
+        # Now attempt to acquire another read lock - should block or timeout because writer preference
+        another_r = rw_wrapper.read()
+        with pytest.raises((Timeout, Exception)):
+            another_r.acquire(timeout=0.1, blocking=True)
+
+    # Now that the read lock is released, the writer should get the lock and release it
+    t.join()
+    assert not rlock.is_locked
+    assert not wlock.is_locked
+
+
+def test_non_blocking_read_when_write_held(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    wlock = rw_wrapper.write()
+    rlock = rw_wrapper.read()
+
+    wlock.acquire()
+    assert wlock.is_locked
+    # Non-blocking read should fail immediately
+    with pytest.raises((Timeout, Exception)):
+        rlock.acquire(blocking=False)
+    wlock.release()
+
+
+def test_timeout_read_lock(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    wlock = rw_wrapper.write()
+    rlock = rw_wrapper.read()
+
+    wlock.acquire()
+    with pytest.raises((Timeout, Exception)):
+        # Attempt read lock with some timeout
+        rlock.acquire(timeout=0.1)
+    wlock.release()
+
+
+def test_timeout_write_lock(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    rlock = rw_wrapper.read()
+    wlock = rw_wrapper.write()
+
+    # Acquire a read lock first
+    rlock.acquire()
+    assert rlock.is_locked
+    # Attempt to acquire a write lock with a short timeout
+    with pytest.raises((Timeout, Exception)):
+        wlock.acquire(timeout=0.1)
+    rlock.release()
+
+
+def test_forced_release(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    rlock = rw_wrapper.read()
+    rlock.acquire()
+    assert rlock.is_locked
+
+    # Force release
+    rlock.release(force=True)
+    assert not rlock.is_locked
+
+
+def test_stress_multiple_threads_readers_and_writers(tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
+    # Stress test: multiple readers and writers competing
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+    num_readers = 50
+    num_writers = 10
+
+    read_hold_time = 0.01
+    write_hold_time = 0.02
+
+    # Shared resource
+    shared_data = []
+    shared_data_lock = threading.Lock()
+
+    def reader() -> None:
+        with rw_wrapper.read():
+            # Multiple readers can enter
+            # Just check that no writes happen simultaneously
+            time.sleep(read_hold_time)
+            with shared_data_lock:
+                # Check consistency
+                pass
+
+    def writer() -> None:
+        with rw_wrapper.write():
+            # Exclusive access
+            old_len = len(shared_data)
+            time.sleep(write_hold_time)
+            with shared_data_lock:
+                shared_data.append(1)
+                assert len(shared_data) == old_len + 1
+
+    threads = []
+    threads.extend(ex_thread_cls(target=reader, name=f"reader_{i}") for i in range(num_readers))
+    threads.extend(ex_thread_cls(target=writer, name=f"writer_{i}") for i in range(num_writers))
+
+    # Shuffle threads to randomize execution
+    random.shuffle(threads)
+
+    for t in threads:
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    # We expect that all writers appended to the list
+    assert len(shared_data) == num_writers
+
+
+def test_thrashing_with_thread_pool_readers_writers(tmp_path: Path) -> None:
+    rw_wrapper = ReadWriteFileLockWrapper(str(tmp_path / "test_rw"))
+
+    txt_file = tmp_path / "data.txt"
+    txt_file.write_text("initial")
+
+    def read_work() -> None:
+        with rw_wrapper.read():
+            txt_file.read_text()
+            time.sleep(0.001)
+
+    def write_work() -> None:
+        with rw_wrapper.write():
+            current = txt_file.read_text()
+            txt_file.write_text(current + "x")
+            time.sleep(0.002)
+
+    with ThreadPoolExecutor() as executor:
+        futures = []
+        futures.extend(executor.submit(read_work) for _ in range(50))
+        futures.extend(executor.submit(write_work) for _ in range(10))
+
+        # Add more mixed load
+        for _ in range(20):
+            futures.append(executor.submit(read_work))  # noqa: FURB113
+            futures.append(executor.submit(write_work))
+
+        for f in futures:
+            f.result()
+
+    # Ensure file got appended by writers
+    final_data = txt_file.read_text()
+    # At least writers appended something
+    assert len(final_data) > len("initial")
+
+
+def test_threaded_read_write_lock(tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
     # Runs 100 reader and 10 writer threads.
     # Ensure all readers can acquire the lock at the same time, while no writer can
     # acquire the lock.
     # Release all the readers and ensure only one writer can acquire the lock at the same time.
-    read_write_lock = lock_wrapper_type(str(tmp_path / "rw"))
+
+    # Note that we can do this because ReadWriteFileLock is thread local by default.
+    read_write_lock = ReadWriteFileLockWrapper(str(tmp_path / "rw"))
 
     num_readers = 0
     num_readers_lock = threading.Lock()
@@ -96,3 +337,299 @@ def test_threaded_read_write_lock(
     assert not read_write_lock(ReadWriteMode.WRITE).is_locked
     assert num_readers == 0
     assert num_writers == 0
+
+
+@pytest.mark.asyncio
+async def test_async_basic_read_lock(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    async with rw_wrapper.read_lock as lock:
+        assert lock.is_locked
+        assert lock.read_write_mode == ReadWriteMode.READ
+    assert not lock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_basic_write_lock(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    async with rw_wrapper.write_lock as lock:
+        assert lock.is_locked
+        assert lock.read_write_mode == ReadWriteMode.WRITE
+    assert not lock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_reentrant_read_lock(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    lock = rw_wrapper.read_lock
+    async with lock:
+        assert lock.is_locked
+        async with lock:
+            assert lock.is_locked
+        assert lock.is_locked
+    assert not lock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_reentrant_write_lock(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    lock = rw_wrapper.write_lock
+    async with lock:
+        assert lock.is_locked
+        async with lock:
+            assert lock.is_locked
+        assert lock.is_locked
+    assert not lock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_multiple_readers_shared_lock(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    lock1 = rw_wrapper.read_lock
+    lock2 = rw_wrapper.read_lock
+
+    async with lock1:
+        assert lock1.is_locked
+        # Another read lock should also be acquirable without blocking
+        async with lock2:
+            assert lock2.is_locked
+        assert lock1.is_locked
+    assert not lock1.is_locked
+    assert not lock2.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_writer_excludes_readers(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    rlock = rw_wrapper.read_lock
+    wlock = rw_wrapper.write_lock
+
+    async with wlock:
+        assert wlock.is_locked
+        # Attempting to acquire read lock should fail immediately if non-blocking
+        with pytest.raises(Timeout):
+            await rlock.acquire(timeout=0.1, blocking=False)
+    assert not wlock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_readers_blocked_by_writer_priority(tmp_path: Path) -> None:
+    """
+    Once a writer is waiting for the lock, new readers should not start.
+    This ensures writer preference.
+    """
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    rlock = rw_wrapper.read_lock
+    wlock = rw_wrapper.write_lock
+
+    await rlock.acquire()
+    try:
+        # Start a writer attempt in another task
+        async def writer() -> None:
+            async with wlock:
+                pass
+
+        writer_task = asyncio.create_task(writer())
+        # Give the writer a moment to start and attempt acquire
+        await asyncio.sleep(0.1)
+
+        # Now attempt another read lock - should fail due to writer preference
+        another_r = rw_wrapper.read_lock
+        with pytest.raises(Timeout):
+            await another_r.acquire(timeout=0.1, blocking=True)
+
+    finally:
+        await rlock.release()
+
+    # Once read lock is released, writer should proceed
+    await writer_task
+
+
+@pytest.mark.asyncio
+async def test_async_non_blocking_read_when_write_held(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    wlock = rw_wrapper.write_lock
+    rlock = rw_wrapper.read_lock
+
+    await wlock.acquire()
+    try:
+        with pytest.raises(Timeout):
+            await rlock.acquire(blocking=False)
+    finally:
+        await wlock.release()
+
+
+@pytest.mark.asyncio
+async def test_async_timeout_read_lock(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    wlock = rw_wrapper.write_lock
+    rlock = rw_wrapper.read_lock
+
+    await wlock.acquire()
+    try:
+        with pytest.raises(Timeout):
+            await rlock.acquire(timeout=0.1)
+    finally:
+        await wlock.release()
+
+
+@pytest.mark.asyncio
+async def test_async_timeout_write_lock(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    rlock = rw_wrapper.read_lock
+    wlock = rw_wrapper.write_lock
+
+    await rlock.acquire()
+    try:
+        with pytest.raises(Timeout):
+            await wlock.acquire(timeout=0.1)
+    finally:
+        await rlock.release()
+
+
+@pytest.mark.asyncio
+async def test_async_forced_release(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    rlock = rw_wrapper.read_lock
+    await rlock.acquire()
+    assert rlock.is_locked
+    await rlock.release(force=True)
+    assert not rlock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_stress_multiple_tasks_readers_and_writers(tmp_path: Path) -> None:
+    num_readers = 50
+    num_writers = 10
+
+    # Shared state
+    shared_data = []
+    data_lock = asyncio.Lock()
+
+    async def reader() -> None:
+        rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+        async with rw_wrapper.read_lock:
+            # Multiple readers allowed
+            await asyncio.sleep(0.01)
+            # Just check/inspect shared_data under lock
+            async with data_lock:
+                # read operation
+                pass
+
+    async def writer() -> None:
+        rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+        async with rw_wrapper.write_lock:
+            async with data_lock:
+                old_len = len(shared_data)
+            await asyncio.sleep(0.02)
+            async with data_lock:
+                shared_data.append(1)
+                assert len(shared_data) == old_len + 1
+
+    tasks = []
+    tasks.extend(asyncio.create_task(reader()) for _ in range(num_readers))
+    tasks.extend(asyncio.create_task(writer()) for _ in range(num_writers))
+
+    # Shuffle tasks
+    random.shuffle(tasks)
+    await asyncio.gather(*tasks)
+
+    # All writers must have appended to shared_data
+    assert len(shared_data) == num_writers
+
+
+@pytest.mark.asyncio
+async def test_async_asyncio_concurrent_readers_writers(tmp_path: Path) -> None:
+    # Similar stress test with mixed load
+    txt_file = tmp_path / "data.txt"
+    txt_file.write_text("initial")
+
+    async def read_work() -> None:
+        rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+        async with rw_wrapper.read_lock:
+            _ = txt_file.read_text()
+            await asyncio.sleep(0.001)
+
+    async def write_work() -> None:
+        rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+        async with rw_wrapper.write_lock:
+            current = txt_file.read_text()
+            txt_file.write_text(current + "x")
+            await asyncio.sleep(0.002)
+
+    tasks = []
+    tasks.extend(asyncio.create_task(read_work()) for _ in range(50))
+    tasks.extend(asyncio.create_task(write_work()) for _ in range(10))
+
+    # Add more mixed load
+    for _ in range(20):
+        tasks.append(asyncio.create_task(read_work()))  # noqa: FURB113
+        tasks.append(asyncio.create_task(write_work()))
+
+    await asyncio.gather(*tasks)
+
+    final_data = txt_file.read_text()
+    # At least some writes have occurred
+    assert len(final_data) > len("initial")
+
+
+def test_async_cannot_use_with_instead_of_async_with(tmp_path: Path) -> None:
+    rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+    # Trying to use sync `with` should raise NotImplementedError
+    lock = rw_wrapper.read_lock
+    with pytest.raises(NotImplementedError, match="Do not use `with` for asyncio locks"), lock:
+        pass
+
+    lock = rw_wrapper.write_lock
+    with pytest.raises(NotImplementedError, match="Do not use `with` for asyncio locks"), lock:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_async_writer_priority_race_condition(tmp_path: Path) -> None:
+    """
+    Tests a scenario where multiple tasks attempt to read and write concurrently,
+    to ensure writer preference is maintained.
+    """
+
+    # Track how many readers and writers are active
+    active_readers = 0
+    active_writers = 0
+    lock = asyncio.Lock()  # to guard active_readers & active_writers
+
+    async def reader() -> None:
+        nonlocal active_readers, active_writers
+        rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+        read_lock = rw_wrapper.read_lock
+        async with read_lock:
+            async with lock:
+                active_readers += 1
+                # No writer should be active while reading
+                assert active_writers == 0
+            await asyncio.sleep(0.001)
+            async with lock:
+                active_readers -= 1
+
+    async def writer() -> None:
+        nonlocal active_readers, active_writers
+        rw_wrapper = AsyncReadWriteFileLockWrapper(lock_file=str(tmp_path / "test_rw"))
+        write_lock = rw_wrapper.write_lock
+        async with write_lock:
+            async with lock:
+                active_writers += 1
+                # No readers should be active while writing
+                assert active_readers == 0
+            await asyncio.sleep(0.002)
+            async with lock:
+                active_writers -= 1
+
+    tasks = []
+    tasks.extend(asyncio.create_task(reader()) for _ in range(5))
+    tasks.extend(asyncio.create_task(writer()) for _ in range(5))
+
+    # Shuffle tasks
+    random.shuffle(tasks)
+
+    await asyncio.gather(*tasks)
+
+    assert active_readers == 0
+    assert active_writers == 0

--- a/tests/test_read_write_filelock.py
+++ b/tests/test_read_write_filelock.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import threading
 import time
+from pathlib import Path
 from queue import Queue
 
 import pytest
@@ -10,10 +11,11 @@ from filelock.read_write import (
     BaseReadWriteFileLockWrapper,
     ReadWriteFileLockWrapper,
     ReadWriteMode,
+    has_read_write_lock,
 )
 
 
-@pytest.mark.skipif(not _has_read_write_lock, reason="ReadWriteFileLock is not available")
+@pytest.mark.skipif(not has_read_write_lock, reason="ReadWriteFileLock is not available")
 @pytest.mark.parametrize("lock_wrapper_type", [ReadWriteFileLockWrapper])
 def test_threaded_read_write_lock(
     lock_wrapper_type: type[BaseReadWriteFileLockWrapper], tmp_path: Path, ex_thread_cls: threading.Thread
@@ -79,7 +81,7 @@ def test_threaded_read_write_lock(
 
     should_proceed_event.set()
 
-    for thread in write_threads:
+    for _ in write_threads:
         is_ready_writers_queue.get()
         with num_writers_lock:
             assert num_writers in {0, 1}

--- a/tests/test_read_write_filelock.py
+++ b/tests/test_read_write_filelock.py
@@ -11,14 +11,14 @@ from filelock.read_write import (
     BaseReadWriteFileLockWrapper,
     ReadWriteFileLockWrapper,
     ReadWriteMode,
-    has_read_write_lock,
+    has_read_write_file_lock,
 )
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.skipif(not has_read_write_lock, reason="ReadWriteFileLock is not available")
+@pytest.mark.skipif(not has_read_write_file_lock, reason="ReadWriteFileLock is not available")
 @pytest.mark.parametrize("lock_wrapper_type", [ReadWriteFileLockWrapper])
 def test_threaded_read_write_lock(
     lock_wrapper_type: type[BaseReadWriteFileLockWrapper], tmp_path: Path, ex_thread_cls: threading.Thread

--- a/tests/test_read_write_filelock.py
+++ b/tests/test_read_write_filelock.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import threading
+import time
+from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Tuple, Type, Union
+from queue import Queue
+
+from filelock.read_write import BaseReadWriteFileLockWrapper, ReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
+
+_has_read_write_lock = ReadWriteFileLockWrapper is not _DisabledReadWriteFileLockWrapper
+
+
+@pytest.mark.skipif(not _has_read_write_lock, reason="ReadWriteFileLock is not available")
+@pytest.mark.parametrize("lock_wrapper_type", [ReadWriteFileLockWrapper])
+def test_threaded_read_write_lock(lock_wrapper_type: type[BaseReadWriteFileLockWrapper], tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
+    # Runs 100 reader and 10 writer threads.
+    # Ensure all readers can acquire the lock at the same time, while no writer can
+    # acquire the lock.
+    # Release all the readers and ensure only one writer can acquire the lock at the same time.
+    read_write_lock = lock_wrapper_type(str(tmp_path / "rw"))
+
+    num_readers = 0
+    num_readers_lock = threading.Lock()
+    num_writers = 0
+    num_writers_lock = threading.Lock()
+    is_ready_readers_queue = Queue()
+    is_ready_writers_queue = Queue()
+    should_proceed_event = threading.Event()
+    is_writer_ready_event = threading.Event()
+
+    def read_thread_work() -> None:
+        nonlocal num_readers
+        with read_write_lock(ReadWriteMode.READ):
+            assert read_write_lock(ReadWriteMode.READ).is_locked
+            with num_readers_lock:
+                num_readers += 1
+            is_ready_readers_queue.put_nowait(None)
+            should_proceed_event.wait()
+            with num_readers_lock:
+                num_readers -= 1
+
+    def write_thread_work() -> None:
+        nonlocal num_writers
+        is_writer_ready_event.set()
+        with read_write_lock(ReadWriteMode.WRITE):
+            assert read_write_lock(ReadWriteMode.WRITE).is_locked
+            with num_writers_lock:
+                num_writers += 1
+            is_ready_writers_queue.put(1)
+            with num_writers_lock:
+                num_writers -= 1
+
+    read_threads = [ex_thread_cls(target=read_thread_work, name=f"rt{i}") for i in range(100)]
+    for thread in read_threads:
+        thread.start()
+
+    for thread in read_threads:
+        is_ready_readers_queue.get()
+
+    with num_readers_lock:
+        assert num_readers == len(read_threads)
+
+    write_threads = [ex_thread_cls(target=write_thread_work, name=f"wt{i}") for i in range(10)]
+    for thread in write_threads:
+        thread.start()
+
+    is_writer_ready_event.wait()
+
+    # Sleeps are not ideal...
+    time.sleep(0.1)
+    with num_writers_lock:
+        assert num_writers == 0
+    time.sleep(0.1)
+
+    should_proceed_event.set()
+
+    for thread in write_threads:
+        is_ready_writers_queue.get()
+        with num_writers_lock:
+            assert num_writers in [0, 1]
+
+    for thread in write_threads:
+        thread.join()
+
+    assert not read_write_lock(ReadWriteMode.READ).is_locked
+    assert not read_write_lock(ReadWriteMode.WRITE).is_locked
+    assert num_readers == 0
+    assert num_writers == 0

--- a/tests/test_read_write_filelock.py
+++ b/tests/test_read_write_filelock.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import threading
 import time
 from queue import Queue
+
 import pytest
 
 from filelock.read_write import (
     BaseReadWriteFileLockWrapper,
     ReadWriteFileLockWrapper,
     ReadWriteMode,
-    has_read_write_file_lock,
 )
 
 

--- a/tests/test_read_write_filelock.py
+++ b/tests/test_read_write_filelock.py
@@ -1,20 +1,23 @@
-import os
-import sys
+from __future__ import annotations
+
 import threading
 import time
-from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
-from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Tuple, Type, Union
 from queue import Queue
 
-from filelock.read_write import BaseReadWriteFileLockWrapper, ReadWriteFileLockWrapper, _DisabledReadWriteFileLockWrapper
+from filelock.read_write import (
+    BaseReadWriteFileLockWrapper,
+    ReadWriteFileLockWrapper,
+    _DisabledReadWriteFileLockWrapper,
+)
 
 _has_read_write_lock = ReadWriteFileLockWrapper is not _DisabledReadWriteFileLockWrapper
 
 
 @pytest.mark.skipif(not _has_read_write_lock, reason="ReadWriteFileLock is not available")
 @pytest.mark.parametrize("lock_wrapper_type", [ReadWriteFileLockWrapper])
-def test_threaded_read_write_lock(lock_wrapper_type: type[BaseReadWriteFileLockWrapper], tmp_path: Path, ex_thread_cls: threading.Thread) -> None:
+def test_threaded_read_write_lock(
+    lock_wrapper_type: type[BaseReadWriteFileLockWrapper], tmp_path: Path, ex_thread_cls: threading.Thread
+) -> None:
     # Runs 100 reader and 10 writer threads.
     # Ensure all readers can acquire the lock at the same time, while no writer can
     # acquire the lock.
@@ -79,7 +82,7 @@ def test_threaded_read_write_lock(lock_wrapper_type: type[BaseReadWriteFileLockW
     for thread in write_threads:
         is_ready_writers_queue.get()
         with num_writers_lock:
-            assert num_writers in [0, 1]
+            assert num_writers in {0, 1}
 
     for thread in write_threads:
         thread.join()

--- a/tests/test_read_write_filelock.py
+++ b/tests/test_read_write_filelock.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import threading
 import time
-from pathlib import Path
 from queue import Queue
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,6 +13,9 @@ from filelock.read_write import (
     ReadWriteMode,
     has_read_write_lock,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.skipif(not has_read_write_lock, reason="ReadWriteFileLock is not available")

--- a/tests/test_read_write_filelock.py
+++ b/tests/test_read_write_filelock.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import threading
 import time
 from queue import Queue
+import pytest
 
 from filelock.read_write import (
     BaseReadWriteFileLockWrapper,
     ReadWriteFileLockWrapper,
-    _DisabledReadWriteFileLockWrapper,
+    ReadWriteMode,
+    has_read_write_file_lock,
 )
-
-_has_read_write_lock = ReadWriteFileLockWrapper is not _DisabledReadWriteFileLockWrapper
 
 
 @pytest.mark.skipif(not _has_read_write_lock, reason="ReadWriteFileLock is not available")
@@ -59,7 +59,7 @@ def test_threaded_read_write_lock(
     for thread in read_threads:
         thread.start()
 
-    for thread in read_threads:
+    for _ in read_threads:
         is_ready_readers_queue.get()
 
     with num_readers_lock:


### PR DESCRIPTION
This PR adds a `ReadWriteFileLock` API and sync & async implementation (currently only for Unix. I don't know if this is possible on Windows). `ReadWriteFileLock` allows the caller to operate in either READ or WRITE mode. The lock can be held by multiple READers at the same time, but a WRITEr is guaranteed to have exclusive access to the lock (across both READers and WRITErs). The lock is writer-preferred by employing an outer and inner lock (with the outer serving as staging for acquiring the inner - this means the outer lock is much easier to acquire).

In reader case:
1. outer lock is acquired non-exclusively
2. inner lock is acquired non-exclusively
3. outer lock is released
4. work is done
5. inner lock is released

In writer case:
1. outer lock is acquired exclusively
2. inner lock is acquired exclusively
3. work is done
4. inner lock is released
5. outer lock is released

While this seems to be working well in practice, there are no actual guarantees of ordering and priority.

I am not firmly settled on the API. Other idea would be to roll wrapper functionality into the base class and provide `write_acquire` and `read_acquire` functions (though the context managers would get a bit trickier - one would need to do `with self.read_write_lock.read():` instead of simply `self.read_write_lock:` - as this doesn't allow specifying the mode)

Closes #307 