### PR TITLE
Fix TOCTOU symlink vulnerability in SoftFileLock

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -216,6 +216,22 @@ The :class:`SoftFileLock <filelock.SoftFileLock>` only watches the existence of 
 portable, but also more prone to dead locks if the application crashes. You can simply delete the lock file in such
 cases.
 
+.. warning::
+
+   **Security Consideration - TOCTOU Vulnerability**: On platforms without ``O_NOFOLLOW`` support
+   (such as GraalPy), :class:`SoftFileLock <filelock.SoftFileLock>` may be vulnerable to symlink-based
+   Time-of-Check-Time-of-Use (TOCTOU) attacks. An attacker with local filesystem access could create
+   a symlink at the lock file path during the small race window between permission validation and file
+   creation.
+
+   On most modern platforms with ``O_NOFOLLOW`` support, this vulnerability is mitigated by refusing
+   to follow symlinks when creating the lock file.
+
+   For security-sensitive applications, prefer :class:`UnixFileLock <filelock.UnixFileLock>` or
+   :class:`WindowsFileLock <filelock.WindowsFileLock>` which provide stronger guarantees via OS-level
+   file locking. :class:`SoftFileLock <filelock.SoftFileLock>` should only be used as a fallback mechanism
+   on platforms where OS-level locking primitives are unavailable.
+
 Asyncio support
 ---------------
 


### PR DESCRIPTION
Fix TOCTOU symlink vulnerability in SoftFileLock by adding O_NOFOLLOW flag protection.

## Vulnerability Details

A Time-of-Check-Time-of-Use (TOCTOU) race condition vulnerability existed in SoftFileLock._acquire() between the permission check and the actual file creation. An attacker with local filesystem access could create a symlink at the lock path during this window, causing the lock to operate on an unintended target file.

**Attack scenario:**
1. `raise_on_not_writable_file()` validates permissions
2. **RACE WINDOW** - attacker creates symlink
3. `os.open()` tries to open lock path
4. Without O_NOFOLLOW: symlink is followed, lock operates on wrong file
5. With O_NOFOLLOW: symlink is rejected, attack prevented

**Attack requirements:**
- Local filesystem access
- Permission to create symlinks (normal for regular users)

## Changes Made

**Add conditional O_NOFOLLOW flag:**
- Pattern used: `o_nofollow = getattr(os, "O_NOFOLLOW", None)`
- Same approach as UnixFileLock (commit 5088854)
- Gracefully degrades on platforms without O_NOFOLLOW (e.g., GraalPy)

**Documentation update:**
- Added security warning about TOCTOU vulnerability
- Explains protection on platforms with O_NOFOLLOW
- Recommends UnixFileLock/WindowsFileLock for security-sensitive applications

## Why This Fix is Safe

The pre-check (`raise_on_not_writable_file`) is safe from TOCTOU itself because:
- It only reads metadata via `os.stat()` (doesn't follow symlinks for checking)
- The attack only works if a symlink is **followed** by a write operation
- By preventing symlink following in `os.open()` with O_NOFOLLOW, we block the attack even if the symlink is created during the race window


## Security Improvement

| Platform | O_NOFOLLOW Support | Result |
|----------|-------------------|--------|
| Most modern systems | ✅ Yes | Symlink attacks completely prevented |
| Rare platforms (GraalPy) | ❌ No | TOCTOU window remains but documented |

## Related

- Similar to CVE-2025-68146 (fixed for UnixFileLock/WindowsFileLock in commit 4724d7f)
- Reported by George Tsigourakos (@tsigouris007)