### PR TITLE
✨ feat(mode): respect POSIX default ACL inheritance

### DIFF
--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -39,7 +39,7 @@ class SoftFileLock(BaseFileLock):
         if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:
             flags |= o_nofollow
         try:
-            file_handler = os.open(self.lock_file, flags, self._context.mode)
+            file_handler = os.open(self.lock_file, flags, self._open_mode())
         except OSError as exception:  # re-raise unless expected exception
             if not (
                 exception.errno == EEXIST  # lock already exist

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -63,7 +63,7 @@ if sys.platform == "win32":  # pragma: win32 cover
                 | os.O_TRUNC  # truncate file if not empty
             )
             try:
-                fd = os.open(self.lock_file, flags, self._context.mode)
+                fd = os.open(self.lock_file, flags, self._open_mode())
             except OSError as exception:
                 if exception.errno != EACCES:  # has no access to this lock
                     raise

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -12,7 +12,7 @@ from inspect import iscoroutinefunction
 from threading import local
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
-from ._api import BaseFileLock, FileLockContext, FileLockMeta
+from ._api import _UNSET_FILE_MODE, BaseFileLock, FileLockContext, FileLockMeta
 from ._error import Timeout
 from ._soft import SoftFileLock
 from ._unix import UnixFileLock
@@ -74,7 +74,7 @@ class AsyncFileLockMeta(FileLockMeta):
         cls,  # noqa: N805
         lock_file: str | os.PathLike[str],
         timeout: float = -1,
-        mode: int = 0o644,
+        mode: int = _UNSET_FILE_MODE,
         thread_local: bool = False,  # noqa: FBT001, FBT002
         *,
         blocking: bool = True,
@@ -111,7 +111,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         self,
         lock_file: str | os.PathLike[str],
         timeout: float = -1,
-        mode: int = 0o644,
+        mode: int = _UNSET_FILE_MODE,
         thread_local: bool = False,  # noqa: FBT001, FBT002
         *,
         blocking: bool = True,
@@ -127,7 +127,8 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         :param timeout: default timeout when acquiring the lock, in seconds. It will be used as fallback value in
             the acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it
             to a negative value. A timeout of 0 means that there is exactly one attempt to acquire the file lock.
-        :param mode: file permissions for the lockfile
+        :param mode: file permissions for the lockfile. When not specified, the OS controls permissions via umask
+            and default ACLs, preserving POSIX default ACL inheritance in shared directories.
         :param thread_local: Whether this object's internal context should be thread local or not. If this is set
             to ``False`` then the lock will be reentrant across threads.
         :param blocking: whether the lock should be blocking or not

--- a/tests/test_default_mode.py
+++ b/tests/test_default_mode.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import os
+import sys
+from stat import filemode
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import FileLock, SoftFileLock
+from filelock._api import _UNSET_FILE_MODE, BaseFileLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_default_mode_property_returns_0o644(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock = lock_type(tmp_path / "a.lock")
+    assert lock.mode == 0o644
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_explicit_mode_property_returns_value(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock = lock_type(tmp_path / "a.lock", mode=0o600)
+    assert lock.mode == 0o600
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_has_explicit_mode_false_by_default(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock = lock_type(tmp_path / "a.lock")
+    assert lock.has_explicit_mode is False
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_has_explicit_mode_true_when_set(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock = lock_type(tmp_path / "a.lock", mode=0o644)
+    assert lock.has_explicit_mode is True
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_open_mode_returns_0o666_when_unset(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock = lock_type(tmp_path / "a.lock")
+    assert lock._open_mode() == 0o666
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_open_mode_returns_explicit_value(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock = lock_type(tmp_path / "a.lock", mode=0o600)
+    assert lock._open_mode() == 0o600
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows does not apply umask to file permissions")
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_default_mode_respects_umask(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock = lock_type(str(lock_path))
+
+    initial_umask = os.umask(0o022)
+    try:
+        lock.acquire()
+        assert lock.is_locked
+
+        mode = filemode(lock_path.stat().st_mode)
+        assert mode == "-rw-r--r--"
+    finally:
+        os.umask(initial_umask)
+
+    lock.release()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fchmod only on Unix")
+def test_default_mode_skips_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock = FileLock(str(lock_path))
+
+    fchmod_spy = mocker.patch("os.fchmod")
+    lock.acquire()
+    assert lock.is_locked
+    fchmod_spy.assert_not_called()
+    lock.release()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fchmod only on Unix")
+def test_explicit_mode_calls_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock = FileLock(str(lock_path), mode=0o644)
+
+    fchmod_spy = mocker.spy(os, "fchmod")
+    lock.acquire()
+    assert lock.is_locked
+    fchmod_spy.assert_called_once()
+    assert fchmod_spy.call_args[0][1] == 0o644
+    lock.release()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fchmod only on Unix")
+def test_explicit_mode_overrides_umask(tmp_path: Path) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock = FileLock(str(lock_path), mode=0o666)
+
+    initial_umask = os.umask(0o022)
+    try:
+        lock.acquire()
+        assert lock.is_locked
+
+        mode = filemode(lock_path.stat().st_mode)
+        assert mode == "-rw-rw-rw-"
+    finally:
+        os.umask(initial_umask)
+
+    lock.release()
+
+
+def test_singleton_default_mode_matches(tmp_path: Path) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock_1 = FileLock(str(lock_path), is_singleton=True)
+    lock_2 = FileLock(str(lock_path), is_singleton=True)
+    assert lock_1 is lock_2
+
+
+def test_singleton_explicit_mode_matches(tmp_path: Path) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock_1 = FileLock(str(lock_path), mode=0o600, is_singleton=True)
+    lock_2 = FileLock(str(lock_path), mode=0o600, is_singleton=True)
+    assert lock_1 is lock_2
+
+
+def test_singleton_default_vs_explicit_mode_differ(tmp_path: Path) -> None:
+    lock_path = tmp_path / "a.lock"
+    lock = FileLock(str(lock_path), is_singleton=True)
+    with pytest.raises(ValueError, match="mode"):
+        FileLock(str(lock_path), mode=0o644, is_singleton=True)
+    del lock
+
+
+def test_unset_file_mode_sentinel_value() -> None:
+    assert _UNSET_FILE_MODE == -1


### PR DESCRIPTION
When directories have default ACLs configured via `setfacl -d`, newly created files should inherit those permissions.
However, filelock's hardcoded `mode=0o644` passed to `os.open()` combined with an unconditional `os.fchmod()` call
were preventing this — the explicit mode overrides the OS permission machinery, stripping default ACL entries
entirely. This is a significant pain point in multi-user shared environments (e.g. HuggingFace `.cache` directories)
where one user's lock file becomes inaccessible to others, requiring manual deletion. 🔐

The fix introduces a sentinel default for the `mode` parameter. When no explicit mode is passed, lock files are now
created with `0o666` (the standard "let the OS decide" value) and `fchmod()` is skipped, allowing both umask and
default ACLs to control the final permissions naturally. When `mode` is explicitly set by the caller, the existing
behavior is fully preserved — the mode is passed to `os.open()` and enforced via `fchmod()`. ✨ This distinction is
tracked internally via a `_UNSET_FILE_MODE` sentinel so the `.mode` property still returns `0o644` for backward
compatibility.

For users without ACLs and a standard umask (`0o022`), file permissions are identical to before: `0o666 & ~0o022 =
0o644`. The only observable change is for users who have default ACLs configured — which is exactly the population
that needs this fix. Users in security-sensitive environments who want deterministic permissions can explicitly pass
`mode=0o644` to opt into the previous behavior. This approach avoids the thread-safety concerns from #204 since we
never manipulate `umask` — we simply stop overriding the kernel's decision.

Closes #378

See also: https://man7.org/linux/man-pages/man5/acl.5.html (POSIX ACL semantics — "OBJECT CREATION AND DEFAULT ACLs"
section covers how `open()` mode interacts with inherited ACL entries)