### PR TITLE
🐛 fix(unix): auto-fallback to SoftFileLock on ENOSYS

### DIFF
--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -601,10 +601,13 @@ def test_wrong_platform(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="flock not run on windows")
+@pytest.mark.filterwarnings("default::UserWarning")
 def test_flock_not_implemented_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("fcntl.flock", side_effect=OSError(ENOSYS, "mock error"))
-    with pytest.raises(NotImplementedError), FileLock(tmp_path / "a.lock"):
-        pass
+    lock = FileLock(tmp_path / "a.lock")
+    with lock:
+        assert lock.is_locked
+        assert isinstance(lock, SoftFileLock)
 
 
 def test_soft_errors(tmp_path: Path, mocker: MockerFixture) -> None:

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from errno import ENOSYS
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import SoftFileLock, UnixFileLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+
+unix_only = pytest.mark.skipif(sys.platform == "win32", reason="unix-only flock fallback")
+_ENOSYS_SIDE_EFFECT = OSError(ENOSYS, "Function not implemented")
+_FLOCK_PATCH_TARGET = "filelock._unix.fcntl.flock"
+
+
+@unix_only
+def test_fallback_emits_warning(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+    lock = UnixFileLock(tmp_path / "test.lock")
+
+    with pytest.warns(UserWarning, match="flock not supported on this filesystem, falling back to SoftFileLock"):
+        lock.acquire()
+    lock.release()
+
+
+@unix_only
+@pytest.mark.filterwarnings("default::UserWarning")
+def test_fallback_swaps_to_soft(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+    lock = UnixFileLock(tmp_path / "test.lock")
+
+    with lock:
+        assert lock.is_locked
+        assert isinstance(lock, SoftFileLock)
+
+
+@unix_only
+@pytest.mark.filterwarnings("default::UserWarning")
+def test_fallback_writes_pid_and_hostname(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+    lock = UnixFileLock(lock_path)
+
+    with lock:
+        content = lock_path.read_text(encoding="utf-8")
+        assert content == f"{os.getpid()}\n{socket.gethostname()}\n"
+
+
+@unix_only
+@pytest.mark.filterwarnings("default::UserWarning")
+def test_fallback_release_unlinks_file(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+    lock = UnixFileLock(lock_path)
+
+    lock.acquire()
+    assert lock_path.exists()
+    lock.release()
+    assert not lock_path.exists()
+
+
+@unix_only
+@pytest.mark.filterwarnings("default::UserWarning")
+def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, mocker: MockerFixture) -> None:
+    flock_mock: MagicMock = mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+    lock = UnixFileLock(tmp_path / "test.lock")
+
+    lock.acquire()
+    lock.release()
+    flock_mock.reset_mock()
+
+    lock.acquire()
+    lock.release()
+    flock_mock.assert_not_called()
+
+
+@unix_only
+@pytest.mark.filterwarnings("default::UserWarning")
+def test_fallback_reentrant_locking(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+    lock = UnixFileLock(tmp_path / "test.lock")
+
+    with lock:
+        with lock:
+            assert lock.is_locked
+        assert lock.is_locked
+    assert not lock.is_locked


### PR DESCRIPTION
On platforms like Android/Termux and network filesystems (NFS, CIFS), `fcntl` imports fine but `flock()` fails at runtime with `ENOSYS`. 💥 Previously this raised `NotImplementedError`, leaving users no recourse except monkey-patching `filelock.FileLock = filelock.SoftFileLock` before any other import — fragile and easy to get wrong.

This catches `ENOSYS` in `UnixFileLock._acquire()`, cleans up the leftover lock file, and transparently swaps `self.__class__` to `SoftFileLock` (or `AsyncSoftFileLock` for async instances). Both classes share the same `BaseFileLock` layout with no extra instance state, so the swap is safe and preserves all context. ✨ Subsequent acquire/release cycles go straight through the soft path with no repeated `flock()` attempts.

The soft fallback relies on `O_CREAT | O_EXCL` which is [atomic on NFSv3+ with Linux kernel 2.6+](https://man7.org/linux/man-pages/man2/open.2.html) and [endorsed by CERT as secure against TOCTOU](https://wiki.sei.cmu.edu/confluence/display/c/FIO45-C.+Avoid+TOCTOU+race+conditions+while+accessing+files). Symlink attacks are mitigated by `O_NOFOLLOW` already used in `SoftFileLock._acquire()`. On Android/Termux the local filesystem (ext4/f2fs) provides full `O_EXCL` guarantees. The `__class__` swap is [validated by CPython's `compatible_for_assignment()`](https://github.com/python/cpython/blob/main/Objects/typeobject.c) when both types share the same base layout.

Fixes #289, fixes #349