### PR TITLE
Suppress ValueError in _try_break_stale_lock for corrupted lock files

### DIFF
--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -54,7 +54,7 @@ class SoftFileLock(BaseFileLock):
             self._context.lock_file_fd = file_handler
 
     def _try_break_stale_lock(self) -> None:
-        with suppress(OSError):
+        with suppress(OSError, ValueError):
             content = Path(self.lock_file).read_text(encoding="utf-8")
             lines = content.strip().splitlines()
             if len(lines) != 2:  # noqa: PLR2004


### PR DESCRIPTION
`SoftFileLock._try_break_stale_lock()` wraps its body in `suppress(OSError)` to handle I/O errors gracefully. However, if the lock file content is corrupted (e.g. non-numeric PID line), `int(pid_str)` raises `ValueError` which is not suppressed, crashing the lock acquisition.

This can happen when:
- The lock file was partially written (process killed mid-write)
- The file was corrupted by an external tool
- A different application wrote to the same path

```python
import socket
from filelock import SoftFileLock

# Simulate a corrupted lock file with non-numeric PID
with open("test.lock", "w") as f:
    f.write(f"not_a_pid\n{socket.gethostname()}\n")

lock = SoftFileLock("test.lock")
lock.acquire()  # ValueError: invalid literal for int() with base 10: 'not_a_pid'
```

The fix adds `ValueError` to the `suppress()` call, so corrupted lock files are treated the same as unreadable ones — the stale lock check is skipped and acquisition proceeds normally.
