### PR TITLE
Fix ValueError in _acquire_transaction_lock when blocking=False with timeout

### DIFF
--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -159,11 +159,12 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
             _all_connections.add(self._con)
 
     def _acquire_transaction_lock(self, *, blocking: bool, timeout: float) -> None:
-        if timeout == -1:
-            # blocking=True with no timeout means wait indefinitely per threading.Lock.acquire semantics
-            acquired = self._transaction_lock.acquire(blocking)
+        if not blocking:
+            acquired = self._transaction_lock.acquire(False)
+        elif timeout == -1:
+            acquired = self._transaction_lock.acquire(True)
         else:
-            acquired = self._transaction_lock.acquire(blocking, timeout)
+            acquired = self._transaction_lock.acquire(True, timeout)
         if not acquired:
             raise Timeout(self.lock_file) from None
 


### PR DESCRIPTION
`ReadWriteLock._acquire_transaction_lock()` crashes with `ValueError` when called with `blocking=False` and a non-default timeout.

Python's `threading.Lock.acquire()` raises `ValueError: can't specify a timeout for a non-blocking call` when both `blocking=False` and a timeout are provided. The current code only special-cases `timeout == -1`, so any other timeout value combined with `blocking=False` hits this error:

```python
from filelock import ReadWriteLock

lock = ReadWriteLock("test.db")
lock.acquire_read(timeout=5, blocking=False)
# ValueError: can't specify a timeout for a non-blocking call
```

The fix handles `blocking=False` as a separate branch that never passes a timeout argument, since a timeout is meaningless for non-blocking acquisition anyway.
