### PR TITLE
🐛 fix(soft): skip stale lock detection on Windows

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -228,13 +228,16 @@ This library provides several lock implementations. Pick the one that matches yo
   network mounts where OS-level locking may be unavailable. Async variant:
   :class:`AsyncSoftFileLock <filelock.AsyncSoftFileLock>`.
 
-  The lock file stores the holder's PID and hostname. When a competing process finds an existing lock, it checks whether
-  the holder is still alive (same host only). If the holding process has died, the stale lock is automatically broken
-  via an atomic rename-and-delete sequence. Stale locks from a different host, or lock files with unrecognized content
-  (e.g. from an older version), are left untouched and fall back to the normal retry/timeout behavior.
+  The lock file stores the holder's PID and hostname. On **Unix and macOS**, when a competing process finds an existing
+  lock, it checks whether the holder is still alive (same host only). If the holding process has died, the stale lock
+  is automatically broken via an atomic rename-and-delete sequence. Stale locks from a different host, or lock files
+  with unrecognized content (e.g. from an older version), are left untouched and fall back to the normal retry/timeout
+  behavior.
 
-  *Limitations*: stale lock detection only works when the holder and competitor are on the same host -- cross-host stale
-  locks still require manual removal. Exclusive only. See the TOCTOU warning below.
+  *Limitations*: stale lock detection is **not available on Windows** -- Python's C runtime (``_wopen``) cannot set
+  ``FILE_SHARE_DELETE``, so any read handle on the lock file blocks ``DeleteFileW`` in the release path, causing a
+  livelock under threaded contention. On Unix/macOS, stale detection only works when the holder and competitor are on
+  the same host -- cross-host stale locks still require manual removal. Exclusive only. See the TOCTOU warning below.
 
 - :class:`ReadWriteLock <filelock.ReadWriteLock>` -- shared reads / exclusive writes via SQLite. Use this when you need
   concurrent readers with occasional writers. See :ref:`read-write-lock` below for details.


### PR DESCRIPTION
The stale lock detection merged in #476 causes livelock on Windows under threaded contention. Python's C runtime (`_wopen`) cannot set `FILE_SHARE_DELETE`, so any read handle opened by `_try_break_stale_lock` blocks `DeleteFileW` in `_release`. With many threads competing, there is always at least one reader holding the lock file open, preventing deletion and orphaning the lock forever.

This removes the `CreateFileW`/`FILE_SHARE_DELETE` read path and the `_STALE_LOCK_MIN_AGE` mtime threshold — both were insufficient workarounds. Stale detection is now guarded with `sys.platform != "win32"` and only runs on Unix/macOS where `unlink()` succeeds regardless of open handles. On Windows, `EACCES` already signals the holder is alive (fd still open) and `EEXIST` resolves as the releasing thread deletes the file, so stale detection adds no value.

Docs updated to note the Windows limitation. Tests for stale detection are now marked `@unix_only`.

## Why stale detection is fundamentally broken on Windows

The issue comes down to how Windows file deletion works vs Unix:

- [`DeleteFileW`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-deletefilew) requires **all** existing handles to the file to have been opened with `FILE_SHARE_DELETE`. If any handle lacks this flag, deletion fails with `ERROR_SHARING_VIOLATION`.
- [`CreateFileW`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew) is the only Win32 API that allows setting `FILE_SHARE_DELETE` via `dwShareMode`.
- Python's `os.open()` uses the MSVC CRT [`_wopen`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen) which calls `CreateFileW` internally but [does not expose `FILE_SHARE_DELETE`](https://github.com/python/cpython/blob/main/Modules/_io/fileio.c) — it only sets `FILE_SHARE_READ | FILE_SHARE_WRITE`.
- Even using `CreateFileW` directly via `ctypes` with `FILE_SHARE_DELETE` for the **read** handle is insufficient: the **write** handle (from `os.open` in `_acquire`) also lacks `FILE_SHARE_DELETE`, so `DeleteFileW` still fails while the holder has the file open.
- Additionally, even when `DeleteFileW` succeeds with `FILE_SHARE_DELETE`, it only [marks the file for deletion](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-deletefilew#remarks) — the file name remains visible in the directory until the **last handle closes**. Python's `os.unlink()` uses standard `DeleteFileW`, not [`FileDispositionInfoEx` with `FILE_DISPOSITION_FLAG_POSIX_SEMANTICS`](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_file_disposition_information_ex) which would provide immediate name removal.

There is no `os.O_SHARE_DELETE` flag in Python 3.10–3.14, and no open CPython proposal to add one.

## Considered alternative: sidecar info file

A sidecar file approach (`{lock_file}.info`) would store PID/hostname separately so reading it doesn't block deletion of the lock file itself. This would work but was deemed not worth the complexity:

- Two files to manage per lock, with cleanup for both on release
- The `.info` file may be missing (crash between lock creation and info write) or stale — requiring graceful fallback
- More filesystem operations per acquire/release cycle
- `SoftFileLock` on Windows is a niche case — Windows normally uses `WindowsFileLock` (msvcrt) via the `FileLock` alias, so stale locks are primarily a Unix problem (CI systems, long-running daemons)

This can be revisited if there is demand for Windows stale detection.