### PR TITLE
✨ feat(soft): detect and break stale locks

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -228,8 +228,13 @@ This library provides several lock implementations. Pick the one that matches yo
   network mounts where OS-level locking may be unavailable. Async variant:
   :class:`AsyncSoftFileLock <filelock.AsyncSoftFileLock>`.
 
-  *Limitations*: if the process crashes without releasing the lock the stale lock file remains and must be deleted
-  manually. Exclusive only. See the TOCTOU warning below.
+  The lock file stores the holder's PID and hostname. When a competing process finds an existing lock, it checks whether
+  the holder is still alive (same host only). If the holding process has died, the stale lock is automatically broken
+  via an atomic rename-and-delete sequence. Stale locks from a different host, or lock files with unrecognized content
+  (e.g. from an older version), are left untouched and fall back to the normal retry/timeout behavior.
+
+  *Limitations*: stale lock detection only works when the holder and competitor are on the same host -- cross-host stale
+  locks still require manual removal. Exclusive only. See the TOCTOU warning below.
 
 - :class:`ReadWriteLock <filelock.ReadWriteLock>` -- shared reads / exclusive writes via SQLite. Use this when you need
   concurrent readers with occasional writers. See :ref:`read-write-lock` below for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ ini_options.asyncio_default_fixture_loop_scope = "session"
 ini_options.testpaths = [
   "tests",
 ]
+ini_options.timeout = 20
 ini_options.verbosity_assertions = 2
 ini_options.filterwarnings = [
   "error",

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import socket
 import sys
+import time
 from errno import ENODEV, EPERM, ESRCH
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,6 +20,12 @@ if TYPE_CHECKING:
 unix_only = pytest.mark.skipif(sys.platform == "win32", reason="uses os.kill for process liveness check")
 
 
+def _make_stale(path: Path) -> None:
+    """Backdate lock file mtime so stale detection considers it old enough to probe."""
+    old_time = time.time() - SoftFileLock._STALE_LOCK_MIN_AGE - 1
+    os.utime(path, (old_time, old_time))
+
+
 def test_lock_writes_pid_and_hostname(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock = SoftFileLock(lock_path)
@@ -32,6 +39,7 @@ def test_stale_lock_broken_when_process_dead(tmp_path: Path, mocker: MockerFixtu
     lock_path = tmp_path / "test.lock"
     dead_pid = 2**22 + 1
     lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n", encoding="utf-8")
+    _make_stale(lock_path)
 
     mocker.patch("filelock._soft.os.kill", side_effect=OSError(ESRCH, "No such process"))
 
@@ -43,6 +51,7 @@ def test_stale_lock_broken_when_process_dead(tmp_path: Path, mocker: MockerFixtu
 def test_stale_lock_not_broken_when_process_alive(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
+    _make_stale(lock_path)
 
     lock = SoftFileLock(lock_path, timeout=0.1)
     with pytest.raises(TimeoutError):
@@ -53,6 +62,7 @@ def test_stale_lock_not_broken_different_hostname(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     dead_pid = 2**22 + 1
     lock_path.write_text(f"{dead_pid}\nother-host.example.com\n", encoding="utf-8")
+    _make_stale(lock_path)
 
     lock = SoftFileLock(lock_path, timeout=0.1)
     with pytest.raises(TimeoutError):
@@ -63,6 +73,7 @@ def test_stale_lock_not_broken_different_hostname(tmp_path: Path) -> None:
 def test_stale_lock_not_broken_when_eperm(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text(f"{99999}\n{socket.gethostname()}\n", encoding="utf-8")
+    _make_stale(lock_path)
 
     mocker.patch("filelock._soft.os.kill", side_effect=OSError(EPERM, "Operation not permitted"))
 
@@ -74,6 +85,7 @@ def test_stale_lock_not_broken_when_eperm(tmp_path: Path, mocker: MockerFixture)
 def test_stale_lock_empty_file_ignored(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text("", encoding="utf-8")
+    _make_stale(lock_path)
 
     lock = SoftFileLock(lock_path, timeout=0.1)
     with pytest.raises(TimeoutError):
@@ -83,6 +95,7 @@ def test_stale_lock_empty_file_ignored(tmp_path: Path) -> None:
 def test_stale_lock_malformed_content_ignored(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text("not-a-pid\n", encoding="utf-8")
+    _make_stale(lock_path)
 
     lock = SoftFileLock(lock_path, timeout=0.1)
     with pytest.raises(TimeoutError):
@@ -94,6 +107,7 @@ def test_stale_lock_rename_race(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     dead_pid = 2**22 + 1
     lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n", encoding="utf-8")
+    _make_stale(lock_path)
 
     mocker.patch("filelock._soft.os.kill", side_effect=OSError(ESRCH, "No such process"))
     mocker.patch.object(Path, "rename", side_effect=FileNotFoundError("already gone"))
@@ -107,6 +121,7 @@ def test_stale_lock_rename_race(tmp_path: Path, mocker: MockerFixture) -> None:
 def test_stale_lock_unexpected_kill_error_suppressed(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text(f"{99999}\n{socket.gethostname()}\n", encoding="utf-8")
+    _make_stale(lock_path)
 
     mocker.patch("filelock._soft.os.kill", side_effect=OSError(ENODEV, "No such device"))
 
@@ -118,6 +133,7 @@ def test_stale_lock_unexpected_kill_error_suppressed(tmp_path: Path, mocker: Moc
 def test_stale_detection_errors_suppressed(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
+    _make_stale(lock_path)
 
     mock_read: MagicMock = mocker.patch.object(SoftFileLock, "_read_lock_info", side_effect=OSError("read failed"))
 
@@ -135,3 +151,13 @@ def test_write_lock_info_errors_suppressed(tmp_path: Path, mocker: MockerFixture
     with lock:
         assert lock.is_locked
         assert not lock_path.read_text(encoding="utf-8")
+
+
+def test_recent_lock_not_probed(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    dead_pid = 2**22 + 1
+    lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n", encoding="utf-8")
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -119,7 +119,7 @@ def test_stale_detection_errors_suppressed(tmp_path: Path, mocker: MockerFixture
     lock_path = tmp_path / "test.lock"
     lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
 
-    mock_read: MagicMock = mocker.patch.object(Path, "read_text", side_effect=OSError("read failed"))
+    mock_read: MagicMock = mocker.patch.object(SoftFileLock, "_read_lock_info", side_effect=OSError("read failed"))
 
     lock = SoftFileLock(lock_path, timeout=0.1)
     with pytest.raises(TimeoutError):

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+import socket
+from errno import EPERM, ESRCH
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import SoftFileLock
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+
+
+def test_lock_writes_pid_and_hostname(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock = SoftFileLock(lock_path)
+    with lock:
+        content = lock_path.read_text(encoding="utf-8")
+        assert content == f"{os.getpid()}\n{socket.gethostname()}\n"
+
+
+def test_stale_lock_broken_when_process_dead(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    dead_pid = 2**22 + 1
+    lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n", encoding="utf-8")
+
+    mocker.patch("filelock._soft.os.kill", side_effect=OSError(ESRCH, "No such process"))
+
+    lock = SoftFileLock(lock_path, timeout=1)
+    with lock:
+        assert lock.is_locked
+
+
+def test_stale_lock_not_broken_when_process_alive(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_stale_lock_not_broken_different_hostname(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    dead_pid = 2**22 + 1
+    lock_path.write_text(f"{dead_pid}\nother-host.example.com\n", encoding="utf-8")
+
+    mocker.patch("filelock._soft.os.kill", side_effect=OSError(ESRCH, "No such process"))
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_stale_lock_not_broken_when_eperm(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.write_text(f"{99999}\n{socket.gethostname()}\n", encoding="utf-8")
+
+    mocker.patch("filelock._soft.os.kill", side_effect=OSError(EPERM, "Operation not permitted"))
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_stale_lock_empty_file_ignored(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.write_text("", encoding="utf-8")
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_stale_lock_malformed_content_ignored(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.write_text("not-a-pid\n", encoding="utf-8")
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_stale_lock_rename_race(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    dead_pid = 2**22 + 1
+    lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n", encoding="utf-8")
+
+    mocker.patch("filelock._soft.os.kill", side_effect=OSError(ESRCH, "No such process"))
+    mocker.patch.object(Path, "rename", side_effect=FileNotFoundError("already gone"))
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_stale_detection_errors_suppressed(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
+
+    mock_read: MagicMock = mocker.patch.object(Path, "read_text", side_effect=OSError("read failed"))
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+    mock_read.assert_called()
+
+
+def test_write_lock_info_errors_suppressed(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    mocker.patch("filelock._soft.os.write", side_effect=OSError("write failed"))
+
+    lock = SoftFileLock(lock_path)
+    with lock:
+        assert lock.is_locked
+        assert not lock_path.read_text(encoding="utf-8")


### PR DESCRIPTION
When a process holding a `SoftFileLock` crashes, the lock file is left behind and blocks every other process forever.
This is especially painful on CI and in long-running daemons where manual cleanup is impractical.

The lock file now stores `{pid}\n{hostname}\n` on acquire. On contention (`EEXIST`), the competing process reads this
metadata, verifies the hostname matches, and probes whether the holding PID is still alive (`os.kill(pid, 0)` on Unix,
`OpenProcess(SYNCHRONIZE)` on Windows). If the holder is confirmed dead, the stale lock is broken via an atomic
`rename` + `unlink` sequence that avoids races between concurrent breakers.

Stale detection is **Unix/macOS only**. On Windows, Python's C runtime (`_wopen`) cannot set `FILE_SHARE_DELETE`, so
any read handle on the lock file blocks `DeleteFileW` during release -- causing a livelock under threaded contention.
Windows already distinguishes `EACCES` (holder alive, fd open) from `EEXIST` (file exists, no active holder), and in
practice `EEXIST` resolves quickly as the releasing thread deletes the file. Cross-host stale locks are also left
untouched since PID liveness cannot be verified remotely.