### PR TITLE
🐛 fix: gracefully handle missing `sqlite3` when importing `ReadWriteLock`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -236,7 +236,8 @@ This library provides several lock implementations. Pick the one that matches yo
 
   *Limitations*: higher overhead than ``FileLock`` due to SQLite transactions. Creates a ``.db`` file on disk.
   No async variant. Cannot upgrade a read lock to a write lock (or vice versa). May not work on network filesystems
-  where SQLite locking is unreliable.
+  where SQLite locking is unreliable. Requires the ``sqlite3`` standard library module (unavailable if Python was built
+  without SQLite support).
 
 .. warning::
 
@@ -264,6 +265,11 @@ transactions. Multiple processes can hold a read lock simultaneously, but a writ
 of :class:`FileLock <filelock.FileLock>` when your workload is read-heavy and you want readers to proceed without
 blocking each other. If you only need exclusive locking, prefer :class:`FileLock <filelock.FileLock>` -- it is
 lighter and faster.
+
+.. note::
+
+   :class:`ReadWriteLock <filelock.ReadWriteLock>` requires the ``sqlite3`` standard library module. If Python was built
+   without SQLite support, importing ``ReadWriteLock`` from ``filelock`` will return ``None``.
 
 Use the ``read_lock()`` and ``write_lock()`` context managers for the most common pattern:
 

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -14,7 +14,12 @@ from typing import TYPE_CHECKING
 
 from ._api import AcquireReturnProxy, BaseFileLock
 from ._error import Timeout
-from ._read_write import ReadWriteLock
+
+try:
+    from ._read_write import ReadWriteLock
+except ModuleNotFoundError:  # sqlite3 may be unavailable if Python was built without it
+    ReadWriteLock = None  # type: ignore[assignment, misc]
+
 from ._soft import SoftFileLock
 from ._unix import UnixFileLock, has_fcntl
 from ._windows import WindowsFileLock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from filelock._read_write import _cleanup_connections
+try:
+    from filelock._read_write import _cleanup_connections
+except ModuleNotFoundError:
+    _cleanup_connections = None  # type: ignore[assignment, misc]
 
 
 def pytest_sessionfinish() -> None:
-    _cleanup_connections()
+    if _cleanup_connections is not None:
+        _cleanup_connections()

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Literal
 
 import pytest
 
+pytest.importorskip("sqlite3")
+
 from filelock import Timeout
 from filelock._read_write import ReadWriteLock
 

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-import sqlite3
 import threading
 from typing import TYPE_CHECKING, Literal
 
 import pytest
+
+pytest.importorskip("sqlite3")
+
+import sqlite3
 
 from filelock import Timeout
 from filelock._read_write import (


### PR DESCRIPTION
`filelock 3.21.0` added `ReadWriteLock` backed by SQLite and imported it unconditionally in `__init__.py`. This broke `import filelock` on Python installations where `_sqlite3` was not compiled (e.g. pyenv-built Python without `libsqlite3-dev`), even when `ReadWriteLock` was never used.

Wrap the import in a try/except so that `ReadWriteLock` is set to `None` when `sqlite3` is unavailable, allowing all other lock types to work as before.