### PR TITLE
🔧 fix(ci): restore git credentials for release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,8 +85,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: false
+          token: ${{ secrets.RELEASE_TOKEN }} # zizmor: ignore[artipacked]
       - name: 📤 Commit changelog and tag
         env:
           CHANGELOG: ${{ needs.build.outputs.changelog }}


### PR DESCRIPTION
The zizmor security tool added `persist-credentials: false` to all checkout steps, which broke releases. The release job pushes version tags and changelog commits to the repository, but stripping credentials after checkout caused these operations to fail with authentication errors.

Removing `persist-credentials: false` from the release job's checkout restores the ability to push. 🔐 The `artipacked` warning is suppressed with an inline ignore because it's a false positive in this context—the release job never uploads artifacts that could leak the persisted credentials. The build job (which does upload artifacts) correctly keeps `persist-credentials: false`.

This change only affects the release workflow. Regular CI checks remain protected with credential stripping intact.