### PR TITLE
Add permissions to check workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: "🧪 Test ${{ matrix.py }} - ${{ matrix.os }}"


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to the check workflow to satisfy the `actions/missing-workflow-permissions` code scanning rule
- All jobs only need read access (checkout, upload artifacts)