### PR TITLE
🐛 fix: catch ImportError for missing sqlite3 C library

### DIFF
--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -17,7 +17,7 @@ from ._error import Timeout
 
 try:
     from ._read_write import ReadWriteLock
-except ModuleNotFoundError:  # sqlite3 may be unavailable if Python was built without it
+except ImportError:  # sqlite3 may be unavailable if Python was built without it or the C library is missing
     ReadWriteLock = None  # type: ignore[assignment, misc]
 
 from ._soft import SoftFileLock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 try:
     from filelock._read_write import _cleanup_connections
-except ModuleNotFoundError:
+except ImportError:
     _cleanup_connections = None  # type: ignore[assignment, misc]
 
 


### PR DESCRIPTION
The fix in #473 caught `ModuleNotFoundError` when importing `ReadWriteLock`, which handles the case where the Python `sqlite3` module is entirely absent. However, in minimal Docker images (e.g. `ubuntu-noble` with Python 3.11), the Python `sqlite3` package exists under `/usr/local/lib/python3.11/sqlite3/` but the underlying C shared library `libsqlite3.so.0` is missing. This raises `ImportError`, not `ModuleNotFoundError`, so the guard didn't catch it and `import filelock` still crashed.

Since `ModuleNotFoundError` is a subclass of `ImportError`, catching the parent class handles both scenarios — missing Python module and missing C library — without any change in behavior for environments where `sqlite3` works normally.

Fixes #474