### PR TITLE
✨ feat(async): add AsyncReadWriteLock

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,11 @@ def setup(app: Sphinx) -> None:
             node: pending_xref,
             contnode: Element,
         ) -> reference | None:
-            mapping = {"_thread._local": ("threading.local", "local")}
+            mapping = {
+                "_thread._local": ("threading.local", "local"),
+                "asyncio.events.AbstractEventLoop": ("asyncio.AbstractEventLoop", "AbstractEventLoop"),
+                "concurrent.futures._base.Executor": ("concurrent.futures.Executor", "Executor"),
+            }
             if target in mapping:
                 of_type, with_name = mapping[target]
                 target = of_type

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ Choose the right lock for your use case:
 
         - ✓ Concurrent readers
         - ✓ Reentrant per mode
-        - ✗ No async, no lifetime
+        - ✓ Async via AsyncReadWriteLock
 
     .. grid-item-card::
         **AsyncFileLock**

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -16,8 +16,11 @@ from ._api import AcquireReturnProxy, BaseFileLock
 from ._error import Timeout
 
 try:
+    from ._async_read_write import AsyncAcquireReadWriteReturnProxy, AsyncReadWriteLock
     from ._read_write import ReadWriteLock
 except ImportError:  # sqlite3 may be unavailable if Python was built without it or the C library is missing
+    AsyncAcquireReadWriteReturnProxy = None  # type: ignore[assignment, misc]
+    AsyncReadWriteLock = None  # type: ignore[assignment, misc]
     ReadWriteLock = None  # type: ignore[assignment, misc]
 
 from ._soft import SoftFileLock
@@ -60,8 +63,10 @@ else:
 
 __all__ = [
     "AcquireReturnProxy",
+    "AsyncAcquireReadWriteReturnProxy",
     "AsyncAcquireReturnProxy",
     "AsyncFileLock",
+    "AsyncReadWriteLock",
     "AsyncSoftFileLock",
     "AsyncUnixFileLock",
     "AsyncWindowsFileLock",

--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -1,0 +1,203 @@
+"""Async wrapper around :class:`ReadWriteLock` for use with ``asyncio``."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from ._read_write import ReadWriteLock
+
+if TYPE_CHECKING:
+    import os
+    from collections.abc import AsyncGenerator, Callable
+    from concurrent import futures
+    from types import TracebackType
+
+
+class AsyncAcquireReadWriteReturnProxy:
+    """Context-aware object that releases the async read/write lock on exit."""
+
+    def __init__(self, lock: AsyncReadWriteLock) -> None:
+        self.lock = lock
+
+    async def __aenter__(self) -> AsyncReadWriteLock:
+        return self.lock
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.lock.release()
+
+
+class AsyncReadWriteLock:
+    """
+    Async wrapper around :class:`ReadWriteLock` for use in ``asyncio`` applications.
+
+    Because Python's :mod:`sqlite3` module has no async API, all blocking SQLite operations are dispatched to a thread
+    pool via ``loop.run_in_executor()``. Reentrancy, upgrade/downgrade rules, and singleton behavior are delegated
+    to the underlying :class:`ReadWriteLock`.
+
+    :param lock_file: path to the SQLite database file used as the lock
+    :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
+    :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable
+    :param is_singleton: if ``True``, reuse existing :class:`ReadWriteLock` instances for the same resolved path
+    :param loop: event loop for ``run_in_executor``; ``None`` uses the running loop
+    :param executor: executor for ``run_in_executor``; ``None`` uses the default executor
+
+    .. versionadded:: 3.21.0
+
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+        is_singleton: bool = True,
+        loop: asyncio.AbstractEventLoop | None = None,
+        executor: futures.Executor | None = None,
+    ) -> None:
+        self._lock = ReadWriteLock(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
+        self._loop = loop
+        self._executor = executor
+
+    @property
+    def lock_file(self) -> str:
+        """:returns: the path to the lock file."""
+        return self._lock.lock_file
+
+    @property
+    def timeout(self) -> float:
+        """:returns: the default timeout."""
+        return self._lock.timeout
+
+    @property
+    def blocking(self) -> bool:
+        """:returns: whether blocking is enabled by default."""
+        return self._lock.blocking
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop | None:
+        """:returns: the event loop (or ``None`` for the running loop)."""
+        return self._loop
+
+    @property
+    def executor(self) -> futures.Executor | None:
+        """:returns: the executor (or ``None`` for the default)."""
+        return self._executor
+
+    async def _run(self, func: Callable[..., object], *args: object, **kwargs: object) -> object:
+        loop = self._loop or asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, functools.partial(func, *args, **kwargs))
+
+    async def acquire_read(self, timeout: float = -1, *, blocking: bool = True) -> AsyncAcquireReadWriteReturnProxy:
+        """
+        Acquire a shared read lock.
+
+        See :meth:`ReadWriteLock.acquire_read` for full semantics.
+
+        :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable
+
+        :returns: a proxy that can be used as an async context manager to release the lock
+
+        :raises RuntimeError: if a write lock is already held on this instance
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        await self._run(self._lock.acquire_read, timeout, blocking=blocking)
+        return AsyncAcquireReadWriteReturnProxy(lock=self)
+
+    async def acquire_write(self, timeout: float = -1, *, blocking: bool = True) -> AsyncAcquireReadWriteReturnProxy:
+        """
+        Acquire an exclusive write lock.
+
+        See :meth:`ReadWriteLock.acquire_write` for full semantics.
+
+        :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable
+
+        :returns: a proxy that can be used as an async context manager to release the lock
+
+        :raises RuntimeError: if a read lock is already held, or a write lock is held by a different thread
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        await self._run(self._lock.acquire_write, timeout, blocking=blocking)
+        return AsyncAcquireReadWriteReturnProxy(lock=self)
+
+    async def release(self, *, force: bool = False) -> None:
+        """
+        Release one level of the current lock.
+
+        See :meth:`ReadWriteLock.release` for full semantics.
+
+        :param force: if ``True``, release the lock completely regardless of the current lock level
+
+        :raises RuntimeError: if no lock is currently held and *force* is ``False``
+
+        """
+        await self._run(self._lock.release, force=force)
+
+    @asynccontextmanager
+    async def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
+        """
+        Async context manager that acquires and releases a shared read lock.
+
+        Falls back to instance defaults for *timeout* and *blocking* when ``None``.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        """
+        if timeout is None:
+            timeout = self._lock.timeout
+        if blocking is None:
+            blocking = self._lock.blocking
+        await self.acquire_read(timeout, blocking=blocking)
+        try:
+            yield
+        finally:
+            await self.release()
+
+    @asynccontextmanager
+    async def write_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
+        """
+        Async context manager that acquires and releases an exclusive write lock.
+
+        Falls back to instance defaults for *timeout* and *blocking* when ``None``.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        """
+        if timeout is None:
+            timeout = self._lock.timeout
+        if blocking is None:
+            blocking = self._lock.blocking
+        await self.acquire_write(timeout, blocking=blocking)
+        try:
+            yield
+        finally:
+            await self.release()
+
+    async def close(self) -> None:
+        """
+        Release the lock (if held) and close the underlying SQLite connection.
+
+        After calling this method, the lock instance is no longer usable.
+
+        """
+        await self._run(self._lock.close)
+
+
+__all__ = [
+    "AsyncAcquireReadWriteReturnProxy",
+    "AsyncReadWriteLock",
+]

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+import pytest
+
+pytest.importorskip("sqlite3")
+
+import sqlite3
+
+from filelock import AsyncReadWriteLock, Timeout
+from filelock._read_write import ReadWriteLock
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clear_singleton_cache() -> Generator[None]:
+    ReadWriteLock._instances.clear()
+    yield
+    for ref in list(ReadWriteLock._instances.valuerefs()):
+        if (lock := ref()) is not None:
+            lock.close()
+    ReadWriteLock._instances.clear()
+
+
+@pytest.fixture
+def lock_file(tmp_path: Path) -> str:
+    return str(tmp_path / "test_lock.db")
+
+
+@pytest.mark.asyncio
+async def test_acquire_release_read(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    proxy = await lock.acquire_read()
+    assert lock._lock._lock_level == 1
+    assert lock._lock._current_mode == "read"
+    await lock.release()
+    assert lock._lock._lock_level == 0
+    assert lock._lock._current_mode is None
+    assert isinstance(proxy, object)
+
+
+@pytest.mark.asyncio
+async def test_acquire_release_write(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.acquire_write()
+    assert lock._lock._lock_level == 1
+    assert lock._lock._current_mode == "write"
+    await lock.release()
+    assert lock._lock._lock_level == 0
+    assert lock._lock._current_mode is None
+
+
+@pytest.mark.asyncio
+async def test_read_lock_context_manager(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    async with lock.read_lock():
+        assert lock._lock._lock_level == 1
+        assert lock._lock._current_mode == "read"
+    assert lock._lock._lock_level == 0
+    assert lock._lock._current_mode is None
+
+
+@pytest.mark.asyncio
+async def test_write_lock_context_manager(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    async with lock.write_lock():
+        assert lock._lock._lock_level == 1
+        assert lock._lock._current_mode == "write"
+    assert lock._lock._lock_level == 0
+    assert lock._lock._current_mode is None
+
+
+@pytest.mark.asyncio
+async def test_reentrant_read(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.acquire_read()
+    await lock.acquire_read()
+    assert lock._lock._lock_level == 2
+    await lock.release()
+    assert lock._lock._lock_level == 1
+    assert lock._lock._current_mode == "read"
+    await lock.release()
+    assert lock._lock._lock_level == 0
+
+
+@pytest.mark.asyncio
+async def test_reentrant_write(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.acquire_write()
+    await lock.acquire_write()
+    assert lock._lock._lock_level == 2
+    await lock.release()
+    assert lock._lock._lock_level == 1
+    assert lock._lock._current_mode == "write"
+    await lock.release()
+    assert lock._lock._lock_level == 0
+
+
+@pytest.mark.asyncio
+async def test_upgrade_prohibited(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.acquire_read()
+    with pytest.raises(RuntimeError, match=r"already holding a read lock.*upgrade not allowed"):
+        await lock.acquire_write()
+    await lock.release()
+
+
+@pytest.mark.asyncio
+async def test_downgrade_prohibited(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.acquire_write()
+    with pytest.raises(RuntimeError, match=r"already holding a write lock.*downgrade not allowed"):
+        await lock.acquire_read()
+    await lock.release()
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_read(lock_file: str) -> None:
+    holder = ReadWriteLock(lock_file, is_singleton=False)
+    holder.acquire_write()
+    try:
+        lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+        with pytest.raises(Timeout):
+            await lock.acquire_read(blocking=False)
+    finally:
+        holder.release()
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_write(lock_file: str) -> None:
+    holder = ReadWriteLock(lock_file, is_singleton=False)
+    holder.acquire_read()
+    try:
+        lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+        with pytest.raises(Timeout):
+            await lock.acquire_write(blocking=False)
+    finally:
+        holder.release()
+
+
+@pytest.mark.asyncio
+async def test_timeout_expires(lock_file: str) -> None:
+    holder = ReadWriteLock(lock_file, is_singleton=False)
+    holder.acquire_write()
+    try:
+        lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+        with pytest.raises(Timeout):
+            await lock.acquire_read(timeout=0.2)
+    finally:
+        holder.release()
+
+
+@pytest.mark.asyncio
+async def test_release_unheld_raises(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    with pytest.raises(RuntimeError, match="not held"):
+        await lock.release()
+
+
+@pytest.mark.asyncio
+async def test_release_force(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.acquire_write()
+    await lock.acquire_write()
+    assert lock._lock._lock_level == 2
+    await lock.release(force=True)
+    assert lock._lock._lock_level == 0
+    assert lock._lock._current_mode is None
+
+
+@pytest.mark.asyncio
+async def test_release_force_unheld_is_noop(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.release(force=True)
+
+
+@pytest.mark.asyncio
+async def test_close(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.acquire_write()
+    assert lock._lock._lock_level == 1
+    await lock.close()
+    assert lock._lock._lock_level == 0
+    with pytest.raises(sqlite3.ProgrammingError, match="Cannot operate on a closed database"):
+        lock._lock._con.execute("SELECT 1;")
+
+
+@pytest.mark.asyncio
+async def test_close_on_unheld_lock(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    await lock.close()
+    with pytest.raises(sqlite3.ProgrammingError, match="Cannot operate on a closed database"):
+        lock._lock._con.execute("SELECT 1;")
+
+
+def test_properties(lock_file: str) -> None:
+    executor = ThreadPoolExecutor(max_workers=1)
+    lock = AsyncReadWriteLock(lock_file, timeout=5.0, blocking=False, is_singleton=False, executor=executor)
+    assert lock.lock_file == lock_file
+    assert lock.timeout == pytest.approx(5.0)
+    assert lock.blocking is False
+    assert lock.loop is None
+    assert lock.executor is executor
+    executor.shutdown(wait=False)
+
+
+@pytest.mark.asyncio
+async def test_custom_executor(lock_file: str) -> None:
+    executor = ThreadPoolExecutor(max_workers=1)
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False, executor=executor)
+    async with lock.read_lock():
+        assert lock._lock._current_mode == "read"
+    assert lock._lock._lock_level == 0
+    executor.shutdown(wait=False)
+
+
+@pytest.mark.asyncio
+async def test_acquire_return_proxy_context_manager(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    async with await lock.acquire_read() as ctx:
+        assert ctx is lock
+        assert lock._lock._lock_level == 1
+    assert lock._lock._lock_level == 0
+
+
+@pytest.mark.asyncio
+async def test_nested_read_context_managers(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    async with lock.read_lock():
+        assert lock._lock._lock_level == 1
+        async with lock.read_lock():
+            assert lock._lock._lock_level == 2
+        assert lock._lock._lock_level == 1
+    assert lock._lock._lock_level == 0
+
+
+@pytest.mark.asyncio
+async def test_nested_write_context_managers(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    async with lock.write_lock():
+        assert lock._lock._lock_level == 1
+        async with lock.write_lock():
+            assert lock._lock._lock_level == 2
+        assert lock._lock._lock_level == 1
+    assert lock._lock._lock_level == 0
+
+
+@pytest.mark.asyncio
+async def test_context_manager_uses_instance_defaults(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, timeout=3.0, blocking=True, is_singleton=False)
+    async with lock.read_lock():
+        assert lock._lock._current_mode == "read"
+    async with lock.write_lock():
+        assert lock._lock._current_mode == "write"
+
+
+@pytest.mark.asyncio
+async def test_sequential_mode_switch(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    async with lock.read_lock():
+        pass
+    async with lock.write_lock():
+        pass
+    async with lock.read_lock():
+        pass


### PR DESCRIPTION
The library has `AsyncFileLock` for async file locking and `ReadWriteLock` for sync shared-read/exclusive-write locking, but no way to use read/write locks from async code. This was requested in #505.

Since Python's `sqlite3` module has no async API, `AsyncReadWriteLock` wraps the existing `ReadWriteLock` and dispatches all blocking SQLite operations to a thread pool via `loop.run_in_executor()` — the same pattern already used by `BaseAsyncFileLock`. 🔄 The class uses composition rather than inheritance because `ReadWriteLock` has a fundamentally different hierarchy from `BaseFileLock`. All reentrancy, upgrade/downgrade, and singleton semantics are delegated to the inner `ReadWriteLock` instance.

The async context managers `read_lock()` and `write_lock()` mirror the sync API, and a custom executor can be passed for applications that need control over the thread pool. ✨ The Sphinx `PatchedPythonDomain` was extended to map internal stdlib paths (`asyncio.events.AbstractEventLoop`, `concurrent.futures._base.Executor`) to their public equivalents, which benefits any future code using these types in documented signatures.

Closes #505