### PR TITLE
Fix ValueError in _acquire_transaction_lock when blocking=False with timeout

### DIFF
--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -159,11 +159,12 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
             _all_connections.add(self._con)
 
     def _acquire_transaction_lock(self, *, blocking: bool, timeout: float) -> None:
-        if timeout == -1:
-            # blocking=True with no timeout means wait indefinitely per threading.Lock.acquire semantics
-            acquired = self._transaction_lock.acquire(blocking)
+        if not blocking:
+            acquired = self._transaction_lock.acquire(False)
+        elif timeout == -1:
+            acquired = self._transaction_lock.acquire(True)
         else:
-            acquired = self._transaction_lock.acquire(blocking, timeout)
+            acquired = self._transaction_lock.acquire(True, timeout)
         if not acquired:
             raise Timeout(self.lock_file) from None
 

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -160,11 +160,11 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
     def _acquire_transaction_lock(self, *, blocking: bool, timeout: float) -> None:
         if not blocking:
-            acquired = self._transaction_lock.acquire(False)
+            acquired = self._transaction_lock.acquire(blocking=False)
         elif timeout == -1:
-            acquired = self._transaction_lock.acquire(True)
+            acquired = self._transaction_lock.acquire(blocking=True)
         else:
-            acquired = self._transaction_lock.acquire(True, timeout)
+            acquired = self._transaction_lock.acquire(blocking=True, timeout=timeout)
         if not acquired:
             raise Timeout(self.lock_file) from None
 

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -397,6 +397,24 @@ def test_non_blocking_transaction_lock_timeout(lock_file: str, mode: Literal["re
         pytest.param("write", id="write"),
     ],
 )
+def test_non_blocking_with_timeout_no_value_error(lock_file: str, mode: Literal["read", "write"]) -> None:
+    lock = ReadWriteLock(lock_file, is_singleton=False)
+    lock._transaction_lock.acquire()
+    try:
+        acquire = lock.acquire_read if mode == "read" else lock.acquire_write
+        with pytest.raises(Timeout):
+            acquire(blocking=False, timeout=5.0)
+    finally:
+        lock._transaction_lock.release()
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param("read", id="read"),
+        pytest.param("write", id="write"),
+    ],
+)
 def test_finite_timeout_transaction_lock(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock = ReadWriteLock(lock_file, is_singleton=False)
     lock._transaction_lock.acquire()


### PR DESCRIPTION
Fix from #497 by @bysiber with added test and lint fixes.

`ReadWriteLock._acquire_transaction_lock()` crashes with `ValueError` when called with `blocking=False` and a non-default timeout.

Python's `threading.Lock.acquire()` raises `ValueError: can't specify a timeout for a non-blocking call` when both `blocking=False` and a timeout are provided. The current code only special-cases `timeout == -1`, so any other timeout value combined with `blocking=False` hits this error:

```python
from filelock import ReadWriteLock

lock = ReadWriteLock("test.db")
lock.acquire_read(timeout=5, blocking=False)
# ValueError: can't specify a timeout for a non-blocking call
```

The fix handles `blocking=False` as a separate branch that never passes a timeout argument, since a timeout is meaningless for non-blocking acquisition anyway.