### PR TITLE
🐛 fix(win): eliminate lock file race in threaded usage

### DIFF
--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
-from contextlib import suppress
 from errno import EACCES
-from pathlib import Path
 from typing import cast
 
 from ._api import BaseFileLock
@@ -60,7 +58,6 @@ if sys.platform == "win32":  # pragma: win32 cover
             flags = (
                 os.O_RDWR  # open for read and write
                 | os.O_CREAT  # create file if not exists
-                | os.O_TRUNC  # truncate file if not empty
             )
             try:
                 fd = os.open(self.lock_file, flags, self._context.mode)
@@ -82,9 +79,6 @@ if sys.platform == "win32":  # pragma: win32 cover
             self._context.lock_file_fd = None
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
             os.close(fd)
-
-            with suppress(OSError):  # Probably another instance of the application hat acquired the file lock.
-                Path(self.lock_file).unlink()
 
 else:  # pragma: win32 no cover
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -266,7 +266,6 @@ def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path)
 def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     # Runs multiple threads, which acquire the same lock file with a different FileLock object. When thread group 1
     # acquired the lock, thread group 2 must not hold their lock.
-
     def t_1() -> None:
         for _ in range(1000):
             with lock_1:
@@ -841,7 +840,15 @@ def test_mtime_zero_exit_branch(
         lock.acquire(timeout=0)
 
 
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+@pytest.mark.parametrize(
+    "lock_type",
+    [
+        pytest.param(
+            FileLock, marks=pytest.mark.skipif(sys.platform == "win32", reason="Windows cannot unlink open files")
+        ),
+        SoftFileLock,
+    ],
+)
 def test_lock_file_removed_after_release(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     lock_path = tmp_path / "test.lock"
     lock = lock_type(str(lock_path))


### PR DESCRIPTION
The Windows threaded lock tests flake on CI because [`_release()`](https://github.com/tox-dev/filelock/blob/79ca84f47294f5da93284b51b66fde5da763cc84/src/filelock/_windows.py#L80-L87) calls `unlink()` after `close()`, but between those two calls another thread has already acquired an open handle via `os.open()`. Since CPython's `_wopen` doesn't set `FILE_SHARE_DELETE`, Windows refuses the deletion — and the suppressed `unlink()` just widens the race window for no benefit. On top of that, [`O_TRUNC` in `_acquire()`](https://github.com/tox-dev/filelock/blob/79ca84f47294f5da93284b51b66fde5da763cc84/src/filelock/_windows.py#L60-L64) maps to `CREATE_ALWAYS` in `CreateFileW`, which causes `EACCES` when truncating a file that other threads hold open, pushing contending threads into the retry loop at the `os.open` level rather than just at `msvcrt.locking`.

The fix removes `unlink()` from `_release()` entirely — the lock file persists on disk, but `_acquire()` already handles existing files via `O_CREAT`, and the base class documents that lock files are not automatically deleted. It also drops `O_TRUNC` from `_acquire()`, since lock file content is irrelevant; only the `msvcrt.locking` byte-range lock provides mutual exclusion. Without `O_TRUNC`, `O_RDWR | O_CREAT` maps to `OPEN_ALWAYS`, which opens without truncation and avoids the write-sharing conflict.

With both race conditions eliminated, the threaded tests no longer need reduced iteration counts on Windows and now run at full Unix-equivalent intensity (100×100 and 10×1000).