### PR TITLE
👷 ci(release): persist changelog on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,8 @@ env:
   dists-artifact-name: python-package-distributions
 
 jobs:
-  bump:
-    name: 🔖 bump
+  build:
+    name: 📦 build
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
@@ -52,21 +52,9 @@ jobs:
           github.event.pull_request.base.sha }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build:
-    name: 📦 build
-    needs: [bump]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: 🔄 Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
       - name: 🏷️ Create temporary tag for hatch-vcs
         if: github.event.inputs.release != 'no' && github.event.inputs.release != null
-        run: git tag '${{ needs.bump.outputs.version }}'
+        run: git tag '${{ steps.v.outputs.version }}'
       - name: 📦 Build package
         run: uv build --python 3.14 --python-preference only-managed --sdist --wheel . --out-dir dist
       - name: 📤 Store the distribution packages
@@ -77,12 +65,12 @@ jobs:
 
   release:
     name: 🚀 release
-    needs: [bump, build]
+    needs: [build]
     if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     environment:
       name: release
-      url: https://pypi.org/project/filelock/${{ needs.bump.outputs.version }}
+      url: https://pypi.org/project/filelock/${{ needs.build.outputs.version }}
     permissions:
       id-token: write
       contents: write
@@ -104,25 +92,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          git tag '${{ needs.bump.outputs.version }}'
+          git tag '${{ needs.build.outputs.version }}'
           git push --tags
-          gh release create '${{ needs.bump.outputs.version }}' \
-            --title='${{ needs.bump.outputs.version }}' --verify-tag \
+          gh release create '${{ needs.build.outputs.version }}' \
+            --title='${{ needs.build.outputs.version }}' --verify-tag \
             --notes "$(cat << 'EOM'
-          ${{ needs.bump.outputs.changelog }}
+          ${{ needs.build.outputs.changelog }}
           EOM
           )"
-
-  all-pass:
-    name: ✅ release
-    if: always()
-    needs: [bump, build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Decide whether all jobs passed or were skipped
-        run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "Some jobs failed or were canceled"
-            exit 1
-          fi
-          echo "All jobs passed or were skipped"


### PR DESCRIPTION
The release workflow generated changelog entries but only passed them as GitHub release notes text, never writing them back to `docs/changelog.rst`. This meant the in-repo changelog had to be maintained manually and could drift from actual releases.

The release job now prepends the new version entry to `docs/changelog.rst`, commits attributed to the actor who triggered the workflow, and pushes the commit along with the version tag before publishing to PyPI. 📝 The changelog script reads the excluded authors list from `.github/release.yml` instead of hardcoding bot names, keeping it in sync with GitHub's own release notes configuration.

On PyPy, SQLite `Cursor.__del__` can fire during pytest's session teardown path resolution, causing a segfault. Explicitly closing all SQLite connections in `pytest_sessionfinish` prevents this by ensuring no cursors remain for GC to collect at an unsafe time.

⚠️ The `RELEASE_TOKEN` PAT must belong to a repo admin to bypass branch protection when pushing the changelog commit back to `main`.