### PR TITLE
🐛 fix(ci): add trailing blank line after changelog entries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
           {
             head -4 docs/changelog.rst
             printf '%s\n %s\n%s\n\n' "$separator" "$header" "$separator"
-            printf '%s\n' "$CHANGELOG"
+            printf '%s\n\n' "$CHANGELOG"
             tail -n +5 docs/changelog.rst
           } > docs/changelog.tmp
           mv docs/changelog.tmp docs/changelog.rst

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@
 - 🐛 fix(rw): close sqlite3 cursors and skip SoftFileLock Windows race :pr:`491`
 - 🐛 fix(test): resolve flaky write non-starvation test :pr:`490`
 - 📝 docs: restructure using Diataxis framework :pr:`489`
+
 *********************
  3.24.1 (2026-02-15)
 *********************


### PR DESCRIPTION
The release workflow's changelog generation omitted a blank line between the bullet list and the next version's header, causing a Sphinx warning treated as error: \`Bullet list ends without a blank line; unexpected unindent\`.

Changed \`printf '%s\n'\` to \`printf '%s\n\n'\` to ensure a trailing blank line after changelog entries. Also fixes the 3.24.2 entry that was already generated without it.