### PR TITLE
📝 docs: restructure using Diataxis framework

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,11 +92,12 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
           header="$VERSION ($(date -u +%Y-%m-%d))"
-          separator=$(printf '%0.s-' $(seq 1 ${#header}))
+          separator=$(printf '%0.s*' $(seq 1 $((${#header} + 1))))
           {
-            head -2 docs/changelog.rst
-            printf '%s\n%s\n%s\n\n' "$header" "$separator" "$CHANGELOG"
-            tail -n +3 docs/changelog.rst
+            head -4 docs/changelog.rst
+            printf '%s\n %s\n%s\n\n' "$separator" "$header" "$separator"
+            printf '%s\n' "$CHANGELOG"
+            tail -n +5 docs/changelog.rst
           } > docs/changelog.tmp
           mv docs/changelog.tmp docs/changelog.rst
           git add docs/changelog.rst

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,9 @@
-API
-===
+###############
+ API Reference
+###############
+
+This section documents all public classes, exceptions, and attributes. For usage examples and task-oriented guidance,
+see :doc:`tutorials` and :doc:`how-to`.
 
 .. automodule:: filelock
     :members:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,11 +1,17 @@
-Changelog
-=========
-3.24.1 (2026-02-15)
--------------------
+###########
+ Changelog
+###########
+
+*********************
+ 3.24.1 (2026-02-15)
+*********************
+
 - 🐛 fix(soft): resolve Windows deadlock and test race condition :pr:`488`
 
-3.24.0 (2026-02-14)
--------------------
+*********************
+ 3.24.0 (2026-02-14)
+*********************
+
 - ✨ feat(lock): add lifetime parameter for lock expiration (#68) :pr:`486`
 - ✨ feat(lock): add cancel_check to acquire (#309) :pr:`487`
 - 🐛 fix(api): detect same-thread self-deadlock :pr:`481`
@@ -14,27 +20,37 @@ Changelog
 - ✨ feat(lock): add poll_interval to constructor :pr:`482`
 - 🐛 fix(unix): auto-fallback to SoftFileLock on ENOSYS :pr:`480`
 
-3.23.0 (2026-02-14)
--------------------
+*********************
+ 3.23.0 (2026-02-14)
+*********************
+
 - 📝 docs: move from Unlicense to MIT :pr:`479`
 - 📝 docs: add fasteners to similar libraries :pr:`478`
 
-3.22.0 (2026-02-14)
--------------------
+*********************
+ 3.22.0 (2026-02-14)
+*********************
+
 - 🐛 fix(soft): skip stale detection on Windows :pr:`477`
 - ✨ feat(soft): detect and break stale locks :pr:`476`
 
-3.21.2 (2026-02-13)
--------------------
+*********************
+ 3.21.2 (2026-02-13)
+*********************
+
 - 🐛 fix: catch ImportError for missing sqlite3 C library :pr:`475`
 
-3.21.1 (2026-02-12)
--------------------
+*********************
+ 3.21.1 (2026-02-12)
+*********************
+
 - 🐛 fix: gracefully handle missing `sqlite3` when importing `ReadWriteLock` :pr:`473` - by :user:`bayandin`
 - 🐛 fix(ci): make release workflow robust
 
-3.21.0 (2026-02-12)
--------------------
+*********************
+ 3.21.0 (2026-02-12)
+*********************
+
 - 🐛 fix(ci): make release workflow robust
 - 👷 ci(release): commit changelog and use release config :pr:`472`
 - 👷 ci(release): consolidate to two jobs :pr:`471`
@@ -42,246 +58,353 @@ Changelog
 - ✨ feat(lock): add SQLite-based ReadWriteLock :pr:`399` - by :user:`leventov`
 - 🔧 chore: modernize tooling and bump deps :pr:`470`
 
+**********************
+ v3.20.3 (2026-01-09)
+**********************
 
-v3.20.3 (2026-01-09)
---------------------
 - Fix TOCTOU symlink vulnerability in :class:`SoftFileLock <filelock.SoftFileLock>` :pr:`465`.
 
-v3.20.2 (2026-01-02)
---------------------
+**********************
+ v3.20.2 (2026-01-02)
+**********************
+
 - Support Unix systems without ``O_NOFOLLOW`` :pr:`463`.
 
-v3.20.1 (2025-12-15)
---------------------
+**********************
+ v3.20.1 (2025-12-15)
+**********************
+
 - Fix TOCTOU symlink vulnerability in lock file creation :pr:`461`.
 
-v3.20.0 (2025-10-08)
---------------------
+**********************
+ v3.20.0 (2025-10-08)
+**********************
+
 - Add Python 3.14 support, drop 3.9 :pr:`448`.
 - Add ``tox.toml`` to sdist :pr:`436`.
 
-v3.19.1 (2025-08-14)
---------------------
+**********************
+ v3.19.1 (2025-08-14)
+**********************
+
 - Increase test coverage :pr:`434`.
 
-v3.19.0 (2025-08-13)
---------------------
+**********************
+ v3.19.0 (2025-08-13)
+**********************
+
 - Add support for Python 3.14 :pr:`432`.
 
-v3.18.0 (2025-03-11)
---------------------
+**********************
+ v3.18.0 (2025-03-11)
+**********************
+
 - Support ``fcntl`` check on Emscripten :pr:`398`.
 - Indicate that locks are exclusive/write locks :pr:`394`.
 
-v3.17.0 (2025-01-21)
---------------------
+**********************
+ v3.17.0 (2025-01-21)
+**********************
+
 - Drop Python 3.8 support :pr:`388`.
 
-v3.16.1 (2024-09-17)
---------------------
+**********************
+ v3.16.1 (2024-09-17)
+**********************
+
 - CI improvements :pr:`362`.
 
-v3.16.0 (2024-09-07)
---------------------
+**********************
+ v3.16.0 (2024-09-07)
+**********************
+
 - Add Python 3.13 to CI :pr:`359`.
 
-v3.15.4 (2024-06-22)
---------------------
+**********************
+ v3.15.4 (2024-06-22)
+**********************
+
 - Pass ``file_lock`` as positional argument :pr:`347`.
 
-v3.15.3 (2024-06-19)
---------------------
+**********************
+ v3.15.3 (2024-06-19)
+**********************
+
 - Fix ``TypeError: _CountedFileLock.__init__() got an unexpected keyword argument`` :pr:`345`.
 
-v3.15.2 (2024-06-19)
---------------------
+**********************
+ v3.15.2 (2024-06-19)
+**********************
+
 - Use a metaclass to implement the singleton pattern :pr:`340`.
 
-v3.15.1 (2024-06-12)
---------------------
+**********************
+ v3.15.1 (2024-06-12)
+**********************
+
 - Restore ``__init__`` method; more robust initialization for singleton locks :pr:`338`.
 
-v3.15.0 (2024-06-11)
---------------------
+**********************
+ v3.15.0 (2024-06-11)
+**********************
+
 - Add asyncio support :pr:`332`.
 - Don't re-initialize ``BaseFileLock`` when returning existing singleton instance :pr:`334`.
 
-v3.14.0 (2024-04-27)
---------------------
+**********************
+ v3.14.0 (2024-04-27)
+**********************
+
 - Add ``blocking`` parameter on lock constructor :pr:`325`.
 
-v3.13.4 (2024-04-09)
---------------------
+**********************
+ v3.13.4 (2024-04-09)
+**********************
+
 - Raise error on incompatible singleton ``timeout`` and ``mode`` arguments :pr:`320`.
 
-v3.13.3 (2024-03-25)
---------------------
+**********************
+ v3.13.3 (2024-03-25)
+**********************
+
 - Make singleton class instance dict unique per subclass :pr:`318`.
 
-v3.13.2 (2024-03-25)
---------------------
+**********************
+ v3.13.2 (2024-03-25)
+**********************
+
 - Fix permission denied error when lock file is placed in ``/tmp`` :pr:`317`.
 
-v3.13.1 (2023-10-30)
---------------------
+**********************
+ v3.13.1 (2023-10-30)
+**********************
+
 - Allow users to subclass ``FileLock`` with custom keyword arguments :pr:`284`.
 
-v3.13.0 (2023-10-27)
---------------------
+**********************
+ v3.13.0 (2023-10-27)
+**********************
+
 - Support reentrant locking on lock file path via optional ``is_singleton`` instance :pr:`283`.
 
-v3.12.4 (2023-09-13)
---------------------
+**********************
+ v3.12.4 (2023-09-13)
+**********************
+
 - Change ``typing-extensions`` to be installed only with the ``[typing]`` extra :pr:`276`.
 
-v3.12.3 (2023-08-28)
---------------------
+**********************
+ v3.12.3 (2023-08-28)
+**********************
+
 - Add ``tox.ini`` to sdist :pr:`265`.
 - Create parent directories if necessary :pr:`254`.
 
-v3.12.2 (2023-06-12)
---------------------
+**********************
+ v3.12.2 (2023-06-12)
+**********************
+
 - Restore ``if TYPE_CHECKING`` syntax for ``FileLock`` definition :pr:`245`.
 
-v3.12.1 (2023-06-10)
---------------------
+**********************
+ v3.12.1 (2023-06-10)
+**********************
+
 - Add Python 3.12 support :pr:`237`.
 - Use ruff for linting :pr:`244`.
 
-v3.12.0 (2023-04-18)
---------------------
-- Make the thread local behavior something the caller can enable/disable via a flag during the lock creation, it's on
-  by default.
+**********************
+ v3.12.0 (2023-04-18)
+**********************
+
+- Make the thread local behavior something the caller can enable/disable via a flag during the lock creation, it's on by
+  default.
 - Better error handling on Windows.
 
-v3.11.0 (2023-04-06)
---------------------
+**********************
+ v3.11.0 (2023-04-06)
+**********************
+
 - Make the lock thread local.
 
-v3.10.7 (2023-03-27)
---------------------
+**********************
+ v3.10.7 (2023-03-27)
+**********************
+
 - Use ``fchmod`` instead of ``chmod`` to work around bug in PyPy via Anaconda.
 
-v3.10.6 (2023-03-25)
---------------------
+**********************
+ v3.10.6 (2023-03-25)
+**********************
+
 - Enhance the robustness of the try/catch block in _soft.py. by :user:`jahrules`.
 
-v3.10.5 (2023-03-25)
---------------------
+**********************
+ v3.10.5 (2023-03-25)
+**********************
+
 - Add explicit error check as certain UNIX filesystems do not support flock. by :user:`jahrules`.
 
-v3.10.4 (2023-03-24)
---------------------
+**********************
+ v3.10.4 (2023-03-24)
+**********************
+
 - Update os.open to preserve mode= for certain edge cases. by :user:`jahrules`.
 
-v3.10.3 (2023-03-23)
---------------------
+**********************
+ v3.10.3 (2023-03-23)
+**********************
+
 - Fix permission issue - by :user:`jahrules`.
 
-v3.10.2 (2023-03-22)
---------------------
+**********************
+ v3.10.2 (2023-03-22)
+**********************
+
 - Bug fix for using filelock with threaded programs causing undesired file permissions - by :user:`jahrules`.
 
-v3.10.1 (2023-03-22)
---------------------
+**********************
+ v3.10.1 (2023-03-22)
+**********************
+
 - Handle pickle for :class:`filelock.Timeout` :pr:`203` - by :user:`TheMatt2`.
 
-v3.10.0 (2023-03-15)
---------------------
+**********************
+ v3.10.0 (2023-03-15)
+**********************
+
 - Add support for explicit file modes for lockfiles :pr:`192` - by :user:`jahrules`.
 
-v3.9.1 (2023-03-14)
--------------------
+*********************
+ v3.9.1 (2023-03-14)
+*********************
+
 - Use ``time.perf_counter`` instead of ``time.monotonic`` for calculating timeouts.
 
-v3.9.0 (2022-12-28)
--------------------
+*********************
+ v3.9.0 (2022-12-28)
+*********************
+
 - Move build backend to ``hatchling`` :pr:`185` - by :user:`gaborbernat`.
 
-v3.8.1 (2022-12-04)
--------------------
+*********************
+ v3.8.1 (2022-12-04)
+*********************
+
 - Fix mypy does not accept ``filelock.FileLock`` as a valid type
 
-v3.8.0 (2022-12-04)
--------------------
+*********************
+ v3.8.0 (2022-12-04)
+*********************
+
 - Bump project dependencies
 - Add timeout unit to docstrings
 - Support 3.11
 
-v3.7.1 (2022-05-31)
--------------------
+*********************
+ v3.7.1 (2022-05-31)
+*********************
+
 - Make the readme documentation point to the index page
 
-v3.7.0 (2022-05-13)
--------------------
+*********************
+ v3.7.0 (2022-05-13)
+*********************
+
 - Add ability to return immediately when a lock cannot be obtained
 
-v3.6.0 (2022-02-17)
--------------------
-- Fix pylint warning "Abstract class :class:`WindowsFileLock <filelock.WindowsFileLock>` with abstract methods instantiated"
-  :pr:`135` - by :user:`vonschultz`
+*********************
+ v3.6.0 (2022-02-17)
+*********************
+
+- Fix pylint warning "Abstract class :class:`WindowsFileLock <filelock.WindowsFileLock>` with abstract methods
+  instantiated" :pr:`135` - by :user:`vonschultz`
 - Fix pylint warning "Abstract class :class:`UnixFileLock <filelock.UnixFileLock>` with abstract methods instantiated"
   :pr:`135` - by :user:`vonschultz`
 
-v3.5.1 (2022-02-16)
--------------------
+*********************
+ v3.5.1 (2022-02-16)
+*********************
+
 - Use ``time.monotonic`` instead of ``time.time`` for calculating timeouts.
 
-v3.5.0 (2022-02-15)
--------------------
+*********************
+ v3.5.0 (2022-02-15)
+*********************
+
 - Enable use as context decorator
 
-v3.4.2 (2021-12-16)
--------------------
+*********************
+ v3.4.2 (2021-12-16)
+*********************
+
 - Drop support for python ``3.6``
 
-v3.4.1 (2021-12-16)
--------------------
+*********************
+ v3.4.1 (2021-12-16)
+*********************
+
 - Add ``stacklevel`` to deprecation warnings for argument name change
 
-v3.4.0 (2021-11-16)
--------------------
+*********************
+ v3.4.0 (2021-11-16)
+*********************
+
 - Add correct spelling of poll interval parameter for :meth:`acquire <filelock.BaseFileLock.acquire>` method, raise
   deprecation warning when using the misspelled form :pr:`119` - by :user:`XuehaiPan`.
 
-v3.3.2 (2021-10-29)
--------------------
+*********************
+ v3.3.2 (2021-10-29)
+*********************
+
 - Accept path types (like ``pathlib.Path`` and ``pathlib.PurePath``) in the constructor for ``FileLock`` objects.
 
-v3.3.1 (2021-10-15)
--------------------
+*********************
+ v3.3.1 (2021-10-15)
+*********************
+
 - Add changelog to the documentation :pr:`108` - by :user:`gaborbernat`
 - Leave the log level of the ``filelock`` logger as not set (previously was set to warning) :pr:`108` - by
   :user:`gaborbernat`
 
-v3.3.0 (2021-10-03)
--------------------
+*********************
+ v3.3.0 (2021-10-03)
+*********************
+
 - Drop python 2.7 and 3.5 support, add type hints :pr:`100` - by :user:`gaborbernat`
 - Document asyncio support - by :user:`gaborbernat`
 - fix typo :pr:`98` - by :user:`jugmac00`
 
-v3.2.1 (2021-10-02)
--------------------
+*********************
+ v3.2.1 (2021-10-02)
+*********************
+
 - Improve documentation
 - Changed logger name from ``filelock._api`` to ``filelock`` :pr:`97` - by :user:`hkennyv`
 
-v3.2.0 (2021-09-30)
--------------------
+*********************
+ v3.2.0 (2021-09-30)
+*********************
+
 - Raise when trying to acquire in R/O or missing folder :pr:`96` - by :user:`gaborbernat`
 - Move lock acquire/release log from INFO to DEBUG :pr:`95` - by :user:`gaborbernat`
 - Fix spelling and remove ignored flake8 checks - by :user:`gaborbernat`
 - Split main module :pr:`94` - by :user:`gaborbernat`
 - Move test suite to pytest :pr:`93` - by :user:`gaborbernat`
 
-v3.1.0 (2021-09-27)
--------------------
+*********************
+ v3.1.0 (2021-09-27)
+*********************
+
 - Update links for new home at tox-dev :pr:`88` - by :user:`hugovk`
 - Fixed link to LICENSE file :pr:`63` - by :user:`sharkwouter`
 - Adopt tox-dev organization best practices :pr:`87` - by :user:`gaborbernat`
 - Ownership moved from :user:`benediktschmitt` to the tox-dev organization (new primary maintainer :user:`gaborbernat`)
 
-v3.0.12 (2019-05-18)
---------------------
+**********************
+ v3.0.12 (2019-05-18)
+**********************
+
 - *fixed* setuptools and twine/warehouse error by making the license only 1 line long
 - *update* version for pypi upload
 - *fixed* python2 setup error
@@ -290,139 +413,195 @@ v3.0.12 (2019-05-18)
 - Update Trove classifiers for PyPI
 - test: Skip test_del on PyPy since it hangs
 
-v3.0.10 (2018-11-01)
---------------------
+**********************
+ v3.0.10 (2018-11-01)
+**********************
+
 - Fix README rendering on PyPI
 
-v3.0.9 (2018-10-02)
--------------------
+*********************
+ v3.0.9 (2018-10-02)
+*********************
+
 - :pr:`38` from cottsay/shebang
 - *updated* docs config for older sphinx compatibility
 - *removed* misleading shebang from module
 
-v3.0.8 (2018-09-09)
--------------------
+*********************
+ v3.0.8 (2018-09-09)
+*********************
+
 - *updated* use setuptools
 
-v3.0.7 (2018-09-09)
--------------------
+*********************
+ v3.0.7 (2018-09-09)
+*********************
+
 - *fixed* garbage collection (:issue:`37`)
 - *fix* travis ci badge (use rst not markdown)
 - *changed* travis uri
 
-v3.0.6 (2018-08-22)
--------------------
+*********************
+ v3.0.6 (2018-08-22)
+*********************
+
 - *clean up*
 - Fixed unit test for Python 2.7
 - Added Travis banner
 - Added Travis CI support
 
-v3.0.5 (2018-04-26)
--------------------
+*********************
+ v3.0.5 (2018-04-26)
+*********************
+
 - Corrected the prequel reference
 
-v3.0.4 (2018-02-01)
--------------------
+*********************
+ v3.0.4 (2018-02-01)
+*********************
+
 - *updated* README
 
-v3.0.3 (2018-01-30)
--------------------
+*********************
+ v3.0.3 (2018-01-30)
+*********************
+
 - *updated* readme
 
-v3.0.1 (2018-01-30)
--------------------
+*********************
+ v3.0.1 (2018-01-30)
+*********************
+
 - *updated* README (added navigation)
 - *updated* documentation :issue:`22`
 - *fix* the ``SoftFileLock`` test was influenced by the test for ``FileLock``
 - *undo* ``cb1d83d`` :issue:`31`
 
-v3.0.0 (2018-01-05)
--------------------
+*********************
+ v3.0.0 (2018-01-05)
+*********************
+
 - *updated* major version number due to :issue:`29` and :issue:`27`
 - *fixed* use proper Python3 ``reraise`` method
 - Attempting to clean up lock file on Unix after ``release``
 
-v2.0.13 (2017-11-05)
---------------------
+**********************
+ v2.0.13 (2017-11-05)
+**********************
+
 - *changed* The logger is now acquired when first needed. :issue:`24`
 
-v2.0.12 (2017-09-02)
---------------------
+**********************
+ v2.0.12 (2017-09-02)
+**********************
+
 - correct spelling mistake
 
-v2.0.11 (2017-07-19)
---------------------
+**********************
+ v2.0.11 (2017-07-19)
+**********************
+
 - *added* official support for python 2 :issue:`20`
 
-v2.0.10 (2017-06-07)
---------------------
+**********************
+ v2.0.10 (2017-06-07)
+**********************
+
 - *updated* readme
 
-v2.0.9 (2017-06-07)
--------------------
+*********************
+ v2.0.9 (2017-06-07)
+*********************
+
 - *updated* readme :issue:`19`
 - *added* example :pr:`16`
 - *updated* readthedocs url
 - *updated* change order of the examples (:pr:`16`)
 
-v2.0.8 (2017-01-24)
--------------------
+*********************
+ v2.0.8 (2017-01-24)
+*********************
+
 - Added logging
 - Removed unused imports
 
-v2.0.7 (2016-11-05)
--------------------
+*********************
+ v2.0.7 (2016-11-05)
+*********************
+
 - *fixed* :issue:`14` (moved license and readme file to ``MANIFEST``)
 
-v2.0.6 (2016-05-01)
--------------------
+*********************
+ v2.0.6 (2016-05-01)
+*********************
+
 - *changed* unlocking sequence to fix transient test failures
 - *changed* threads in tests so exceptions surface
 - *added* test lock file cleanup
 
-v2.0.5 (2015-11-11)
--------------------
+*********************
+ v2.0.5 (2015-11-11)
+*********************
+
 - Don't remove file after releasing lock
 - *updated* docs
 
-v2.0.4 (2015-07-29)
--------------------
+*********************
+ v2.0.4 (2015-07-29)
+*********************
+
 - *added* the new classes to ``__all__``
 
-v2.0.3 (2015-07-29)
--------------------
+*********************
+ v2.0.3 (2015-07-29)
+*********************
+
 - *added* The ``SoftFileLock`` is now always tested
 
-v2.0.2 (2015-07-29)
--------------------
-- The filelock classes are now always available and have been moved out of the
-  ``if msvrct: ... elif fcntl ... else`` clauses.
+*********************
+ v2.0.2 (2015-07-29)
+*********************
 
-v2.0.1 (2015-06-13)
--------------------
+- The filelock classes are now always available and have been moved out of the ``if msvrct: ... elif fcntl ... else``
+  clauses.
+
+*********************
+ v2.0.1 (2015-06-13)
+*********************
+
 - fixed :issue:`5`
 - *updated* test cases
 - *updated* documentation
 - *fixed* :issue:`2` which has been introduced with the lock counter
 
-v2.0.0 (2015-05-25)
--------------------
+*********************
+ v2.0.0 (2015-05-25)
+*********************
+
 - *added* default timeout (fixes :issue:`2`)
 
-v1.0.3 (2015-04-22)
--------------------
+*********************
+ v1.0.3 (2015-04-22)
+*********************
+
 - *added* new test case, *fixed* unhandled exception
 
-v1.0.2 (2015-04-22)
--------------------
+*********************
+ v1.0.2 (2015-04-22)
+*********************
+
 - *fixed* a timeout could still be thrown if the lock is already acquired
 
-v1.0.1 (2015-04-22)
--------------------
+*********************
+ v1.0.1 (2015-04-22)
+*********************
+
 - *fixed* :issue:`1`
 
-v1.0.0 (2015-04-07)
--------------------
+*********************
+ v1.0.0 (2015-04-07)
+*********************
+
 - *added* lock counter, *added* unittest, *updated* to version 1
 - *changed* filenames
 - *updated* version for pypi

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,0 +1,432 @@
+#####################
+ Concepts and design
+#####################
+
+This section explains the ideas behind file locking, how filelock works across different platforms, and the trade-offs
+involved in choosing a lock type.
+
+*****************
+ Why file locks?
+*****************
+
+Multi-process applications often need to coordinate access to shared resources. Without coordination, processes can
+interfere with each other and cause data corruption or inconsistent state.
+
+For example, imagine two processes writing to the same configuration file:
+
+.. mermaid::
+
+    sequenceDiagram
+        participant A as Process A
+        participant File as Configuration File
+        participant B as Process B
+        A->>File: Read (value: 1)
+        B->>File: Read (value: 1)
+        Note over A: Increment to 2
+        Note over B: Increment to 2
+        A->>File: Write 2
+        B->>File: Write 2
+        Note over File: Final value: 2 (should be 3!)
+
+This scenario is a **race condition**. Process B's write overwrites Process A's changes, and the final result is
+incorrect.
+
+File locks prevent this by ensuring only one process can access a resource at a time:
+
+.. mermaid::
+
+    sequenceDiagram
+        participant A as Process A
+        participant Lock as File Lock
+        participant File as Configuration File
+        participant B as Process B
+        A->>Lock: Acquire lock
+        activate Lock
+        B->>Lock: Try to acquire (waits...)
+        A->>File: Read (value: 1)
+        Note over A: Increment to 2
+        A->>File: Write 2
+        A->>Lock: Release lock
+        deactivate Lock
+        Lock->>B: Lock acquired!
+        B->>File: Read (value: 2)
+        Note over B: Increment to 3
+        B->>File: Write 3
+        B->>Lock: Release lock
+        Note over File: Final value: 3 ✓
+
+Now both processes complete successfully and their changes are preserved.
+
+Self-deadlock detection
+=======================
+
+A common mistake is creating two separate ``FileLock`` instances for the same file and trying to acquire both in the
+same thread:
+
+.. code-block:: python
+
+    lock_a = FileLock("work.lock")
+    lock_b = FileLock("work.lock")
+
+    with lock_a:
+        with lock_b:  # RuntimeError: Deadlock detected!
+            pass
+
+This would normally deadlock forever because ``lock_b`` waits for a lock that ``lock_a`` holds in the same thread.
+filelock detects this and raises ``RuntimeError`` with a message suggesting ``is_singleton=True`` as the fix.
+
+This detection only applies to blocking acquires (``timeout < 0``) within the same thread. Non-blocking or timed
+acquires raise :class:`Timeout <filelock.Timeout>` as usual.
+
+************************
+ How file locking works
+************************
+
+There are two fundamentally different approaches to file locking on modern systems:
+
+**OS-level locking** (FileLock on Windows/Unix, UnixFileLock, WindowsFileLock)
+
+The operating system manages locks. When you create a lock, the OS tracks it and enforces it. Only code with an open
+file handle can lock it. When a process dies, the OS automatically releases its locks.
+
+.. list-table::
+    :header-rows: 1
+
+    - - Pros
+      - Cons
+    - - ✓ Enforced by the kernel—foolproof.
+      - ✗ Exclusive only—no reader/writer distinction (use ReadWriteLock for that).
+    - - ✓ Works even if your process crashes.
+      - ✗ Unreliable on some network filesystems.
+    - - ✓ No network filesystem issues.
+      -
+    - - ✓ Lower overhead.
+      -
+
+**Soft locks** (SoftFileLock, the fallback on systems without fcntl)
+
+A separate "lock file" indicates that a resource is in use. The lock file contains the PID and hostname of the holder. A
+process acquires a lock by creating this file; it releases by deleting it.
+
+On Unix/macOS, processes can check if the lock holder is still alive and break stale locks automatically. On Windows,
+stale lock breaking is skipped because the lock file cannot be atomically renamed while another process holds a handle.
+
+.. list-table::
+    :header-rows: 1
+
+    - - Pros
+      - Cons
+    - - ✓ Works on any filesystem, including network mounts.
+      - ✗ Not enforced—requires cooperation (a buggy process can ignore it).
+    - - ✓ Portable—same code works everywhere.
+      - ✗ Stale lock detection not available on Windows.
+    - - ✓ Can detect stale locks (Unix/macOS only).
+      - ✗ Higher overhead than OS-level locks.
+    - -
+      - ✗ Cross-host detection doesn't work (stale locks from other hosts require manual cleanup).
+    - -
+      - ✗ On Windows, stale lock detection is skipped (file rename is not atomic while handle is open).
+
+***************************
+ Platform-specific details
+***************************
+
+**Windows**
+    Uses the :class:`WindowsFileLock <filelock.WindowsFileLock>` class, backed by ``msvcrt.locking``. This is enforced
+    by Windows, so all code running on the system respects it—whether it uses filelock or not.
+
+    The lock is exclusive and works reliably on local filesystems. Network filesystem (SMB) support is available but
+    considered less reliable.
+
+**Unix and macOS**
+    Uses the :class:`UnixFileLock <filelock.UnixFileLock>` class, backed by ``fcntl.flock``. This is the POSIX standard
+    for file locking and enforced by the kernel.
+
+    Works best on local filesystems. Network filesystems (NFS) may have issues—locking isn't always reliable on NFS even
+    in POSIX-compliant systems.
+
+**Other platforms without fcntl**
+    Falls back to :class:`SoftFileLock <filelock.SoftFileLock>` and emits a warning. The lock is not enforced by the OS,
+    but filelock includes stale lock detection on Unix-like systems (though without fcntl, this detection is less
+    reliable than on systems with full fcntl support).
+
+*******************************
+ Which lock type should I use?
+*******************************
+
+**Start with FileLock** — the platform-aware alias that automatically chooses the best backend:
+
+.. code-block:: python
+
+    from filelock import FileLock
+
+    lock = FileLock("work.lock")
+
+This gives you OS-level locking on Windows and Unix/macOS, with an automatic fallback to soft locks on other systems.
+It's the right choice 99% of the time.
+
+**Use UnixFileLock or WindowsFileLock** only if you need to force a specific backend. This is rare and usually only
+necessary in testing or if you need platform-specific behavior.
+
+**Use SoftFileLock** when:
+
+- You're on a network filesystem where OS-level locking is unavailable (NFS).
+- You need cross-filesystem compatibility and can tolerate the overhead.
+- You need stale lock detection (Unix/macOS only).
+
+**Use ReadWriteLock** when:
+
+- Your workload is read-heavy with occasional writes.
+- Multiple processes need to read simultaneously.
+- You want a single writer while no readers are active.
+
+Lock selection flowchart:
+
+.. mermaid::
+
+    flowchart TD
+        start["Choose a lock type"] --> question1{"Read-heavy workload?"}
+        question1 -->|Yes| rw["Use ReadWriteLock"]
+        question1 -->|No| question2{"Need network<br/>filesystem support?"}
+        question2 -->|Yes| soft["Use SoftFileLock"]
+        question2 -->|No| question3{"Need platform<br/>specific control?"}
+        question3 -->|Yes| platform["Use UnixFileLock<br/>or WindowsFileLock"]
+        question3 -->|No| default["Use FileLock<br/>(recommended)"]
+
+        classDef recommended fill:#dcfce7,stroke:#22c55e,stroke-width:2px,color:#14532d
+        classDef alternative fill:#fef3c7,stroke:#f59e0b,stroke-width:2px,color:#78350f
+        classDef special fill:#dbeafe,stroke:#3b82f6,stroke-width:2px,color:#1e3a5f
+        class default recommended
+        class soft,platform alternative
+        class rw special
+
+Lock types compared
+===================
+
+.. list-table::
+    :header-rows: 1
+
+    - - Feature
+      - FileLock
+      - SoftFileLock
+      - ReadWriteLock
+    - - Exclusive/shared
+      - Exclusive only
+      - Exclusive only
+      - Both (separate context managers)
+    - - Platform enforcement
+      - OS-level (Windows/Unix)
+      - No (file-based)
+      - File-based (SQLite)
+    - - Network filesystem
+      - Not reliable
+      - Works (if you accept the limitations)
+      - Not reliable
+    - - Stale lock detection
+      - N/A (OS-enforced)
+      - Yes (Unix/macOS only)
+      - N/A
+    - - Lifetime expiration
+      - Yes
+      - Yes
+      - No
+    - - Cancel acquisition
+      - Yes (``cancel_check``)
+      - Yes (``cancel_check``)
+      - No
+    - - Force release
+      - Yes (``force=True``)
+      - Yes (``force=True``)
+      - Yes (``force=True``)
+    - - Async support
+      - AsyncFileLock
+      - AsyncSoftFileLock
+      - No
+    - - Singleton default
+      - No
+      - No
+      - Yes
+    - - Overhead
+      - Low
+      - High
+      - Medium (SQLite)
+
+**********************
+ TOCTOU vulnerability
+**********************
+
+**TOCTOU** (Time-of-Check-Time-of-Use) is a potential security issue: a time gap exists between when you check something
+and when you act on it.
+
+For example, this code has a TOCTOU vulnerability:
+
+.. code-block:: python
+
+    if os.path.exists("sensitive.txt"):  # Check
+        data = open("sensitive.txt").read()  # Use (race window here!)
+
+An attacker with filesystem access could create a symlink between the check and the use, redirecting you to read a
+different file.
+
+How filelock mitigates this:
+
+:class:`SoftFileLock <filelock.SoftFileLock>` on systems without ``O_NOFOLLOW`` support may be vulnerable. But on most
+modern platforms (Linux, macOS, Windows), ``O_NOFOLLOW`` is supported, and filelock uses it to refuse following
+symlinks.
+
+On older platforms without ``O_NOFOLLOW``, prefer :class:`UnixFileLock <filelock.UnixFileLock>` or
+:class:`WindowsFileLock <filelock.WindowsFileLock>` for security-sensitive applications.
+
+***************************************
+ What filelock doesn't protect against
+***************************************
+
+**Lock files on the actual resource**
+    Don't use a lock on the file you want to protect:
+
+    .. code-block:: python
+
+        lock = FileLock("data.txt")  # ⚠️ Wrong!
+        with lock:
+            data = open("data.txt").read()
+
+    This doesn't work reliably. If you delete ``data.txt``, the lock is gone too. Instead, create a separate lock file:
+
+    .. code-block:: python
+
+        lock = FileLock("data.txt.lock")  # ✓ Right
+        with lock:
+            data = open("data.txt").read()
+
+**Locks on network filesystems**
+    OS-level locks (FileLock on Windows/Unix) are unreliable on network filesystems (NFS, SMB). This is a fundamental
+    limitation of how network filesystems work—they don't reliably support locking semantics.
+
+    If you need locking on network filesystems, consider: - Using SoftFileLock (less efficient but more portable) -
+    Switching to a centralized lock service (Redis, Consul, etc.) - Using a database with transactions
+
+**Locks across different machines**
+    A lock on one machine doesn't stop another machine from accessing the resource unless they use a centralized locking
+    service. Filelock is for inter-process coordination on the same machine (or at least the same shared filesystem).
+
+**Read-write semantics**
+    FileLock is exclusive only—readers block writers and vice versa. If you need multiple readers with occasional
+    writers, use ReadWriteLock instead.
+
+**Atomicity without locks**
+    If another process doesn't use the lock, it will still interfere:
+
+    .. code-block:: python
+
+        # Process A (uses lock)
+        with lock:
+            # Process B might still write at the same time
+            # if Process B doesn't use the lock
+            open("data.txt").write("A")
+
+    Locks require cooperation—all code accessing a resource must use the same lock.
+
+*******************
+ Design trade-offs
+*******************
+
+Why not use OS-level locks everywhere?
+======================================
+
+OS-level locks (FileLock on Windows/Unix) are fast and enforced by the kernel. But they don't work on all network
+filesystems. For portability, filelock includes SoftFileLock as a fallback.
+
+Why does SoftFileLock use a separate file instead of just checking a directory?
+===============================================================================
+
+A directory can't reliably be atomically created and deleted across platforms. A file can be created with ``O_EXCL``
+(atomic, all-or-nothing) to detect conflicts. This is why SoftFileLock uses files.
+
+Why is stale lock detection only on Unix/macOS?
+===============================================
+
+Stale lock detection requires: 1. Knowing the PID of the lock holder 2. A way to check if that process is still alive
+3. A way to atomically break the stale lock without corruption.
+
+On Unix/macOS, ``kill(pid, 0)`` checks process liveness and ``rename()`` atomically replaces the lock file. On Windows,
+process liveness can be checked via ``OpenProcess``, but the lock file cannot be atomically renamed while another process
+holds a handle to it. So stale detection is skipped on Windows to avoid corruption.
+
+Why is ReadWriteLock backed by SQLite?
+======================================
+
+A simple file can only track "locked" or "not locked." To track multiple readers + one writer, you need state
+management. SQLite handles: - Atomic transactions - Multiple concurrent readers - Exclusive write transactions -
+Persistence across process crashes
+
+This makes it the natural choice for read-write locks without adding network dependencies.
+
+****************************
+ File permissions and mode
+****************************
+
+By default, filelock does not set explicit permissions on the lock file (``mode=-1``). This lets the OS control
+permissions through umask and default ACLs. In shared directories with POSIX default ACLs, this preserves ACL
+inheritance so the lock file gets the directory's default permissions rather than the creating user's umask.
+
+When you pass an explicit ``mode`` value (e.g., ``mode=0o644``), filelock uses that value directly via ``os.open``. This
+overrides any default ACLs on the directory.
+
+*****************************
+ Thread-local vs shared state
+*****************************
+
+Each ``FileLock`` instance tracks its lock counter and file descriptor in a context object. By default
+(``thread_local=True``), each thread gets its own context via ``threading.local``. This means:
+
+- Two threads holding the same ``FileLock`` object each maintain independent lock counters.
+- Thread A releasing the lock doesn't affect Thread B's counter.
+
+When ``thread_local=False``, all threads share the same context. This is useful for objects passed between threads, but
+requires external coordination to avoid counter mismatches.
+
+Async locks default to ``thread_local=False`` because the thread that calls ``acquire()`` (via
+``run_in_executor``) may differ from the thread that calls ``release()``. Using ``thread_local=True`` with
+``run_in_executor=True`` raises ``ValueError``.
+
+.. mermaid::
+
+    flowchart LR
+        subgraph "thread_local=True (default)"
+            T1["Thread A<br/>counter: 2"] --- L1["Lock File"]
+            T2["Thread B<br/>counter: 1"] --- L1
+        end
+
+        subgraph "thread_local=False"
+            T3["Thread A"] --- SC["Shared<br/>counter: 3"] --- L2["Lock File"]
+            T4["Thread B"] --- SC
+        end
+
+****************************
+ When not to use file locks
+****************************
+
+**High-frequency synchronization**
+    File locks have high latency and are inefficient for protecting variables that change frequently. Use threading
+    locks or multiprocessing synchronization primitives instead.
+
+**Distributed systems without shared filesystems**
+    If processes are on different machines without a shared filesystem, file locks don't work. Use a centralized lock
+    service (Redis, Consul, Zookeeper, etc.).
+
+**Real-time systems**
+    File locking is subject to filesystem delays and network latency. Real-time systems need sub-millisecond guarantees
+    that file locks can't provide.
+
+**Very large numbers of locks**
+    Creating thousands of lock files consumes filesystem resources. For that scale, use an in-memory lock service.
+
+************
+ Next steps
+************
+
+- New to file locking? Start with :doc:`tutorials`.
+- Need to cancel acquisition or force-release? See :ref:`how-to:Cancel lock acquisition` and
+  :ref:`how-to:Force-release a lock`.
+- Using async locks? See :ref:`how-to:Use async locks`.
+- Consult :doc:`api` for complete API documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,9 +28,32 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx_sitemap",
+    "sphinxcontrib.mermaid",
+    "sphinxext.opengraph",
 ]
+mermaid_output_format = "raw"
+
+# sphinx-copybutton: add copy button to code blocks
+copybutton_prompt_is_regexp = True
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: "
+
+# sphinx-design: no special config needed
+
+# sphinx-sitemap: generate sitemap.xml
+# sphinx-notfound-page: custom 404 pages (no config needed)
+
+# sphinxext-opengraph: social media metadata
+ogp_site_url = "https://py-filelock.readthedocs.io"
+ogp_social_cards = {"enable": False}
+ogp_use_first_image = True
+ogp_description_length = 200
+
 html_theme = "furo"
 html_title, html_last_updated_fmt = name, now.isoformat()
+html_baseurl = "https://py-filelock.readthedocs.io/"
 pygments_style, pygments_dark_style = "sphinx", "monokai"
 autoclass_content, autodoc_member_order, autodoc_typehints = "class", "bysource", "none"
 autodoc_default_options = {"member-order": "bysource", "undoc-members": True, "show-inheritance": True}

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -1,0 +1,484 @@
+###############
+ How-to guides
+###############
+
+These guides solve specific problems. Each one assumes you're familiar with the basics from :doc:`tutorials`. For design
+rationale and trade-offs, see :doc:`concepts`.
+
+**********************
+ Handle lock timeouts
+**********************
+
+When another process holds a lock, you might want to give up after a certain time rather than waiting forever.
+
+Use the ``timeout`` parameter when acquiring a lock:
+
+.. code-block:: python
+
+    from filelock import FileLock, Timeout
+
+    lock = FileLock("work.lock", timeout=10)
+
+    try:
+        with lock:
+            # This will wait up to 10 seconds for the lock
+            print("Got the lock!")
+    except Timeout:
+        print("Couldn't get the lock after 10 seconds")
+
+You can also pass ``timeout`` directly to ``acquire()``:
+
+.. code-block:: python
+
+    lock = FileLock("work.lock")
+
+    try:
+        with lock.acquire(timeout=5):
+            print("Got the lock!")
+    except Timeout:
+        print("Timeout after 5 seconds")
+
+************************
+ Use non-blocking locks
+************************
+
+Sometimes you want to attempt the lock exactly once—either you get it immediately or you don't.
+
+Set ``blocking=False``:
+
+.. code-block:: python
+
+    from filelock import FileLock, Timeout
+
+    lock = FileLock("work.lock", blocking=False)
+
+    try:
+        with lock:
+            print("Got the lock immediately")
+    except Timeout:
+        print("Lock is held by another process")
+
+When ``blocking=False``, the lock makes only one attempt and raises ``Timeout`` if it can't acquire immediately.
+
+The ``blocking`` parameter takes precedence over ``timeout``\ —if you set both, ``blocking`` wins:
+
+.. code-block:: python
+
+    # This ignores the timeout and tries once
+    with lock.acquire(blocking=False, timeout=10):
+        pass
+
+**************************
+ Control polling interval
+**************************
+
+When waiting for a lock, filelock retries at regular intervals. By default it waits 0.05 seconds between attempts.
+
+Increase the poll interval for long-lived locks to reduce CPU usage:
+
+.. code-block:: python
+
+    lock = FileLock("work.lock", poll_interval=0.25)
+
+    with lock:
+        # Will check every 0.25 seconds instead of every 0.05 seconds
+        pass
+
+Or pass it to ``acquire()``:
+
+.. code-block:: python
+
+    lock = FileLock("work.lock")
+
+    with lock.acquire(poll_interval=1.0):
+        # Checks every 1 second
+        pass
+
+Change the poll interval anytime via the property:
+
+.. code-block:: python
+
+    lock.poll_interval = 0.5
+
+*****************
+ Use async locks
+*****************
+
+For async code, use the async variants with ``async with``:
+
+.. code-block:: python
+
+    from pathlib import Path
+    from filelock import AsyncFileLock
+
+    lock = AsyncFileLock("work.lock")
+
+
+    async def read_shared_file():
+        async with lock:
+            data = Path("data.txt").read_text()
+            return data
+
+By default, async locks run blocking I/O in a thread pool. You can customize this:
+
+.. code-block:: python
+
+    # Use a custom executor
+    from concurrent.futures import ThreadPoolExecutor
+
+    executor = ThreadPoolExecutor(max_workers=2)
+    lock = AsyncFileLock("work.lock", executor=executor)
+
+    # Or disable executor (only if your filesystem is non-blocking)
+    lock = AsyncFileLock("work.lock", run_in_executor=False)
+
+You can also pass a specific event loop:
+
+.. code-block:: python
+
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    lock = AsyncFileLock("work.lock", loop=loop)
+
+Note that async locks default to ``thread_local=False`` (unlike sync locks which default to ``True``) because the
+acquiring and releasing threads may differ when using an executor.
+
+Available async lock classes:
+
+- :class:`AsyncFileLock <filelock.AsyncFileLock>` — platform-aware (recommended).
+- :class:`AsyncSoftFileLock <filelock.AsyncSoftFileLock>`.
+- :class:`AsyncUnixFileLock <filelock.AsyncUnixFileLock>`.
+- :class:`AsyncWindowsFileLock <filelock.AsyncWindowsFileLock>`.
+
+*********************************
+ Use locks with multiple threads
+*********************************
+
+By default, locks are thread-local. Each thread maintains its own lock state, so nested acquisitions from the same
+thread don't block:
+
+.. code-block:: python
+
+    from filelock import FileLock
+    import threading
+
+    lock = FileLock("work.lock")  # thread_local=True by default
+
+
+    def worker():
+        with lock:
+            print(f"{threading.current_thread().name} has the lock")
+
+
+    # Each thread can acquire the same lock without blocking
+    threading.Thread(target=worker).start()
+    worker()  # Main thread
+
+If you need one lock instance shared across threads (and reentrant per thread), set ``thread_local=False``:
+
+.. code-block:: python
+
+    lock = FileLock("work.lock", thread_local=False)
+    # Now the lock is reentrant across threads, not per-thread
+
+*********************
+ Use singleton locks
+*********************
+
+Sometimes you want multiple code paths to reference the same lock without passing it around.
+
+Set ``is_singleton=True``:
+
+.. code-block:: python
+
+    from filelock import FileLock
+
+    # First reference creates the lock
+    lock_a = FileLock("work.lock", is_singleton=True)
+
+    # Second reference returns the same instance
+    lock_b = FileLock("work.lock", is_singleton=True)
+
+    assert lock_a is lock_b  # Same object
+
+Acquiring through one reference counts toward the same lock depth:
+
+.. code-block:: python
+
+    lock_a.acquire()
+    lock_b.acquire()  # Reentrant—lock counter is now 2
+    lock_b.release()  # Lock counter is 1
+    lock_a.release()  # Lock is fully released
+
+Parameters are frozen when the singleton is first created. Requesting with different parameters raises ``ValueError``:
+
+.. code-block:: python
+
+    lock1 = FileLock("work.lock", is_singleton=True, timeout=10)
+    lock2 = FileLock("work.lock", is_singleton=True, timeout=5)  # ValueError!
+
+*****************************************
+ Use shared read / exclusive write locks
+*****************************************
+
+When you have many readers and occasional writers, use :class:`ReadWriteLock <filelock.ReadWriteLock>` to allow readers
+to proceed concurrently. The lock file must use a ``.db`` extension because ``ReadWriteLock`` is backed by SQLite:
+
+.. code-block:: python
+
+    from filelock import ReadWriteLock
+
+    rw = ReadWriteLock("data.db")
+
+    # Multiple processes can read simultaneously
+    with rw.read_lock():
+        data = get_shared_data()
+
+    # Only one process can write at a time
+    with rw.write_lock():
+        update_shared_data()
+
+You can pass ``timeout`` and ``blocking`` to the context managers:
+
+.. code-block:: python
+
+    with rw.read_lock(timeout=5):
+        data = get_shared_data()
+
+    with rw.write_lock(timeout=10, blocking=True):
+        update_shared_data()
+
+``ReadWriteLock`` is singleton by default (``is_singleton=True``). Calling ``ReadWriteLock("data.db")`` with the same
+path returns the same instance, unlike ``FileLock`` which defaults to ``is_singleton=False``.
+
+Use low-level methods for more control:
+
+.. code-block:: python
+
+    rw.acquire_read(timeout=5)
+    try:
+        data = get_shared_data()
+    finally:
+        rw.release()
+
+    rw.acquire_write(timeout=5)
+    try:
+        update_shared_data()
+    finally:
+        rw.release()
+
+Read locks are reentrant from the same thread:
+
+.. code-block:: python
+
+    with rw.read_lock():
+        with rw.read_lock():  # OK
+            pass
+
+Write locks are also reentrant from the same thread:
+
+.. code-block:: python
+
+    with rw.write_lock():
+        with rw.write_lock():  # OK
+            pass
+
+But upgrading from read to write (or downgrading) raises an error:
+
+.. code-block:: python
+
+    with rw.read_lock():
+        with rw.write_lock():  # RuntimeError
+            pass
+
+When you're done with a ``ReadWriteLock``, close it to release the underlying SQLite connection:
+
+.. code-block:: python
+
+    rw = ReadWriteLock("data.db")
+    try:
+        with rw.read_lock():
+            data = get_shared_data()
+    finally:
+        rw.close()  # releases any held lock and closes the SQLite connection
+
+**************************************
+ Detect stale locks (soft locks only)
+**************************************
+
+:class:`SoftFileLock <filelock.SoftFileLock>` stores the PID and hostname of the lock holder. On Unix and macOS, it can
+detect when the holding process has died and automatically break stale locks.
+
+This happens automatically—you don't need to do anything special:
+
+.. code-block:: python
+
+    from filelock import SoftFileLock
+
+    lock = SoftFileLock("work.lock")
+
+    with lock:
+        # If the process holding the lock dies,
+        # another process will automatically clean up the stale lock
+        pass
+
+Stale lock detection only works on Unix/macOS and only detects locks from the same host. Cross-host stale locks still
+require manual removal.
+
+On Windows, stale lock detection is skipped because the lock file cannot be atomically renamed while another process
+holds a handle to it.
+
+*****************
+ Control logging
+*****************
+
+All log messages use the ``DEBUG`` level under the ``filelock`` logger name. Control logging via Python's standard
+library:
+
+.. code-block:: python
+
+    import logging
+
+    # Hide filelock debug messages
+    logging.getLogger("filelock").setLevel(logging.INFO)
+
+    # Or show all messages
+    logging.getLogger("filelock").setLevel(logging.DEBUG)
+
+    # Configure a handler to see them
+    handler = logging.StreamHandler()
+    logging.getLogger("filelock").addHandler(handler)
+
+*******************
+ Set lock lifetime
+*******************
+
+You can create locks that automatically expire after a certain time:
+
+.. code-block:: python
+
+    from filelock import FileLock
+
+    # Lock expires after 3600 seconds (1 hour)
+    lock = FileLock("work.lock", lifetime=3600)
+
+    with lock:
+        # Lock is held, but will auto-expire after 1 hour
+        pass
+
+This is useful for distributed systems where a process might crash and leave a lock behind. After the lifetime expires,
+other processes can acquire it automatically.
+
+**************************
+ Cancel lock acquisition
+**************************
+
+You can interrupt a waiting ``acquire()`` by passing a ``cancel_check`` callable. The lock polls this function between
+retry attempts and raises :class:`Timeout <filelock.Timeout>` when it returns ``True``:
+
+.. code-block:: python
+
+    import threading
+    from filelock import FileLock, Timeout
+
+    shutdown = threading.Event()
+    lock = FileLock("work.lock")
+
+    try:
+        with lock.acquire(timeout=-1, cancel_check=shutdown.is_set):
+            print("Got the lock")
+    except Timeout:
+        print("Acquisition canceled")
+
+    # From another thread:
+    shutdown.set()  # causes the acquire loop to stop
+
+This is useful in long-running services where you need to shut down gracefully without waiting for a lock that may never
+become available.
+
+.. mermaid::
+
+    sequenceDiagram
+        participant W as Worker Thread
+        participant L as File Lock
+        participant M as Main Thread
+        W->>L: acquire(cancel_check=shutdown.is_set)
+        loop Every poll_interval
+            L->>L: Try lock (busy)
+            L->>W: Check cancel_check()
+            W-->>L: False (keep waiting)
+        end
+        M->>M: shutdown.set()
+        L->>W: Check cancel_check()
+        W-->>L: True (cancel!)
+        L->>W: Raise Timeout
+        Note over W: Clean shutdown
+
+***********************
+ Force-release a lock
+***********************
+
+When a lock is acquired multiple times (reentrant), ``release()`` only decrements the counter. To immediately release
+regardless of the counter, pass ``force=True``:
+
+.. code-block:: python
+
+    from filelock import FileLock
+
+    lock = FileLock("work.lock")
+
+    lock.acquire()
+    lock.acquire()
+    print(lock.lock_counter)  # 2
+
+    lock.release(force=True)
+    print(lock.is_locked)  # False — fully released
+
+This is useful in error recovery or cleanup handlers where you need to ensure the lock is fully released:
+
+.. code-block:: python
+
+    import signal
+
+    lock = FileLock("work.lock")
+
+
+    def cleanup(signum, frame):
+        lock.release(force=True)
+        raise SystemExit(1)
+
+
+    signal.signal(signal.SIGTERM, cleanup)
+
+*******************************
+ Check your own lock state
+*******************************
+
+Use the :attr:`~filelock.BaseFileLock.is_locked` property to check whether *your* lock instance currently holds the
+lock, and :attr:`~filelock.BaseFileLock.lock_counter` to see the reentrant depth:
+
+.. code-block:: python
+
+    from filelock import FileLock
+
+    lock = FileLock("work.lock")
+
+    if not lock.is_locked:
+        with lock:
+            print(f"Lock depth: {lock.lock_counter}")
+
+These properties reflect the state of your lock instance only. To check if *another* process holds the lock, try to
+acquire with ``blocking=False``:
+
+.. code-block:: python
+
+    from filelock import FileLock, Timeout
+
+    lock = FileLock("work.lock")
+
+    try:
+        with lock.acquire(blocking=False):
+            print("Lock was free")
+    except Timeout:
+        print("Lock is held by another process")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,466 +1,151 @@
-filelock
-========
+##########
+ filelock
+##########
 
 A platform-independent file locking library for Python, providing inter-process synchronization:
 
 .. code-block:: python
 
-    from filelock import Timeout, FileLock
+    from filelock import FileLock
 
     lock = FileLock("high_ground.txt.lock")
     with lock:
-        with open("high_ground.txt", "a") as file_handler:
-            file_handler.write("You were the chosen one.")
-
-**Don't use** a :class:`FileLock <filelock.FileLock>` to lock the file you want to write to, instead create a separate
-``.lock`` file as shown above.
+        with open("high_ground.txt", "a") as f:
+            f.write("You were the chosen one.")
 
 .. image:: example.gif
-  :alt: Example gif
+    :alt: filelock in action
 
+**************
+ Installation
+**************
 
-Similar libraries
------------------
-
-Perhaps you are looking for something like:
-
-- the `pid <https://pypi.org/project/pid/>`_ 3rd party library,
-- for Windows the `msvcrt <https://docs.python.org/3/library/msvcrt.html#msvcrt.locking>`_ module in the standard
-  library,
-- for UNIX the `fcntl <https://docs.python.org/3/library/fcntl.html#fcntl.flock>`_ module in the standard library,
-- the `flufl.lock <https://pypi.org/project/flufl.lock/>`_ 3rd party library,
-- the `fasteners <https://pypi.org/project/fasteners/>`_ 3rd party library.
-
-
-Installation
-------------
-
-``filelock`` is available via PyPI, so you can pip install it:
+``filelock`` is available via PyPI:
 
 .. code-block:: bash
 
     python -m pip install filelock
 
-Usage
------
+****************
+ Learn filelock
+****************
 
-Tutorial
-^^^^^^^^
+.. grid:: 1 2 2 2
+    :gutter: 2
 
-A :class:`FileLock <filelock.FileLock>` is used to indicate to another process of your application that a resource or
-working directory is currently in use. To do so, create a :class:`FileLock <filelock.FileLock>` first:
+    .. grid-item-card::
+        **New to file locking?**
 
-.. code-block:: python
+        Start with the :doc:`tutorials` to learn the basics through hands-on examples.
 
-    from pathlib import Path
+    .. grid-item-card::
+        **Have a specific task?**
 
-    from filelock import Timeout, FileLock
+        Check :doc:`how-to` for task-oriented solutions to real-world problems.
 
-    file_path = Path("high_ground.txt")
-    lock_path = Path("high_ground.txt.lock")
+    .. grid-item-card::
+        **Want to understand the design?**
 
-    lock = FileLock(lock_path, timeout=1)
+        Read :doc:`concepts` to explore design decisions and trade-offs.
 
-The lock object represents an exclusive lock and can be acquired in multiple ways, including the ones used to acquire
-standard Python thread locks:
+    .. grid-item-card::
+        **Need API details?**
 
-.. code-block:: python
+        See the :doc:`api` reference for complete technical documentation.
 
-    with lock:
-        if not file_path.exists():
-            file_path.write_text("Hello there!")
-    # here, all processes can see consistent content in the file
+************
+ Lock Types
+************
 
-    lock.acquire()
-    try:
-        if not file_path.exists():
-            file_path.write_text("General Kenobi!")
-    finally:
-        lock.release()
-    # here, all processes can see consistent content in the file
+Choose the right lock for your use case:
 
-    @lock
-    def decorated():
-        print("You're a decorated Jedi!")
+.. grid:: 1 2 2 2
+    :gutter: 2
 
+    .. grid-item-card::
+        **FileLock**
 
-    decorated()
+        Platform-aware alias. Uses OS-level locking (``fcntl``/``msvcrt``) with automatic fallback to soft locks.
 
-Note: When a process gets the lock (i.e. within the ``with lock:`` region), it is usually good to check what has
-already been done by other processes. For example, each process above first checks the existence of the file. If
-it is already created, we should not destroy the work of other processes. This is typically the case when we want
-just one process to write content into a file, and let every process read the content.
+        - ✓ Recommended default
+        - ✓ Lifetime expiration, cancellable acquire
+        - ✓ Self-deadlock detection
 
-The lock objects are reentrant, which means that once acquired, they will not block on successive lock requests:
+    .. grid-item-card::
+        **SoftFileLock**
 
-.. code-block:: python
+        File-existence based locking. Works on any filesystem including network mounts.
 
-    def cite1():
-        with lock:
-            with file_path.open("a") as file_handler:
-                file_handler.write("I hate it when he does that.")
+        - ✓ Network filesystems
+        - ✓ Stale detection (Unix)
+        - ✓ Lifetime expiration, cancellable acquire
 
+    .. grid-item-card::
+        **ReadWriteLock**
 
-    def cite2():
-        with lock:
-            with file_path.open("a") as file_handler:
-                file_handler.write("You don't want to sell me death sticks.")
+        SQLite-backed multiple readers + one writer. Singleton by default.
 
+        - ✓ Concurrent readers
+        - ✓ Reentrant per mode
+        - ✗ No async, no lifetime
 
-    # The lock is acquired here.
-    with lock:
-        cite1()
-        cite2()
-    # And released here.
+    .. grid-item-card::
+        **AsyncFileLock**
 
-It should also be noted that the lock is released during garbage collection.
-Put another way, if you do not assign an acquired lock to a variable,
-the lock will eventually be released (implicitly, not explicitly).
-For this reason, using the lock in the way shown below is not something you should ever do,
-always use the context manager (``with`` form) instead.
+        Async-compatible variants. Run blocking I/O in thread pool or custom executor.
 
-This issue is illustrated with code below:
+        - ✓ Async/await support
+        - ✓ All lock types
+        - ✓ Custom executor and event loop
 
-.. code-block:: python
+******************
+ Platform Support
+******************
 
-    # If you create a lock and acquire it but don't assign it,
-    # you will not actually hold the lock forever.
-    # Instead, the lock is released
-    # when the created variable is garbage collected.
-    FileLock(lock_path).acquire()
-    # At some point after the creation above,
-    # the lock is released again even though there is no explicit call to `release`.
+.. grid:: 1 2 2 2
+    :gutter: 2
 
-    # If you instead assign to a dummy variable,
-    # the lock will be held
-    _ = FileLock(lock_path).acquire()
-    # Now the lock is being held
-    # (at least until `_` is reassigned and the lock is garbage collected)
+    .. grid-item-card::
+        **Windows**
 
-Timeouts and non-blocking locks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        Uses ``msvcrt.locking``. Enforced by the kernel.
 
-The :meth:`acquire <filelock.BaseFileLock.acquire>` method accepts a ``timeout`` parameter. If the lock cannot be
-acquired within ``timeout`` seconds, a :class:`Timeout <filelock.Timeout>` exception is raised:
+        - ✓ Native support
+        - ✓ Most reliable
 
-.. code-block:: python
+    .. grid-item-card::
+        **Unix / macOS**
 
-    try:
-        with lock.acquire(timeout=10):
-            with file_path.open("a") as file_handler:
-                file_handler.write("I have a bad feeling about this.")
-    except Timeout:
-        print("Another instance of this application currently holds the lock.")
+        Uses ``fcntl.flock``. POSIX standard, kernel-enforced.
 
-Using a ``timeout < 0`` makes the lock block until it can be acquired
-while ``timeout == 0`` results in only one attempt to acquire the lock before raising a :class:`Timeout <filelock.Timeout>` exception (-> non-blocking).
+        - ✓ Native support
+        - ✓ Stale detection
 
-You can also use the ``blocking`` parameter to attempt a non-blocking :meth:`acquire <filelock.BaseFileLock.acquire>`.
+    .. grid-item-card::
+        **Other Platforms**
 
-.. code-block:: python
+        Automatic fallback to ``SoftFileLock``. Portable across all filesystems.
 
-    try:
-        with lock.acquire(blocking=False):
-            with file_path.open("a") as file_handler:
-                file_handler.write("I have a bad feeling about this.")
-    except Timeout:
-        print("Another instance of this application currently holds the lock.")
-
-
-The ``blocking`` option takes precedence over ``timeout``.
-Meaning, if you set ``blocking=False`` while ``timeout > 0``, a :class:`Timeout <filelock.Timeout>` exception is raised without waiting for the lock to release.
-
-You can pre-parametrize both of these options when constructing the lock for ease-of-use.
-
-.. code-block:: python
-
-    from filelock import Timeout, FileLock
-
-    lock_1 = FileLock("high_ground.txt.lock", blocking = False)
-    try:
-        with lock_1:
-            # do some work
-            pass
-    except Timeout:
-        print("Well, we tried once and couldn't acquire.")
-
-    lock_2 = FileLock("high_ground.txt.lock", timeout = 10)
-    try:
-        with lock_2:
-            # do some other work
-            pass
-    except Timeout:
-        print("Ten seconds feel like forever sometimes.")
-
-Poll interval
-^^^^^^^^^^^^^
-
-When the lock cannot be acquired immediately, the :meth:`acquire <filelock.BaseFileLock.acquire>` method retries at a
-fixed interval. The ``poll_interval`` parameter controls how many seconds to wait between attempts (default ``0.05``).
-
-You can pass ``poll_interval`` directly to :meth:`acquire <filelock.BaseFileLock.acquire>`:
-
-.. code-block:: python
-
-    with lock.acquire(poll_interval=0.1):
-        with file_path.open("a") as file_handler:
-            file_handler.write("Patience you must have, my young Padawan.")
-
-Or set it on the constructor so that it applies when using the lock as a context manager:
-
-.. code-block:: python
-
-    lock = FileLock("high_ground.txt.lock", poll_interval=0.25)
-    with lock:
-        with file_path.open("a") as file_handler:
-            file_handler.write("This is where the fun begins.")
-
-The default can also be changed at any time via the :attr:`~filelock.BaseFileLock.poll_interval` property:
-
-.. code-block:: python
-
-    lock.poll_interval = 0.5
-
-Logging
-^^^^^^^
-
-All log messages by this library are made using the ``DEBUG`` level, under the ``filelock`` name. On how to control
-displaying/hiding that please consult the
-`logging documentation of the standard library <https://docs.python.org/3/howto/logging.html>`_. E.g. to hide these
-messages you can use:
-
-.. code-block:: python
-
-    logging.getLogger("filelock").setLevel(logging.INFO)
-
-Lock types
-----------
-
-Choosing the right lock
-^^^^^^^^^^^^^^^^^^^^^^^
-
-This library provides several lock implementations. Pick the one that matches your use case:
-
-- :class:`FileLock <filelock.FileLock>` (recommended default) -- a platform-aware alias that resolves to the best
-  available backend at import time:
-
-  - **Windows** -- :class:`WindowsFileLock <filelock.WindowsFileLock>` (``msvcrt.locking``)
-  - **Unix / macOS** -- :class:`UnixFileLock <filelock.UnixFileLock>` (``fcntl.flock``)
-  - **Other** (no ``fcntl``) -- :class:`SoftFileLock <filelock.SoftFileLock>` (file-existence fallback, emits a warning)
-
-  Always import :class:`FileLock <filelock.FileLock>` rather than a platform-specific class unless you have a reason
-  to pin the backend. For async code, use :class:`AsyncFileLock <filelock.AsyncFileLock>` (same platform resolution).
-
-  *Limitations*: exclusive only -- no shared/reader mode. May not work correctly on some network filesystems (e.g. NFS)
-  where OS-level locking is unreliable.
-
-- :class:`SoftFileLock <filelock.SoftFileLock>` -- portable file-existence lock. Works on any filesystem, including
-  network mounts where OS-level locking may be unavailable. Async variant:
-  :class:`AsyncSoftFileLock <filelock.AsyncSoftFileLock>`.
-
-  The lock file stores the holder's PID and hostname. On **Unix and macOS**, when a competing process finds an existing
-  lock, it checks whether the holder is still alive (same host only). If the holding process has died, the stale lock
-  is automatically broken via an atomic rename-and-delete sequence. Stale locks from a different host, or lock files
-  with unrecognized content (e.g. from an older version), are left untouched and fall back to the normal retry/timeout
-  behavior.
-
-  *Limitations*: stale lock detection is **not available on Windows** -- Python's C runtime (``_wopen``) cannot set
-  ``FILE_SHARE_DELETE``, so any read handle on the lock file blocks ``DeleteFileW`` in the release path, causing a
-  livelock under threaded contention. On Unix/macOS, stale detection only works when the holder and competitor are on
-  the same host -- cross-host stale locks still require manual removal. Exclusive only. See the TOCTOU warning below.
-
-- :class:`ReadWriteLock <filelock.ReadWriteLock>` -- shared reads / exclusive writes via SQLite. Use this when you need
-  concurrent readers with occasional writers. See :ref:`read-write-lock` below for details.
-
-  *Limitations*: higher overhead than ``FileLock`` due to SQLite transactions. Creates a ``.db`` file on disk.
-  No async variant. Cannot upgrade a read lock to a write lock (or vice versa). May not work on network filesystems
-  where SQLite locking is unreliable. Requires the ``sqlite3`` standard library module (unavailable if Python was built
-  without SQLite support).
-
-.. warning::
-
-   **Security Consideration - TOCTOU Vulnerability**: On platforms without ``O_NOFOLLOW`` support
-   (such as GraalPy), :class:`SoftFileLock <filelock.SoftFileLock>` may be vulnerable to symlink-based
-   Time-of-Check-Time-of-Use (TOCTOU) attacks. An attacker with local filesystem access could create
-   a symlink at the lock file path during the small race window between permission validation and file
-   creation.
-
-   On most modern platforms with ``O_NOFOLLOW`` support, this vulnerability is mitigated by refusing
-   to follow symlinks when creating the lock file.
-
-   For security-sensitive applications, prefer :class:`UnixFileLock <filelock.UnixFileLock>` or
-   :class:`WindowsFileLock <filelock.WindowsFileLock>` which provide stronger guarantees via OS-level
-   file locking. :class:`SoftFileLock <filelock.SoftFileLock>` should only be used as a fallback mechanism
-   on platforms where OS-level locking primitives are unavailable.
-
-.. _read-write-lock:
-
-ReadWriteLock
-^^^^^^^^^^^^^
-
-:class:`ReadWriteLock <filelock.ReadWriteLock>` provides cross-process shared/exclusive locking backed by SQLite
-transactions. Multiple processes can hold a read lock simultaneously, but a write lock is exclusive. Use this instead
-of :class:`FileLock <filelock.FileLock>` when your workload is read-heavy and you want readers to proceed without
-blocking each other. If you only need exclusive locking, prefer :class:`FileLock <filelock.FileLock>` -- it is
-lighter and faster.
-
-.. note::
-
-   :class:`ReadWriteLock <filelock.ReadWriteLock>` requires the ``sqlite3`` standard library module. If Python was built
-   without SQLite support, importing ``ReadWriteLock`` from ``filelock`` will return ``None``.
-
-Use the ``read_lock()`` and ``write_lock()`` context managers for the most common pattern:
-
-.. code-block:: python
-
-    from pathlib import Path
-
-    from filelock import ReadWriteLock
-
-    rw = ReadWriteLock("data.db")
-    data_path = Path("data.txt")
-
-    # Multiple processes/threads can read concurrently
-    with rw.read_lock():
-        data = data_path.read_text()
-
-    # Only one process/thread can write at a time
-    with rw.write_lock():
-        data_path.write_text("new content")
-
-For more control, use the low-level ``acquire_read()`` / ``acquire_write()`` / ``release()`` methods:
-
-.. code-block:: python
-
-    rw.acquire_write(timeout=5)
-    try:
-        data_path.write_text("new content")
-    finally:
-        rw.release()
-
-The lock is reentrant within the same mode -- nested read locks or nested write locks (from the same thread) work:
-
-.. code-block:: python
-
-    with rw.read_lock():
-        with rw.read_lock():  # OK, reentrant
-            pass
-
-Upgrading from read to write (or downgrading from write to read) raises ``RuntimeError``:
-
-.. code-block:: python
-
-    with rw.read_lock():
-        with rw.write_lock():  # RuntimeError: upgrade not allowed
-            pass
-
-Write locks are pinned to the thread that acquired them. A different thread attempting to re-enter an existing write
-lock raises ``RuntimeError``.
-
-.. note::
-
-   The lock file is a SQLite database. Use a ``.db`` extension by convention.
-
-FileLocks and threads
-^^^^^^^^^^^^^^^^^^^^^
-
-By default the :class:`FileLock <filelock.FileLock>` internally uses :class:`threading.local <threading.local>`
-to ensure that the lock is thread-local. If you have a use case where you'd like an instance of ``FileLock`` to be shared
-across threads, you can set the ``thread_local`` parameter to ``False`` when creating a lock. For example:
-
-.. code-block:: python
-
-    lock = FileLock("test.lock", thread_local=False)
-    # lock will be re-entrant across threads
-
-    # The same behavior would also work with other BaseFileLock subclasses like SoftFileLock:
-    from filelock import SoftFileLock
-
-    soft_lock = SoftFileLock("soft_test.lock", thread_local=False)
-    # soft_lock will be re-entrant across threads.
-
-
-Behavior where :class:`FileLock <filelock.FileLock>` is thread-local started in version 3.11.0. Previous versions
-were not thread-local by default.
-
-Note: If disabling thread-local, be sure to remember that locks are re-entrant: You will be able to
-:meth:`acquire <filelock.BaseFileLock.acquire>` the same lock multiple times across multiple threads.
-
-Singleton locks
-^^^^^^^^^^^^^^^
-
-All lock classes accept an ``is_singleton`` parameter. When ``True``, constructing a lock with the same file path
-returns the existing instance instead of creating a new one:
-
-.. code-block:: python
-
-    from filelock import FileLock
-
-    a = FileLock("test.lock", is_singleton=True)
-    b = FileLock("test.lock", is_singleton=True)
-    assert a is b  # same instance
-
-This is useful for reentrant locking without passing the same object around. Acquiring through one reference counts
-toward the same lock level:
-
-.. code-block:: python
-
-    a.acquire()
-    b.acquire()   # reentrant, lock_counter == 2
-    b.release()
-    a.release()   # fully released
-
-Parameters are fixed at creation time. Requesting a singleton with different ``timeout``, ``mode``, or ``blocking``
-raises ``ValueError``.
-
-.. note::
-
-   :class:`FileLock <filelock.FileLock>` and other :class:`BaseFileLock <filelock.BaseFileLock>` subclasses default to
-   ``is_singleton=False``. :class:`ReadWriteLock <filelock.ReadWriteLock>` defaults to ``is_singleton=True``.
-
-Asyncio support
-^^^^^^^^^^^^^^^
-
-Each :class:`BaseFileLock <filelock.BaseFileLock>` subclass has an async counterpart that can be used with
-``async with`` (:class:`ReadWriteLock <filelock.ReadWriteLock>` does not have an async variant):
-
-- :class:`AsyncFileLock <filelock.AsyncFileLock>`
-- :class:`AsyncSoftFileLock <filelock.AsyncSoftFileLock>`
-- :class:`AsyncUnixFileLock <filelock.AsyncUnixFileLock>`
-- :class:`AsyncWindowsFileLock <filelock.AsyncWindowsFileLock>`
-
-.. code-block:: python
-
-    from pathlib import Path
-
-    from filelock import AsyncFileLock
-
-    lock = AsyncFileLock("high_ground.txt.lock")
-
-    async with lock:
-        with Path("high_ground.txt").open("a") as file_handler:
-            file_handler.write("You were the chosen one.")
-
-By default, the underlying blocking I/O runs in a thread-pool executor (``run_in_executor=True``). You can pass a
-custom executor or set ``run_in_executor=False`` to run the I/O directly in the event loop (only advisable when the
-filesystem is known to be non-blocking).
-
-.. warning::
-
-   ``thread_local=True`` and ``run_in_executor=True`` are incompatible. Creating a lock with both raises
-   ``ValueError``. Async locks default to ``thread_local=False``.
-
-Contributions and issues
-------------------------
-
-Contributions are always welcome, please make sure they pass all tests before creating a pull request. This project is
-hosted on `GitHub <https://github.com/tox-dev/py-filelock>`_. If you have any questions or suggestions, don't hesitate
-to open a new issue 😊. There's no bad question, just a missed opportunity to learn more.
+        - ✓ Full compatibility
+        - ✓ Network filesystems
+
+*******************
+ Similar libraries
+*******************
+
+- `pid <https://pypi.org/project/pid/>`_ - process ID file locks
+- `msvcrt <https://docs.python.org/3/library/msvcrt.html#msvcrt.locking>`_ - Windows file locking (stdlib)
+- `fcntl <https://docs.python.org/3/library/fcntl.html#fcntl.flock>`_ - Unix file locking (stdlib)
+- `flufl.lock <https://pypi.org/project/flufl.lock/>`_ - Another file locking library
+- `fasteners <https://pypi.org/project/fasteners/>`_ - Cross-platform locks and synchronization
 
 .. toctree::
-   :hidden:
+    :hidden:
 
-   self
-   api
-   license
-   changelog
+    self
+    tutorials
+    how-to
+    concepts
+    api
+    license
+    changelog

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,5 +1,6 @@
-License
-=======
+#########
+ License
+#########
 
 *py-filelock* is licensed under the MIT License:
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1,0 +1,187 @@
+###########
+ Tutorials
+###########
+
+This section guides you through the fundamentals of file locking. We'll learn by doing, starting with the basics and
+building up to more advanced patterns.
+
+*****************
+ Your first lock
+*****************
+
+Let's create our first lock and use it to coordinate between processes.
+
+First, we'll import what we need and create a lock object:
+
+.. code-block:: python
+
+    from pathlib import Path
+    from filelock import FileLock
+
+    lock = FileLock("myapp.lock")
+
+Now we have a lock object that represents a lock file on disk. We can use the lock with a context manager (the ``with``
+statement):
+
+.. code-block:: python
+
+    with lock:
+        # Inside this block, we hold the lock
+        print("I have the lock!")
+    # Outside this block, the lock is released
+
+Run this code multiple times in different terminal windows at the same time. You'll see that only one process prints the
+message at a time—the others wait for their turn. The lock is working correctly!
+
+************************
+ Protecting shared data
+************************
+
+File locks are most useful when protecting data that multiple processes access. Let's see how:
+
+.. code-block:: python
+
+    from pathlib import Path
+    from filelock import FileLock
+
+    data_file = Path("data.txt")
+    lock = FileLock("data.txt.lock")
+
+    # Process A writes a greeting
+    with lock:
+        if not data_file.exists():
+            data_file.write_text("Hello from Process A\n")
+
+    # Process B appends another greeting
+    with lock:
+        with data_file.open("a") as f:
+            f.write("Hello from Process B\n")
+
+The key pattern here: **Before making changes, check what's already done.** Process A checks if the file exists before
+writing. Process B doesn't need to check because it's just appending. But both use the lock to ensure only one process
+modifies the file at a time.
+
+Run this code from two different processes. The file will contain messages from both in a consistent order.
+
+*****************
+ Reentrant locks
+*****************
+
+Sometimes you need to acquire the same lock multiple times from the same process or thread. The lock allows this:
+
+.. code-block:: python
+
+    from filelock import FileLock
+
+    lock = FileLock("reentrant.lock")
+
+
+    def helper_function():
+        with lock:
+            print("Helper has the lock")
+
+
+    with lock:
+        print("Main code has the lock")
+        helper_function()  # Can acquire the same lock again
+        print("Still have the lock")
+
+No deadlock occurs—the lock counts how many times it's been acquired and releases only when the count reaches zero. You
+can inspect this counter and the lock state at any time:
+
+.. code-block:: python
+
+    lock = FileLock("reentrant.lock")
+
+    print(lock.is_locked)     # False
+    print(lock.lock_counter)  # 0
+
+    lock.acquire()
+    print(lock.is_locked)     # True
+    print(lock.lock_counter)  # 1
+
+    lock.acquire()
+    print(lock.lock_counter)  # 2
+
+    lock.release()
+    print(lock.lock_counter)  # 1 — still locked
+    print(lock.is_locked)     # True
+
+    lock.release()
+    print(lock.lock_counter)  # 0 — fully released
+    print(lock.is_locked)     # False
+
+Key lesson: You can safely call functions that acquire a lock, even if you already hold the lock.
+
+*****************************
+ Multiple ways to use a lock
+*****************************
+
+So far we've used the ``with`` statement. There are other ways:
+
+**Manual acquire and release:**
+
+.. code-block:: python
+
+    lock.acquire()
+    try:
+        print("I have the lock")
+    finally:
+        lock.release()
+
+Always use a ``try/finally`` block to guarantee the lock is released, even if an exception occurs.
+
+**As a decorator:**
+
+.. code-block:: python
+
+    @lock
+    def protected_operation():
+        print("This function runs with the lock held")
+
+
+    protected_operation()  # Lock is acquired, function runs, lock is released
+
+Choose whichever feels most natural for your code. The ``with`` statement is usually clearest.
+
+Important: Always use the context manager
+=========================================
+
+Avoid this pattern:
+
+.. code-block:: python
+
+    FileLock("my.lock").acquire()  # ⚠️ Don't do this
+    # The lock might be released during garbage collection
+    # before your code finishes
+
+This doesn't work reliably because if you don't assign the lock to a variable, Python's garbage collector might release
+it before you're done with it.
+
+Instead, always keep a reference to the lock object:
+
+.. code-block:: python
+
+    lock = FileLock("my.lock")
+    with lock:  # ✓ Good
+        # your code here
+        pass
+
+**************************
+ Thread-local by default
+**************************
+
+By default, each lock uses thread-local state (``thread_local=True``). This means each thread tracks its own lock
+counter independently. Two threads holding the same ``FileLock`` object each get their own reentrant state.
+
+Async locks default to ``thread_local=False`` because they run in a thread pool where the acquiring thread may differ
+from the releasing thread.
+
+See :ref:`how-to:Use locks with multiple threads` for practical examples of controlling this behavior.
+
+************
+ Next steps
+************
+
+- Want to handle timeouts, cancellation, or force-release? See :doc:`how-to`.
+- Curious about how locks work across different platforms? Read :doc:`concepts`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,11 @@ docs = [
   "furo>=2025.12.19",
   "sphinx>=9.1",
   "sphinx-autodoc-typehints>=3.6.2",
+  "sphinx-copybutton>=0.5.2",
+  "sphinx-design>=0.6.1",
+  "sphinx-sitemap>=2.6",
+  "sphinxcontrib-mermaid>=0.9.5",
+  "sphinxext-opengraph>=0.10.2",
 ]
 coverage = [
   "covdefaults>=2.3",

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -2,7 +2,7 @@
 A platform independent file lock that supports the with-statement.
 
 .. autodata:: filelock.__version__
-   :no-value:
+    :no-value:
 
 """
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -179,9 +179,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     """
     Abstract base class for a file lock object.
 
-    Provides a reentrant, cross-process exclusive lock backed by OS-level primitives. Subclasses implement the
-    actual locking mechanism (:class:`UnixFileLock <filelock.UnixFileLock>`,
-    :class:`WindowsFileLock <filelock.WindowsFileLock>`, :class:`SoftFileLock <filelock.SoftFileLock>`).
+    Provides a reentrant, cross-process exclusive lock backed by OS-level primitives. Subclasses implement the actual
+    locking mechanism (:class:`UnixFileLock <filelock.UnixFileLock>`, :class:`WindowsFileLock
+    <filelock.WindowsFileLock>`, :class:`SoftFileLock <filelock.SoftFileLock>`).
+
     """
 
     _instances: WeakValueDictionary[str, BaseFileLock]
@@ -207,22 +208,22 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         Create a new lock object.
 
         :param lock_file: path to the file
-        :param timeout: default timeout when acquiring the lock, in seconds. It will be used as fallback value in
-            the acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it
-            to a negative value. A timeout of 0 means that there is exactly one attempt to acquire the file lock.
-        :param mode: file permissions for the lockfile. When not specified, the OS controls permissions via umask
-            and default ACLs, preserving POSIX default ACL inheritance in shared directories.
-        :param thread_local: Whether this object's internal context should be thread local or not. If this is set
-            to ``False`` then the lock will be reentrant across threads.
+        :param timeout: default timeout when acquiring the lock, in seconds. It will be used as fallback value in the
+            acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it to a
+            negative value. A timeout of 0 means that there is exactly one attempt to acquire the file lock.
+        :param mode: file permissions for the lockfile. When not specified, the OS controls permissions via umask and
+            default ACLs, preserving POSIX default ACL inheritance in shared directories.
+        :param thread_local: Whether this object's internal context should be thread local or not. If this is set to
+            ``False`` then the lock will be reentrant across threads.
         :param blocking: whether the lock should be blocking or not
-        :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per
-            lock file. This is useful if you want to use the lock object for reentrant locking without needing to
-            pass the same object around.
-        :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback
-            value in the acquire method, if no poll_interval value (``None``) is given.
-        :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set,
-            a waiting process will break a lock whose file modification time is older than ``lifetime`` seconds.
-            ``None`` (the default) means locks never expire.
+        :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per lock
+            file. This is useful if you want to use the lock object for reentrant locking without needing to pass the
+            same object around.
+        :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback value
+            in the acquire method, if no poll_interval value (``None``) is given.
+        :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set, a waiting
+            process will break a lock whose file modification time is older than ``lifetime`` seconds. ``None`` (the
+            default) means locks never expire.
 
         """
         self._is_thread_local = thread_local
@@ -241,29 +242,31 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         self._context: FileLockContext = (ThreadLocalFileContext if thread_local else FileLockContext)(**kwargs)
 
     def is_thread_local(self) -> bool:
-        """:return: a flag indicating if this lock is thread local or not"""
+        """:returns: a flag indicating if this lock is thread local or not"""
         return self._is_thread_local
 
     @property
     def is_singleton(self) -> bool:
         """
-        :return: a flag indicating if this lock is singleton or not
+        :returns: a flag indicating if this lock is singleton or not
 
         .. versionadded:: 3.13.0
+
         """
         return self._is_singleton
 
     @property
     def lock_file(self) -> str:
-        """:return: path to the lock file"""
+        """:returns: path to the lock file"""
         return self._context.lock_file
 
     @property
     def timeout(self) -> float:
         """
-        :return: the default timeout value, in seconds
+        :returns: the default timeout value, in seconds
 
         .. versionadded:: 2.0.0
+
         """
         return self._context.timeout
 
@@ -280,9 +283,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     @property
     def blocking(self) -> bool:
         """
-        :return: whether the locking is blocking or not
+        :returns: whether the locking is blocking or not
 
         .. versionadded:: 3.14.0
+
         """
         return self._context.blocking
 
@@ -299,9 +303,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     @property
     def poll_interval(self) -> float:
         """
-        :return: the default polling interval, in seconds
+        :returns: the default polling interval, in seconds
 
         .. versionadded:: 3.24.0
+
         """
         return self._context.poll_interval
 
@@ -318,9 +323,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     @property
     def lifetime(self) -> float | None:
         """
-        :return: the lock lifetime in seconds, or ``None`` if the lock never expires
+        :returns: the lock lifetime in seconds, or ``None`` if the lock never expires
 
         .. versionadded:: 3.24.0
+
         """
         return self._context.lifetime
 
@@ -336,16 +342,16 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
 
     @property
     def mode(self) -> int:
-        """:return: the file permissions for the lockfile"""
+        """:returns: the file permissions for the lockfile"""
         return 0o644 if self._context.mode == _UNSET_FILE_MODE else self._context.mode
 
     @property
     def has_explicit_mode(self) -> bool:
-        """:return: whether the file permissions were explicitly set"""
+        """:returns: whether the file permissions were explicitly set"""
         return self._context.mode != _UNSET_FILE_MODE
 
     def _open_mode(self) -> int:
-        """:return: the mode for os.open() — 0o666 when unset (let umask/ACLs decide), else the explicit mode"""
+        """:returns: the mode for os.open() — 0o666 when unset (let umask/ACLs decide), else the explicit mode"""
         return 0o666 if self._context.mode == _UNSET_FILE_MODE else self._context.mode
 
     def _try_break_expired_lock(self) -> None:
@@ -372,17 +378,18 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     @property
     def is_locked(self) -> bool:
         """
-        :return: A boolean indicating if the lock file is holding the lock currently.
+        :returns: A boolean indicating if the lock file is holding the lock currently.
 
         .. versionchanged:: 2.0.0
 
             This was previously a method and is now a property.
+
         """
         return self._context.lock_file_fd is not None
 
     @property
     def lock_counter(self) -> int:
-        """:return: The number of times this lock has been acquired (but not yet released)."""
+        """:returns: The number of times this lock has been acquired (but not yet released)."""
         return self._context.lock_counter
 
     @staticmethod
@@ -418,17 +425,19 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         """
         Try to acquire the file lock.
 
-        :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default :attr:`~timeout`
-            is and if ``timeout < 0``, there is no timeout and this method will block until the lock could be acquired
+        :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default :attr:`~timeout` is and
+            if ``timeout < 0``, there is no timeout and this method will block until the lock could be acquired
         :param poll_interval: interval of trying to acquire the lock file, ``None`` means use the default
             :attr:`~poll_interval`
         :param poll_intervall: deprecated, kept for backwards compatibility, use ``poll_interval`` instead
-        :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on
-            the first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
-        :param cancel_check: a callable returning ``True`` when the acquisition should be canceled. Checked on each
-            poll iteration. When triggered, raises :class:`~Timeout` just like an expired timeout.
+        :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on the
+            first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
+        :param cancel_check: a callable returning ``True`` when the acquisition should be canceled. Checked on each poll
+            iteration. When triggered, raises :class:`~Timeout` just like an expired timeout.
+
+        :returns: a context object that will unlock the file when the context is exited
+
         :raises Timeout: if fails to acquire lock within the timeout period
-        :return: a context object that will unlock the file when the context is exited
 
         .. code-block:: python
 
@@ -445,8 +454,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
 
         .. versionchanged:: 2.0.0
 
-            This method returns now a *proxy* object instead of *self*,
-            so that it can be used in a with statement without side effects.
+            This method returns now a *proxy* object instead of *self*, so that it can be used in a with statement
+            without side effects.
 
         """
         # Use the default timeout, if no timeout is provided.
@@ -513,8 +522,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
 
     def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
         """
-        Releases the file lock. Please note, that the lock is only completely released, if the lock counter is 0.
-        Also note, that the lock file itself is not automatically deleted.
+        Release the file lock. The lock is only completely released when the lock counter reaches 0. The lock file
+        itself is not automatically deleted.
 
         :param force: If true, the lock counter is ignored and the lock is released in every case.
 
@@ -535,7 +544,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         """
         Acquire the lock.
 
-        :return: the lock object
+        :returns: the lock object
 
         """
         self.acquire()

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -21,7 +21,7 @@ class Timeout(TimeoutError):  # noqa: N818
 
     @property
     def lock_file(self) -> str:
-        """:return: The path of the file lock."""
+        """:returns: The path of the file lock."""
         return self._lock_file
 
 

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -19,13 +19,14 @@ class SoftFileLock(BaseFileLock):
     """
     Portable file lock based on file existence.
 
-    Unlike :class:`UnixFileLock <filelock.UnixFileLock>` and :class:`WindowsFileLock <filelock.WindowsFileLock>`,
-    this lock does not use OS-level locking primitives. Instead, it creates the lock file with ``O_CREAT | O_EXCL``
-    and treats its existence as the lock indicator. This makes it work on any filesystem but leaves stale lock files
-    behind if the process crashes without releasing the lock.
+    Unlike :class:`UnixFileLock <filelock.UnixFileLock>` and :class:`WindowsFileLock <filelock.WindowsFileLock>`, this
+    lock does not use OS-level locking primitives. Instead, it creates the lock file with ``O_CREAT | O_EXCL`` and
+    treats its existence as the lock indicator. This makes it work on any filesystem but leaves stale lock files behind
+    if the process crashes without releasing the lock.
 
     To mitigate stale locks, the lock file contains the PID and hostname of the holding process. On contention, if the
     holder is on the same host and its PID no longer exists, the stale lock is broken automatically.
+
     """
 
     def _acquire(self) -> None:

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -15,6 +15,7 @@ def raise_on_not_writable_file(filename: str) -> None:
     locked.
 
     :param filename: file to check
+
     :raises OSError: as if the file was opened for writing.
 
     """

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -27,8 +27,11 @@ if sys.platform == "win32":  # pragma: win32 cover
         Check if a path is a reparse point (symlink, junction, etc.) on Windows.
 
         :param path: Path to check
-        :return: True if path is a reparse point, False otherwise
+
+        :returns: True if path is a reparse point, False otherwise
+
         :raises OSError: If GetFileAttributesW fails for reasons other than file-not-found
+
         """
         attrs = _kernel32.GetFileAttributesW(path)
         if attrs == INVALID_FILE_ATTRIBUTES:

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -109,6 +109,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     Base class for asynchronous file locks.
 
     .. versionadded:: 3.15.0
+
     """
 
     def __init__(  # noqa: PLR0913
@@ -130,22 +131,22 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         Create a new lock object.
 
         :param lock_file: path to the file
-        :param timeout: default timeout when acquiring the lock, in seconds. It will be used as fallback value in
-            the acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it
-            to a negative value. A timeout of 0 means that there is exactly one attempt to acquire the file lock.
-        :param mode: file permissions for the lockfile. When not specified, the OS controls permissions via umask
-            and default ACLs, preserving POSIX default ACL inheritance in shared directories.
-        :param thread_local: Whether this object's internal context should be thread local or not. If this is set
-            to ``False`` then the lock will be reentrant across threads.
+        :param timeout: default timeout when acquiring the lock, in seconds. It will be used as fallback value in the
+            acquire method, if no timeout value (``None``) is given. If you want to disable the timeout, set it to a
+            negative value. A timeout of 0 means that there is exactly one attempt to acquire the file lock.
+        :param mode: file permissions for the lockfile. When not specified, the OS controls permissions via umask and
+            default ACLs, preserving POSIX default ACL inheritance in shared directories.
+        :param thread_local: Whether this object's internal context should be thread local or not. If this is set to
+            ``False`` then the lock will be reentrant across threads.
         :param blocking: whether the lock should be blocking or not
-        :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per
-            lock file. This is useful if you want to use the lock object for reentrant locking without needing to
-            pass the same object around.
-        :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback
-            value in the acquire method, if no poll_interval value (``None``) is given.
-        :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set,
-            a waiting process will break a lock whose file modification time is older than ``lifetime`` seconds.
-            ``None`` (the default) means locks never expire.
+        :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per lock
+            file. This is useful if you want to use the lock object for reentrant locking without needing to pass the
+            same object around.
+        :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback value
+            in the acquire method, if no poll_interval value (``None``) is given.
+        :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set, a waiting
+            process will break a lock whose file modification time is older than ``lifetime`` seconds. ``None`` (the
+            default) means locks never expire.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.
@@ -173,12 +174,12 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
 
     @property
     def run_in_executor(self) -> bool:
-        """:return: whether run in executor."""
+        """:returns: whether run in executor."""
         return self._context.run_in_executor
 
     @property
     def executor(self) -> futures.Executor | None:
-        """:return: the executor."""
+        """:returns: the executor."""
         return self._context.executor
 
     @executor.setter
@@ -186,15 +187,14 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         """
         Change the executor.
 
-        :param value: the new executor or ``None``
-        :type value: futures.Executor | None
+        :param futures.Executor | None value: the new executor or ``None``
 
         """
         self._context.executor = value
 
     @property
     def loop(self) -> asyncio.AbstractEventLoop | None:
-        """:return: the event loop."""
+        """:returns: the event loop."""
         return self._context.loop
 
     async def acquire(  # ty: ignore[invalid-method-override]
@@ -209,16 +209,18 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         Try to acquire the file lock.
 
         :param timeout: maximum wait time for acquiring the lock, ``None`` means use the default
-            :attr:`~BaseFileLock.timeout` is and if ``timeout < 0``, there is no timeout and this method will
-            block until the lock could be acquired
+            :attr:`~BaseFileLock.timeout` is and if ``timeout < 0``, there is no timeout and this method will block
+            until the lock could be acquired
         :param poll_interval: interval of trying to acquire the lock file, ``None`` means use the default
             :attr:`~BaseFileLock.poll_interval`
-        :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on
-            the first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
-        :param cancel_check: a callable returning ``True`` when the acquisition should be canceled. Checked on each
-            poll iteration. When triggered, raises :class:`~Timeout` just like an expired timeout.
+        :param blocking: defaults to True. If False, function will return immediately if it cannot obtain a lock on the
+            first attempt. Otherwise, this method will block until the timeout expires or the lock is acquired.
+        :param cancel_check: a callable returning ``True`` when the acquisition should be canceled. Checked on each poll
+            iteration. When triggered, raises :class:`~Timeout` just like an expired timeout.
+
+        :returns: a context object that will unlock the file when the context is exited
+
         :raises Timeout: if fails to acquire lock within the timeout period
-        :return: a context object that will unlock the file when the context is exited
 
         .. code-block:: python
 
@@ -278,8 +280,8 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
 
     async def release(self, force: bool = False) -> None:  # ty: ignore[invalid-method-override]  # noqa: FBT001, FBT002
         """
-        Releases the file lock. Please note, that the lock is only completely released, if the lock counter is 0.
-        Also note, that the lock file itself is not automatically deleted.
+        Release the file lock. The lock is only completely released when the lock counter reaches 0. The lock file
+        itself is not automatically deleted.
 
         :param force: If true, the lock counter is ignored and the lock is released in every case.
 
@@ -310,8 +312,9 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
 
         NOTE: DO NOT USE `with` FOR ASYNCIO LOCKS, USE `async with` INSTEAD.
 
-        :return: none
+        :returns: none
         :rtype: NoReturn
+
         """
         msg = "Do not use `with` for asyncio locks, use `async with` instead."
         raise NotImplementedError(msg)
@@ -320,7 +323,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         """
         Acquire the lock.
 
-        :return: the lock object
+        :returns: the lock object
 
         """
         await self.acquire()

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -209,6 +209,7 @@ def test_write_non_starvation(lock_file: str) -> None:
 
     Creates a chain of reader processes where the writer starts after the first reader acquires a lock. The writer
     should be able to acquire its lock before the entire reader chain has finished, demonstrating non-starvation.
+
     """
     NUM_READERS = 7
 
@@ -338,8 +339,9 @@ def test_timeout_behavior(lock_file: str) -> None:
 def test_non_blocking_behavior(lock_file: str) -> None:
     """Test that non-blocking parameter works correctly.
 
-    This test directly attempts to acquire a read lock in non-blocking mode when a write lock is already held by
-    another process.
+    This test directly attempts to acquire a read lock in non-blocking mode when a write lock is already held by another
+    process.
+
     """
     write_acquired = Event()
     release_write = Event()


### PR DESCRIPTION
The monolithic documentation made it difficult for users to find information relevant to their skill level or intent — beginners, experienced developers, and API consumers all landed on the same page with no clear path forward. 📚 Several features added in recent releases (self-deadlock detection, `cancel_check`, `force` release, `lifetime` expiration) were undocumented or had incorrect examples.

The docs are now organized into four Diataxis sections: Tutorials for hands-on learning, How-to guides for task-oriented solutions, Concepts for design rationale, and API Reference for technical details. Previously undocumented features now have comprehensive coverage with practical examples and mermaid diagrams illustrating concepts like race conditions, cancellation flow, and thread-local vs shared lock state. The homepage uses `sphinx-design` cards to guide users toward the right section for their needs.

The release pipeline in `.github/workflows/release.yaml` now generates RST-formatted changelog entries with proper overline/underline headers, matching the restructured `changelog.rst` format. ✨ Five new Sphinx extensions improve the reading experience: `sphinx-copybutton`, `sphinx-design`, `sphinx-sitemap`, `sphinxcontrib-mermaid`, and `sphinxext-opengraph`. Docstring line-length violations in `_api.py` and `asyncio.py` are also cleaned up.