### PR TITLE
✨ feat(lock): add cancel_check to acquire

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -383,7 +383,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         :param poll_intervall: deprecated, kept for backwards compatibility, use ``poll_interval`` instead
         :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on
             the first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
-        :param cancel_check: a callable returning ``True`` when the acquisition should be cancelled. Checked on each
+        :param cancel_check: a callable returning ``True`` when the acquisition should be canceled. Checked on each
             poll iteration. When triggered, raises :class:`~Timeout` just like an expired timeout.
         :raises Timeout: if fails to acquire lock within the timeout period
         :return: a context object that will unlock the file when the context is exited

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -208,7 +208,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             :attr:`~BaseFileLock.poll_interval`
         :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on
             the first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
-        :param cancel_check: a callable returning ``True`` when the acquisition should be cancelled. Checked on each
+        :param cancel_check: a callable returning ``True`` when the acquisition should be canceled. Checked on each
             poll iteration. When triggered, raises :class:`~Timeout` just like an expired timeout.
         :raises Timeout: if fails to acquire lock within the timeout period
         :return: a context object that will unlock the file when the context is exited


### PR DESCRIPTION
Currently lock acquisition can only be cancelled via a numeric `timeout` or the `blocking=False` flag. This means callers who need to abort for other reasons (application shutdown, user interruption, upstream task failure) must either set an artificially short timeout and poll externally, or resort to thread interruption. Neither approach composes well. Closes #309.

The new `cancel_check` keyword-only parameter on `acquire()` accepts any zero-argument callable that returns `True` when cancellation is requested. The callable is polled each iteration of the retry loop, right after the `blocking` check and before the timeout check. When it fires, the method raises `Timeout` — the same exception callers already handle. This keeps the API surface minimal (one new optional parameter, no new exception types) while being fully composable with `threading.Event().is_set`, shutdown flags, or libraries like `cantok`. ✨

Both the sync `BaseFileLock.acquire()` and async `BaseAsyncFileLock.acquire()` support the parameter. The existing blocking/timeout/cancel checks were extracted into a shared `_check_give_up` static method to keep cyclomatic complexity in check.