### PR TITLE
Support Unix systems without O_NOFOLLOW

### DIFF
--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -38,7 +38,10 @@ else:  # pragma: win32 no cover
 
         def _acquire(self) -> None:
             ensure_directory_exists(self.lock_file)
-            open_flags = os.O_RDWR | os.O_TRUNC | os.O_NOFOLLOW
+            open_flags = os.O_RDWR | os.O_TRUNC
+            o_nofollow = getattr(os, "O_NOFOLLOW", None)
+            if o_nofollow is not None:
+                open_flags |= o_nofollow
             if not Path(self.lock_file).exists():
                 open_flags |= os.O_CREAT
             fd = os.open(self.lock_file, open_flags, self._context.mode)


### PR DESCRIPTION
Acquiring a lock uses the `O_NOFOLLOW` flag when calling `open`. However, this flag is not available on all platforms, such as GraalPy, causing an `AttributeError` to be raised when attempting to acquire a lock. According to the Python docs:

> The above constants are extensions and not present if they are not defined by the C library.

This handles such platforms by checking for the presence of the `O_NOFOLLOW` flag first.