### PR TITLE
🐛 fix(unix): suppress EIO on close in Docker bind mounts

### DIFF
--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -106,7 +106,8 @@ else:  # pragma: win32 no cover
             with suppress(OSError):
                 Path(self.lock_file).unlink()
             fcntl.flock(fd, fcntl.LOCK_UN)
-            os.close(fd)
+            with suppress(OSError):  # close can raise EIO on FUSE/Docker bind-mount filesystems after unlink
+                os.close(fd)
 
 
 __all__ = [

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import socket
 import sys
-from errno import ENOSYS
+from errno import EIO, ENOSYS
 from typing import TYPE_CHECKING
 
 import pytest
@@ -92,4 +92,22 @@ def test_fallback_reentrant_locking(tmp_path: Path, mocker: MockerFixture) -> No
         with lock:
             assert lock.is_locked
         assert lock.is_locked
+    assert not lock.is_locked
+
+
+@unix_only
+def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = UnixFileLock(tmp_path / "test.lock")
+    lock.acquire()
+
+    real_close = os.close
+    fd_to_fail = lock._context.lock_file_fd
+
+    def _close_eio(fd: int) -> None:
+        real_close(fd)
+        if fd == fd_to_fail:
+            raise OSError(EIO, "Input/output error")
+
+    mocker.patch("filelock._unix.os.close", side_effect=_close_eio)
+    lock.release()
     assert not lock.is_locked


### PR DESCRIPTION
Since 3.20.4, releasing a `UnixFileLock` inside Docker on macOS with bind-mounted filesystems raises `OSError: [Errno 5] Input/output error` on `os.close(fd)`. 🐛 The root cause is the `unlink → flock unlock → close` sequence in `_release()`: some FUSE-backed bind-mount drivers return `EIO` when closing an fd whose directory entry was already removed.

The `unlink` must stay before `unlock` to prevent a race where a concurrent acquirer locks the old inode while a new file is created, so reordering is not an option. Instead, `os.close(fd)` is now wrapped in `suppress(OSError)`, matching the existing treatment of `unlink`. At that point the lock is already released and POSIX guarantees the fd is invalidated regardless of the `close` return value, so suppressing the error is safe.

Fixes #512