### PR TITLE
✨ feat(deadlock): detect and raise on same-thread cross-instance deadlock

### DIFF
--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -13,7 +13,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 from ._api import AcquireReturnProxy, BaseFileLock
-from ._error import Timeout
+from ._error import FileLockDeadlockError, Timeout
 
 try:
     from ._read_write import ReadWriteLock
@@ -68,6 +68,7 @@ __all__ = [
     "BaseAsyncFileLock",
     "BaseFileLock",
     "FileLock",
+    "FileLockDeadlockError",
     "ReadWriteLock",
     "SoftFileLock",
     "Timeout",

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -25,6 +25,33 @@ class Timeout(TimeoutError):  # noqa: N818
         return self._lock_file
 
 
+class FileLockDeadlockError(RuntimeError):
+    """Raised when acquiring a lock would deadlock the current thread."""
+
+    def __init__(self, lock_file: str) -> None:
+        super().__init__()
+        self._lock_file = lock_file
+
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        return self.__class__, (self._lock_file,)
+
+    def __str__(self) -> str:
+        return (
+            f"Acquiring lock on '{self._lock_file}' would deadlock: this file is already locked by another "
+            f"FileLock instance in the current thread. Use is_singleton=True to enable cross-instance reentrant "
+            f"locking, or reuse the existing FileLock object."
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.lock_file!r})"
+
+    @property
+    def lock_file(self) -> str:
+        """:return: The path of the file lock."""
+        return self._lock_file
+
+
 __all__ = [
+    "FileLockDeadlockError",
     "Timeout",
 ]

--- a/tests/test_deadlock.py
+++ b/tests/test_deadlock.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import os
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import (
+    AsyncFileLock,
+    AsyncSoftFileLock,
+    BaseAsyncFileLock,
+    BaseFileLock,
+    FileLock,
+    FileLockDeadlockError,
+    SoftFileLock,
+    Timeout,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_cross_instance_deadlock_detected(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path))
+    lock_2 = lock_type(str(lock_path))
+
+    with lock_1:
+        assert lock_1.is_locked
+        with pytest.raises(FileLockDeadlockError, match="would deadlock"):
+            lock_2.acquire(timeout=1)
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_same_instance_reentrant_still_works(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    with lock:
+        assert lock.is_locked
+        with lock:
+            assert lock.is_locked
+            assert lock.lock_counter == 2
+        assert lock.is_locked
+        assert lock.lock_counter == 1
+    assert not lock.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_singleton_avoids_deadlock(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path), is_singleton=True)
+    lock_2 = lock_type(str(lock_path), is_singleton=True)
+
+    assert lock_1 is lock_2
+
+    with lock_1, lock_2:
+        assert lock_1.is_locked
+        assert lock_1.lock_counter == 2
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_registry_cleanup_after_release(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path))
+    lock_2 = lock_type(str(lock_path))
+
+    lock_1.acquire()
+    lock_1.release()
+
+    lock_2.acquire()
+    assert lock_2.is_locked
+    lock_2.release()
+    assert not lock_2.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_registry_cleanup_after_force_release(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path))
+    lock_2 = lock_type(str(lock_path))
+
+    lock_1.acquire()
+    lock_1.acquire()
+    assert lock_1.lock_counter == 2
+
+    lock_1.release(force=True)
+    assert not lock_1.is_locked
+
+    lock_2.acquire()
+    assert lock_2.is_locked
+    lock_2.release()
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_realpath_detection(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    abs_path = str(tmp_path / "a.lock")
+    rel_path = os.path.relpath(abs_path, start=str(tmp_path.parent))
+    lock_1 = lock_type(abs_path)
+    lock_2 = lock_type(str(tmp_path.parent / rel_path))
+
+    with lock_1, pytest.raises(FileLockDeadlockError):
+        lock_2.acquire(timeout=0.1)
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_different_threads_no_false_positive(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path))
+    lock_2 = lock_type(str(lock_path), timeout=1)
+    barrier = threading.Barrier(2)
+    results: dict[str, bool] = {}
+
+    def thread_1() -> None:
+        with lock_1:
+            barrier.wait(timeout=5)
+            barrier.wait(timeout=5)
+        results["t1_released"] = True
+
+    def thread_2() -> None:
+        barrier.wait(timeout=5)
+        try:
+            lock_2.acquire(timeout=0.1)
+        except FileLockDeadlockError:
+            results["t2_deadlock_error"] = True
+        except Timeout:
+            results["t2_timed_out"] = True
+        else:
+            lock_2.release()
+        barrier.wait(timeout=5)
+
+    t1 = threading.Thread(target=thread_1)
+    t2 = threading.Thread(target=thread_2)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert results.get("t1_released") is True
+    assert "t2_deadlock_error" not in results
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_different_files_no_false_positive(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_1 = lock_type(str(tmp_path / "a"))
+    lock_2 = lock_type(str(tmp_path / "b"))
+
+    with lock_1, lock_2:
+        assert lock_1.is_locked
+        assert lock_2.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_deadlock_error_does_not_corrupt_lock_counter(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path))
+    lock_2 = lock_type(str(lock_path))
+
+    with lock_1:
+        with pytest.raises(FileLockDeadlockError):
+            lock_2.acquire()
+        assert lock_2.lock_counter == 0
+    assert lock_1.lock_counter == 0
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_async_cross_instance_deadlock_detected(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path))
+    lock_2 = lock_type(str(lock_path))
+
+    async with lock_1:
+        assert lock_1.is_locked
+        with pytest.raises(FileLockDeadlockError, match="would deadlock"):
+            await lock_2.acquire(timeout=1)
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_async_registry_cleanup_after_release(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_1 = lock_type(str(lock_path))
+    lock_2 = lock_type(str(lock_path))
+
+    await lock_1.acquire()
+    await lock_1.release()
+
+    await lock_2.acquire()
+    assert lock_2.is_locked
+    await lock_2.release()
+    assert not lock_2.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_async_same_instance_reentrant(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock = lock_type(str(lock_path))
+
+    async with lock:
+        async with lock:
+            assert lock.is_locked
+            assert lock.lock_counter == 2
+        assert lock.is_locked
+    assert not lock.is_locked

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pickle  # noqa: S403
 
-from filelock import Timeout
+from filelock import FileLockDeadlockError, Timeout
 
 
 def test_timeout_str() -> None:
@@ -28,3 +28,30 @@ def test_timeout_pickle() -> None:
     assert str(timeout) == str(timeout_loaded)
     assert repr(timeout) == repr(timeout_loaded)
     assert timeout.lock_file == timeout_loaded.lock_file
+
+
+def test_deadlock_error_str() -> None:
+    error = FileLockDeadlockError("/path/to/lock")
+    assert "would deadlock" in str(error)
+    assert "/path/to/lock" in str(error)
+    assert "is_singleton=True" in str(error)
+
+
+def test_deadlock_error_repr() -> None:
+    error = FileLockDeadlockError("/path/to/lock")
+    assert repr(error) == "FileLockDeadlockError('/path/to/lock')"
+
+
+def test_deadlock_error_lock_file() -> None:
+    error = FileLockDeadlockError("/path/to/lock")
+    assert error.lock_file == "/path/to/lock"
+
+
+def test_deadlock_error_pickle() -> None:
+    error = FileLockDeadlockError("/path/to/lock")
+    error_loaded = pickle.loads(pickle.dumps(error))  # noqa: S301
+
+    assert error.__class__ == error_loaded.__class__
+    assert str(error) == str(error_loaded)
+    assert repr(error) == repr(error_loaded)
+    assert error.lock_file == error_loaded.lock_file


### PR DESCRIPTION
When two separate `FileLock` instances target the same file and are both acquired in the same thread, the OS-level locking primitives (`flock`, `msvcrt.locking`, `O_EXCL`) block forever — the thread waits for itself to release a lock it can never release. This is a silent, unrecoverable deadlock that has bitten users in non-trivial codebases where lock objects are created in different scopes. See upstream issue https://github.com/tox-dev/filelock/issues/315 for the original report.

The fix adds a lightweight thread-local registry that tracks which resolved file paths currently hold OS-level locks in each thread. Before calling `_acquire()`, the registry is checked. If the file is already locked by a different instance in the same thread, a `FileLockDeadlockError` is raised immediately with a message guiding users toward `is_singleton=True` or reusing the existing lock object. This mirrors Java's `OverlappingFileLockException` approach — the JVM maintains a similar per-process registry and fails fast rather than deadlocking. 🔒 The registry uses `os.path.realpath()` to catch cases where different path representations (relative vs absolute, symlinks) resolve to the same file.

Same-instance reentrant locking continues to work as before since it increments `lock_counter` without re-entering `_acquire()`. Cross-thread locking of the same file is unaffected — that's legitimate inter-thread mutual exclusion, not deadlock. The registry is cleaned up on `release()` (including `force=True`), so sequential acquire-release-acquire patterns across different instances work correctly.

Closes https://github.com/tox-dev/filelock/issues/315