### PR TITLE
✨ feat(lock): add poll_interval to constructor

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -192,6 +192,35 @@ You can pre-parametrize both of these options when constructing the lock for eas
     except Timeout:
         print("Ten seconds feel like forever sometimes.")
 
+Poll interval
+^^^^^^^^^^^^^
+
+When the lock cannot be acquired immediately, the :meth:`acquire <filelock.BaseFileLock.acquire>` method retries at a
+fixed interval. The ``poll_interval`` parameter controls how many seconds to wait between attempts (default ``0.05``).
+
+You can pass ``poll_interval`` directly to :meth:`acquire <filelock.BaseFileLock.acquire>`:
+
+.. code-block:: python
+
+    with lock.acquire(poll_interval=0.1):
+        with file_path.open("a") as file_handler:
+            file_handler.write("Patience you must have, my young Padawan.")
+
+Or set it on the constructor so that it applies when using the lock as a context manager:
+
+.. code-block:: python
+
+    lock = FileLock("high_ground.txt.lock", poll_interval=0.25)
+    with lock:
+        with file_path.open("a") as file_handler:
+            file_handler.write("This is where the fun begins.")
+
+The default can also be changed at any time via the :attr:`~filelock.BaseFileLock.poll_interval` property:
+
+.. code-block:: python
+
+    lock.poll_interval = 0.5
+
 Logging
 ^^^^^^^
 


### PR DESCRIPTION
When using `FileLock` as a context manager there was no way to control the retry interval — `__enter__` calls `acquire()` without arguments, so `poll_interval` was always hardcoded to `0.05` seconds. Users who needed a different interval had to avoid the context manager and call `acquire(poll_interval=...)` manually, which is less ergonomic and error-prone. See https://github.com/tox-dev/filelock/issues/400.

This adds `poll_interval` as a first-class constructor parameter, following the same pattern already established by `timeout` and `blocking`: the value is stored on `FileLockContext`, accepted in `__init__`, exposed via a read/write property, and used as the fallback in `acquire()` when `None` is passed. Both sync and async lock variants are updated consistently. 🔄 The default remains `0.05` so existing code is unaffected.

```python
lock = FileLock("my.lock", poll_interval=0.25)
with lock:
    ...
```

Singleton validation now also checks `poll_interval` for consistency, matching the existing behavior for `timeout`, `mode`, and `blocking`.

Closes https://github.com/tox-dev/filelock/issues/400