### PR TITLE
add 3.14t (free threading) to matrix

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - "3.14t"
           - "3.14"
           - "3.13"
           - "3.12"


### PR DESCRIPTION
Free Threading is added to https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779

Per #431, 3.14 was added to the test matrix... but not the free threading "3.14t" build. 

This is a minimal change to check.yaml to increase the matrix.

I didn't see any new errors so far, but will experiment / possibly propose new test cases in a separate PR. 