### PR TITLE
✨ feat(lock): add lifetime parameter for lock expiration

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -4,6 +4,7 @@ import contextlib
 import inspect
 import logging
 import os
+import pathlib
 import sys
 import time
 import warnings
@@ -90,6 +91,9 @@ class FileLockContext:
     #: The default polling interval value.
     poll_interval: float
 
+    #: The lock lifetime in seconds; ``None`` means the lock never expires.
+    lifetime: float | None = None
+
     #: The file descriptor for the *_lock_file* as it is returned by the os.open() function, not None when lock held
     lock_file_fd: int | None = None
 
@@ -114,6 +118,7 @@ class FileLockMeta(ABCMeta):
         blocking: bool = True,
         is_singleton: bool = False,
         poll_interval: float = 0.05,
+        lifetime: float | None = None,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> BaseFileLock:
         if is_singleton:
@@ -125,6 +130,7 @@ class FileLockMeta(ABCMeta):
                     "mode": (mode, instance._context.mode),  # noqa: SLF001
                     "blocking": (blocking, instance.blocking),
                     "poll_interval": (poll_interval, instance.poll_interval),
+                    "lifetime": (lifetime, instance.lifetime),
                 }
 
                 non_matching_params = {
@@ -153,6 +159,7 @@ class FileLockMeta(ABCMeta):
             "blocking": blocking,
             "is_singleton": is_singleton,
             "poll_interval": poll_interval,
+            "lifetime": lifetime,
             **kwargs,
         }
 
@@ -193,6 +200,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         blocking: bool = True,
         is_singleton: bool = False,
         poll_interval: float = 0.05,
+        lifetime: float | None = None,
     ) -> None:
         """
         Create a new lock object.
@@ -211,6 +219,9 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             pass the same object around.
         :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback
             value in the acquire method, if no poll_interval value (``None``) is given.
+        :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set,
+            a waiting process will break a lock whose file modification time is older than ``lifetime`` seconds.
+            ``None`` (the default) means locks never expire.
 
         """
         self._is_thread_local = thread_local
@@ -224,6 +235,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             "mode": mode,
             "blocking": blocking,
             "poll_interval": poll_interval,
+            "lifetime": lifetime,
         }
         self._context: FileLockContext = (ThreadLocalFileContext if thread_local else FileLockContext)(**kwargs)
 
@@ -303,6 +315,25 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         self._context.poll_interval = value
 
     @property
+    def lifetime(self) -> float | None:
+        """
+        :return: the lock lifetime in seconds, or ``None`` if the lock never expires
+
+        .. versionadded:: 3.24.0
+        """
+        return self._context.lifetime
+
+    @lifetime.setter
+    def lifetime(self, value: float | None) -> None:
+        """
+        Change the lock lifetime.
+
+        :param value: the new value in seconds, or ``None`` to disable expiration
+
+        """
+        self._context.lifetime = value
+
+    @property
     def mode(self) -> int:
         """:return: the file permissions for the lockfile"""
         return 0o644 if self._context.mode == _UNSET_FILE_MODE else self._context.mode
@@ -315,6 +346,17 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     def _open_mode(self) -> int:
         """:return: the mode for os.open() — 0o666 when unset (let umask/ACLs decide), else the explicit mode"""
         return 0o666 if self._context.mode == _UNSET_FILE_MODE else self._context.mode
+
+    def _try_break_expired_lock(self) -> None:
+        """Remove the lock file if its modification time exceeds the configured :attr:`lifetime`."""
+        if (lifetime := self._context.lifetime) is None:
+            return
+        with contextlib.suppress(OSError):
+            if time.time() - pathlib.Path(self.lock_file).stat().st_mtime < lifetime:
+                return
+            break_path = f"{self.lock_file}.break.{os.getpid()}"
+            pathlib.Path(self.lock_file).rename(break_path)
+            pathlib.Path(break_path).unlink()
 
     @abstractmethod
     def _acquire(self) -> None:
@@ -417,6 +459,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         try:
             while True:
                 if not self.is_locked:
+                    self._try_break_expired_lock()
                     _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)
                     self._acquire()
                 if self.is_locked:

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -26,8 +26,9 @@ _all_connections_lock = threading.Lock()
 def _cleanup_connections() -> None:
     with _all_connections_lock:
         for con in list(_all_connections):
-            with suppress(sqlite3.ProgrammingError):
+            with suppress(Exception):
                 con.close()
+        _all_connections.clear()
 
 
 atexit.register(_cleanup_connections)

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -80,6 +80,7 @@ class AsyncFileLockMeta(FileLockMeta):
         blocking: bool = True,
         is_singleton: bool = False,
         poll_interval: float = 0.05,
+        lifetime: float | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -95,6 +96,7 @@ class AsyncFileLockMeta(FileLockMeta):
             blocking=blocking,
             is_singleton=is_singleton,
             poll_interval=poll_interval,
+            lifetime=lifetime,
             loop=loop,
             run_in_executor=run_in_executor,
             executor=executor,
@@ -119,6 +121,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         blocking: bool = True,
         is_singleton: bool = False,
         poll_interval: float = 0.05,
+        lifetime: float | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -140,6 +143,9 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             pass the same object around.
         :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback
             value in the acquire method, if no poll_interval value (``None``) is given.
+        :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set,
+            a waiting process will break a lock whose file modification time is older than ``lifetime`` seconds.
+            ``None`` (the default) means locks never expire.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.
@@ -156,6 +162,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             "mode": mode,
             "blocking": blocking,
             "poll_interval": poll_interval,
+            "lifetime": lifetime,
             "loop": loop,
             "run_in_executor": run_in_executor,
             "executor": executor,
@@ -243,6 +250,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         try:
             while True:
                 if not self.is_locked:
+                    self._try_break_expired_lock()
                     _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)
                     await self._run_internal_method(self._acquire)
                 if self.is_locked:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import gc
+import sys
+
 try:
     from filelock._read_write import _cleanup_connections
 except ImportError:
@@ -8,4 +11,10 @@ except ImportError:
 
 def pytest_sessionfinish() -> None:
     if _cleanup_connections is not None:
+        if hasattr(sys, "pypy_version_info"):
+            gc.collect()
+            gc.collect()
         _cleanup_connections()
+        if hasattr(sys, "pypy_version_info"):
+            gc.collect()
+            gc.collect()

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import FileLock, SoftFileLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_expired_lock_is_broken(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.touch()
+    os.utime(lock_path, (0, 0))
+
+    lock = lock_type(lock_path, lifetime=0.1, timeout=1)
+    with lock:
+        assert lock.is_locked
+
+
+def test_soft_non_expired_lock_not_broken(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.touch()
+
+    lock = SoftFileLock(lock_path, lifetime=9999, timeout=0.2)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_soft_lifetime_none_no_expiry(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.touch()
+    os.utime(lock_path, (0, 0))
+
+    lock = SoftFileLock(lock_path, lifetime=None, timeout=0.2)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_expired_lock_race_rename_fails(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.touch()
+    os.utime(lock_path, (0, 0))
+
+    mocker.patch("filelock._api.pathlib.Path.rename", side_effect=FileNotFoundError)
+
+    lock = SoftFileLock(lock_path, lifetime=0.1, timeout=0.5)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+def test_lifetime_property_getter_setter(tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "test.lock", lifetime=10.0)
+    assert lock.lifetime == 10.0
+
+    lock.lifetime = 20.0
+    assert lock.lifetime == 20.0
+
+    lock.lifetime = None
+    assert lock.lifetime is None
+
+
+def test_lifetime_default_none(tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "test.lock")
+    assert lock.lifetime is None
+
+
+def test_lifetime_singleton_mismatch(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock1 = FileLock(lock_path, is_singleton=True, lifetime=10.0)
+    assert lock1.lifetime == 10.0
+
+    with pytest.raises(ValueError, match="lifetime"):
+        FileLock(lock_path, is_singleton=True, lifetime=20.0)
+
+
+def test_lifetime_singleton_match(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock1 = FileLock(lock_path, is_singleton=True, lifetime=10.0)
+    lock2 = FileLock(lock_path, is_singleton=True, lifetime=10.0)
+    assert lock1 is lock2
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_lock_file_missing_during_expiry_check(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+
+    lock = lock_type(lock_path, lifetime=0.1, timeout=1)
+    with lock:
+        assert lock.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_expired_lock_becomes_acquirable(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.touch()
+    os.utime(lock_path, (0, 0))
+
+    lock = lock_type(lock_path, lifetime=0.5, timeout=1)
+    with lock:
+        assert lock.is_locked
+    assert not lock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_expired_lock_is_broken(tmp_path: Path) -> None:
+    from filelock import AsyncFileLock
+
+    lock_path = tmp_path / "test.lock"
+    lock_path.touch()
+    os.utime(lock_path, (0, 0))
+
+    lock = AsyncFileLock(lock_path, lifetime=0.1, timeout=1)
+    async with lock:
+        assert lock.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_soft_non_expired_lock_not_broken(tmp_path: Path) -> None:
+    from filelock import AsyncSoftFileLock
+
+    lock_path = tmp_path / "test.lock"
+    lock_path.touch()
+
+    lock = AsyncSoftFileLock(lock_path, lifetime=9999, timeout=0.2)
+    with pytest.raises(TimeoutError):
+        await lock.acquire()
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_lock_mtime_updated_on_acquire(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    before = time.time()
+    lock = lock_type(lock_path, lifetime=60)
+    with lock:
+        if lock_path.exists():
+            assert lock_path.stat().st_mtime >= before - 1


### PR DESCRIPTION
Lock files left behind by crashed or killed processes can block other processes indefinitely. While `SoftFileLock` already detects stale locks via PID checks, this only works on the same host and doesn't cover `UnixFileLock` or `WindowsFileLock`. The new `lifetime` parameter provides a universal, time-based expiration mechanism that works across all lock backends. 🔐

When `lifetime` is set, each acquisition attempt checks the lock file's modification time. If the file is older than `lifetime` seconds, it is considered expired and broken via atomic rename-then-unlink — the same race-safe pattern already used by `SoftFileLock._try_break_stale_lock`. This ensures that when multiple waiters detect expiry simultaneously, only one succeeds in breaking the lock. All filesystem errors during the check are suppressed to avoid disrupting normal operation. ✨

The parameter defaults to `None` (no expiration), preserving full backward compatibility. It is available on all lock types including async variants, and is validated in singleton mode alongside the other constructor parameters.

Fixes https://github.com/tox-dev/filelock/issues/68