### PR TITLE
Increase test coverage

### DIFF
--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -179,3 +179,75 @@ async def test_coroutine_function(tmp_path: Path) -> None:
     await lock.release()
     assert acquired
     assert released
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_wait_message_logged(lock_type: type[BaseAsyncFileLock], tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG)
+    lock_path = tmp_path / "a"
+    first_lock = lock_type(str(lock_path))
+    second_lock = lock_type(str(lock_path), timeout=0.2)
+
+    # Hold the lock so second_lock has to wait
+    await first_lock.acquire()
+    with pytest.raises(Timeout):
+        await second_lock.acquire()
+    assert any("waiting" in msg for msg in caplog.messages)
+
+@pytest.mark.parametrize("lock_type", [AsyncSoftFileLock, AsyncFileLock])
+@pytest.mark.asyncio
+async def test_attempting_to_acquire_branch(lock_type, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    lock = lock_type(str(tmp_path / "a"))
+    await lock.acquire()
+    assert any("Attempting to acquire lock" in m for m in caplog.messages)
+    await lock.release()
+
+@pytest.mark.asyncio
+async def test_thread_local_run_in_executor(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="run_in_executor is not supported when thread_local is True"):
+        AsyncSoftFileLock(str(tmp_path / "a"), thread_local=True, run_in_executor=True)
+
+@pytest.mark.parametrize("lock_type", [AsyncSoftFileLock, AsyncFileLock])
+@pytest.mark.asyncio
+async def test_attempting_to_acquire(lock_type, tmp_path, caplog):
+    caplog.set_level(logging.DEBUG)
+    lock = lock_type(str(tmp_path / "a.lock"), run_in_executor=False)
+    await lock.acquire(timeout=0.1)  # starts unlocked → hits the branch
+    assert any("Attempting to acquire lock" in m for m in caplog.messages)
+    await lock.release()
+
+
+@pytest.mark.parametrize("lock_type", [AsyncSoftFileLock, AsyncFileLock])
+@pytest.mark.asyncio
+async def test_attempting_to_release(lock_type, tmp_path, caplog):
+    caplog.set_level(logging.DEBUG)
+    lock = lock_type(str(tmp_path / "a.lock"), run_in_executor=False)
+
+    await lock.acquire(timeout=0.1)   # lock_counter = 1, is_locked = True
+    await lock.acquire(timeout=0.1)   # lock_counter = 2 (reentrant)
+    await lock.release(force=True)    # hits: if self._context.lock_counter == 0 or force:
+
+    assert any("Attempting to release lock" in m for m in caplog.messages)
+    assert any("released" in m for m in caplog.messages)
+
+@pytest.mark.parametrize("lock_type",[AsyncFileLock,AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_release_early_exit_when_unlocked(lock_type,tmp_path): 
+    lock=lock_type(str(tmp_path/"a.lock"),run_in_executor=False)
+    assert not lock.is_locked
+    await lock.release()
+    assert not lock.is_locked
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_release_nonzero_counter_exit(lock_type, tmp_path, caplog):
+    caplog.set_level(logging.DEBUG)
+    lock = lock_type(str(tmp_path / "a.lock"), run_in_executor=False)
+    await lock.acquire()
+    await lock.acquire()
+    await lock.release()  # counter goes 2→1
+    assert lock.lock_counter == 1 and lock.is_locked and not any("Attempting to release" in m for m in caplog.messages)
+    await lock.release()

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -197,7 +197,7 @@ async def test_wait_message_logged(lock_type: type[BaseAsyncFileLock], tmp_path:
 
 @pytest.mark.parametrize("lock_type", [AsyncSoftFileLock, AsyncFileLock])
 @pytest.mark.asyncio
-async def test_attempting_to_acquire_branch(lock_type, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+async def test_attempting_to_acquire_branch(lock_type: type[BaseAsyncFileLock], tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
 
     lock = lock_type(str(tmp_path / "a"))
@@ -212,23 +212,23 @@ async def test_thread_local_run_in_executor(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("lock_type", [AsyncSoftFileLock, AsyncFileLock])
 @pytest.mark.asyncio
-async def test_attempting_to_acquire(lock_type, tmp_path, caplog):
+async def test_attempting_to_acquire(lock_type: type[BaseAsyncFileLock], tmp_path, caplog):
     caplog.set_level(logging.DEBUG)
     lock = lock_type(str(tmp_path / "a.lock"), run_in_executor=False)
-    await lock.acquire(timeout=0.1)  # starts unlocked → hits the branch
+    await lock.acquire(timeout=0.1)
     assert any("Attempting to acquire lock" in m for m in caplog.messages)
     await lock.release()
 
 
 @pytest.mark.parametrize("lock_type", [AsyncSoftFileLock, AsyncFileLock])
 @pytest.mark.asyncio
-async def test_attempting_to_release(lock_type, tmp_path, caplog):
+async def test_attempting_to_release(lock_type: type[BaseAsyncFileLock], tmp_path, caplog):
     caplog.set_level(logging.DEBUG)
     lock = lock_type(str(tmp_path / "a.lock"), run_in_executor=False)
 
     await lock.acquire(timeout=0.1)   # lock_counter = 1, is_locked = True
     await lock.acquire(timeout=0.1)   # lock_counter = 2 (reentrant)
-    await lock.release(force=True)    # hits: if self._context.lock_counter == 0 or force:
+    await lock.release(force=True)
 
     assert any("Attempting to release lock" in m for m in caplog.messages)
     assert any("released" in m for m in caplog.messages)
@@ -243,7 +243,7 @@ async def test_release_early_exit_when_unlocked(lock_type,tmp_path):
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio
-async def test_release_nonzero_counter_exit(lock_type, tmp_path, caplog):
+async def test_release_nonzero_counter_exit(lock_type: type[BaseAsyncFileLock], tmp_path, caplog):
     caplog.set_level(logging.DEBUG)
     lock = lock_type(str(tmp_path / "a.lock"), run_in_executor=False)
     await lock.acquire()

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -821,7 +821,7 @@ def test_file_lock_positional_argument(tmp_path: Path) -> None:
     ("lock_type", "expected_exc"),
     [
         (SoftFileLock, TimeoutError),
-        (FileLock, PermissionError),
+        (FileLock, TimeoutError) if sys.platform == "win32" else (FileLock, PermissionError)
     ],
 )
 def test_mtime_zero_exit_branch(

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import inspect
 import logging
 import os
+import stat
 import sys
 import threading
+import types
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from errno import ENOSYS
@@ -15,11 +17,18 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, Callable, Union
 from uuid import uuid4
 from weakref import WeakValueDictionary
-import sys, stat, types, pytest
 
 import pytest
 
-from filelock import BaseFileLock, FileLock, SoftFileLock, Timeout, UnixFileLock, WindowsFileLock, _util
+from filelock import (
+    BaseFileLock,
+    FileLock,
+    SoftFileLock,
+    Timeout,
+    UnixFileLock,
+    WindowsFileLock,
+    _util,  # noqa: PLC2701
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -693,7 +702,7 @@ def test_subclass_compatibility(tmp_path: Path) -> None:
             **kwargs: dict[str, Any],  # noqa: ARG002
         ) -> None:
             super().__init__(lock_file, timeout, mode, thread_local, is_singleton=True)
-            self.blocking=True
+            self.blocking = True
             self.my_param = my_param
 
     lock_path = tmp_path / "a"
@@ -818,8 +827,7 @@ def test_file_lock_positional_argument(tmp_path: Path) -> None:
     assert lock.lock_file == str(lock_path) + ".lock"
 
 
-def test_raise_on_not_writable_file_branches(monkeypatch: pytest.MonkeyPatch):
-
+def test_raise_on_not_writable_file_branches(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_stat(mode: int, mtime: int = 1) -> types.SimpleNamespace:
         return types.SimpleNamespace(st_mtime=mtime, st_mode=mode)
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -818,7 +818,7 @@ def test_file_lock_positional_argument(tmp_path: Path) -> None:
     assert lock.lock_file == str(lock_path) + ".lock"
 
 
-def test_raise_on_not_writable_file_branches(monkeypatch):
+def test_raise_on_not_writable_file_branches(monkeypatch: pytest.MonkeyPatch):
 
     def fake_stat(mode: int, mtime: int = 1) -> types.SimpleNamespace:
         return types.SimpleNamespace(st_mtime=mtime, st_mode=mode)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -821,7 +821,7 @@ def test_file_lock_positional_argument(tmp_path: Path) -> None:
     ("lock_type", "expected_exc"),
     [
         (SoftFileLock, TimeoutError),
-        (FileLock, TimeoutError) if sys.platform == "win32" else (FileLock, PermissionError)
+        (FileLock, TimeoutError) if sys.platform == "win32" else (FileLock, PermissionError),
     ],
 )
 def test_mtime_zero_exit_branch(


### PR DESCRIPTION
While doing a little work testing 3.14/3.14t, added a few test cases to close a few uncovered branches:

The remaining gaps are for testing has_fnctl, which I'm not sure can ever occur on most OS's, since Windows already has a separate path for the Windows case. 

## Before
```
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
src/filelock/__init__.py      22      4      2      1    79%   41-44
src/filelock/_api.py         144      1     28      0    99%   237
src/filelock/_unix.py         38      2      4      0    95%   31-32
src/filelock/_util.py         19      0      4      1    96%   26->exit
src/filelock/asyncio.py      109      5     22      5    92%   86-87, 215->218, 229->232, 241-243, 260->exit
----------------------------------------------------------------------
TOTAL                       1038     12     82      7    98%
```

## After
```
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
src/filelock/__init__.py      22      4      2      1    79%   41-44
src/filelock/_unix.py         38      2      4      0    95%   31-32
----------------------------------------------------------------------
TOTAL                       1115      6     84      1    99%
```