### PR TITLE
Support fcntl check on Emscripten

### DIFF
--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -26,6 +26,7 @@ if sys.platform == "win32":  # pragma: win32 cover
 else:  # pragma: win32 no cover
     try:
         import fcntl
+
         _ = (fcntl.lock, fcntl.LOCK_EX, fcntl.LOCK_NB, fcntl.LOCK_UN)
     except (ImportError, AttributeError):
         pass

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -26,7 +26,8 @@ if sys.platform == "win32":  # pragma: win32 cover
 else:  # pragma: win32 no cover
     try:
         import fcntl
-    except ImportError:
+        _ = (fcntl.lock, fcntl.LOCK_EX, fcntl.LOCK_NB, fcntl.LOCK_UN)
+    except (ImportError, AttributeError):
         pass
     else:
         has_fcntl = True

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -27,7 +27,7 @@ else:  # pragma: win32 no cover
     try:
         import fcntl
 
-        _ = (fcntl.lock, fcntl.LOCK_EX, fcntl.LOCK_NB, fcntl.LOCK_UN)
+        _ = (fcntl.flock, fcntl.LOCK_EX, fcntl.LOCK_NB, fcntl.LOCK_UN)
     except (ImportError, AttributeError):
         pass
     else:


### PR DESCRIPTION
In Pyodide/Emscripten, file locking is not (yet) supported (see e.g. https://github.com/pyodide/pyodide/discussions/4150#discussioncomment-7026664).

This PR extends the `fcntl` import check to also test whether the locking APIs are available, so that the soft locking fallback can be used if they are not. As a result, the `filelock` package becomes usable in Pyodide/Emscripten.