### PR TITLE
👷 ci(release): commit changelog and use release config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,6 +79,21 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
+      - name: 📝 Update changelog
+        run: |
+          version='${{ needs.build.outputs.version }}'
+          date=$(date -u +%Y-%m-%d)
+          entry="$version ($date)\n$(printf '%0.s-' $(seq 1 ${#version}) $(seq 1 ${#date}) - - - -)\n${{ needs.build.outputs.changelog }}"
+          awk -v entry="$entry" 'NR==3{print entry; print ""}1' docs/changelog.rst > docs/changelog.tmp
+          mv docs/changelog.tmp docs/changelog.rst
+      - name: 📤 Commit changelog and tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git add docs/changelog.rst
+          git commit -m 'Release ${{ needs.build.outputs.version }}'
+          git tag '${{ needs.build.outputs.version }}'
+          git push --follow-tags
       - name: ⬇️ Download all the dists
         uses: actions/download-artifact@v7
         with:
@@ -92,8 +107,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          git tag '${{ needs.build.outputs.version }}'
-          git push --tags
           gh release create '${{ needs.build.outputs.version }}' \
             --title='${{ needs.build.outputs.version }}' --verify-tag \
             --notes "$(cat << 'EOM'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ pkg-meta = [
 release = [
   "gitpython>=3.1.46",
   "pygithub>=2.8.1",
+  "pyyaml>=6.0.3",
 ]
 
 [tool.hatch]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from filelock._read_write import _cleanup_connections
+
+
+def pytest_sessionfinish() -> None:
+    _cleanup_connections()


### PR DESCRIPTION
The release workflow generated changelog text but never persisted it
to docs/changelog.rst, so the repo changelog was always stale.

The release job now updates the changelog file, commits as the
actor who triggered the release, tags, and pushes before publishing.
The changelog script reads excluded authors from .github/release.yml
instead of hardcoding bot names.
