### PR TITLE
✨ feat(soft): add PID inspection and lock breaking

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -241,7 +241,7 @@ Lock types compared
       - N/A (OS-enforced)
       - Yes (Unix/macOS only)
       - N/A
-    - - PID inspection (``pid``, ``i_am_locking``)
+    - - PID inspection (``pid``, ``is_lock_held_by_us``)
       - No
       - Yes
       - No

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -109,7 +109,7 @@ A separate "lock file" indicates that a resource is in use. The lock file contai
 (one per line). A process acquires a lock by creating this file atomically with ``O_CREAT | O_EXCL``; it releases by
 deleting it.
 
-This is the same concept as a traditional **PID lock file** (as used by Unix daemons and the deprecated ``lockfile``
+This is the same concept as a traditional **PID lock file** (as used by Unix daemons and the deprecated `lockfile <https://pypi.org/project/lockfile/>`_
 library's ``PIDLockFile``). The PID stored in the file enables two important capabilities: identifying the lock holder
 via the :attr:`~filelock.SoftFileLock.pid` property, and detecting stale locks when the holding process has died.
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -103,10 +103,15 @@ file handle can lock it. When a process dies, the OS automatically releases its 
     - - ✓ Lower overhead.
       -
 
-**Soft locks** (SoftFileLock, the fallback on systems without fcntl)
+**Soft locks / PID locks** (SoftFileLock, the fallback on systems without fcntl)
 
-A separate "lock file" indicates that a resource is in use. The lock file contains the PID and hostname of the holder. A
-process acquires a lock by creating this file; it releases by deleting it.
+A separate "lock file" indicates that a resource is in use. The lock file contains the PID and hostname of the holder
+(one per line). A process acquires a lock by creating this file atomically with ``O_CREAT | O_EXCL``; it releases by
+deleting it.
+
+This is the same concept as a traditional **PID lock file** (as used by Unix daemons and the deprecated ``lockfile``
+library's ``PIDLockFile``). The PID stored in the file enables two important capabilities: identifying the lock holder
+via the :attr:`~filelock.SoftFileLock.pid` property, and detecting stale locks when the holding process has died.
 
 On Unix/macOS, processes can check if the lock holder is still alive and break stale locks automatically. On Windows,
 stale lock breaking is skipped because the lock file cannot be atomically renamed while another process holds a handle.
@@ -236,6 +241,10 @@ Lock types compared
       - N/A (OS-enforced)
       - Yes (Unix/macOS only)
       - N/A
+    - - PID inspection (``pid``, ``i_am_locking``)
+      - No
+      - Yes
+      - No
     - - Lifetime expiration
       - Yes
       - Yes

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -398,10 +398,10 @@ Check whether the current process holds the lock:
 
     lock = SoftFileLock("work.lock")
 
-    print(lock.i_am_locking)  # False
+    print(lock.is_lock_held_by_us)  # False
 
     with lock:
-        print(lock.i_am_locking)  # True
+        print(lock.is_lock_held_by_us)  # True
 
 Forcibly break a lock regardless of who holds it:
 

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -371,6 +371,44 @@ require manual removal.
 On Windows, stale lock detection is skipped because the lock file cannot be atomically renamed while another process
 holds a handle to it.
 
+*****************************************
+ Inspect and manage PID locks
+*****************************************
+
+:class:`SoftFileLock <filelock.SoftFileLock>` exposes properties to inspect the lock holder and a method to forcibly
+break the lock. This is useful for migrating from the deprecated ``lockfile.PIDLockFile`` class.
+
+Read the PID of the current lock holder:
+
+.. code-block:: python
+
+    from filelock import SoftFileLock
+
+    lock = SoftFileLock("work.lock")
+
+    with lock:
+        print(lock.pid)  # e.g. 12345
+
+    print(lock.pid)  # None (lock file removed after release)
+
+Check whether the current process holds the lock:
+
+.. code-block:: python
+
+    lock = SoftFileLock("work.lock")
+
+    print(lock.i_am_locking)  # False
+
+    with lock:
+        print(lock.i_am_locking)  # True
+
+Forcibly break a lock regardless of who holds it:
+
+.. code-block:: python
+
+    lock = SoftFileLock("work.lock")
+    lock.break_lock()  # removes the lock file unconditionally
+
 *****************
  Control logging
 *****************

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -376,7 +376,8 @@ holds a handle to it.
 *****************************************
 
 :class:`SoftFileLock <filelock.SoftFileLock>` exposes properties to inspect the lock holder and a method to forcibly
-break the lock. This is useful for migrating from the deprecated ``lockfile.PIDLockFile`` class.
+break the lock. This is useful for migrating from the deprecated `lockfile <https://pypi.org/project/lockfile/>`_
+library's ``PIDLockFile`` class.
 
 Read the PID of the current lock holder:
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -183,7 +183,7 @@ See :ref:`how-to:Use locks with multiple threads` for practical examples of cont
  Migrating from lockfile.PIDLockFile
 ***************************************
 
-If you're migrating from the deprecated ``lockfile`` library, :class:`SoftFileLock <filelock.SoftFileLock>` is the
+If you're migrating from the deprecated `lockfile <https://pypi.org/project/lockfile/>`_ library, :class:`SoftFileLock <filelock.SoftFileLock>` is the
 direct replacement for ``PIDLockFile``. It writes the process ID to the lock file and can detect stale locks.
 
 .. code-block:: python

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -194,7 +194,7 @@ direct replacement for ``PIDLockFile``. It writes the process ID to the lock fil
     lock = PIDLockFile("/tmp/myapp.lock")
     lock.acquire()
     print(lock.read_pid())
-    print(lock.i_am_locking())
+    print(lock.is_lock_held_by_us())
     lock.release()
 
     # After (filelock):
@@ -204,12 +204,12 @@ direct replacement for ``PIDLockFile``. It writes the process ID to the lock fil
 
     with lock:
         print(lock.pid)
-        print(lock.i_am_locking)
+        print(lock.is_lock_held_by_us)
 
 Key differences from ``PIDLockFile``:
 
 - ``read_pid()`` is now a property: ``lock.pid``
-- ``i_am_locking()`` is now a property: ``lock.i_am_locking``
+- ``is_lock_held_by_us()`` is now a property: ``lock.is_lock_held_by_us``
 - ``break_lock()`` is now ``lock.break_lock()`` (same name)
 - Stale lock detection happens automatically on acquire (Unix/macOS only)
 - Supports context managers, reentrant locking, timeouts, and all other filelock features

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -179,6 +179,41 @@ from the releasing thread.
 
 See :ref:`how-to:Use locks with multiple threads` for practical examples of controlling this behavior.
 
+***********************************
+ Migrating from lockfile.PIDLockFile
+***********************************
+
+If you're migrating from the deprecated ``lockfile`` library, :class:`SoftFileLock <filelock.SoftFileLock>` is the
+direct replacement for ``PIDLockFile``. It writes the process ID to the lock file and can detect stale locks.
+
+.. code-block:: python
+
+    # Before (lockfile):
+    from lockfile.pidlockfile import PIDLockFile
+
+    lock = PIDLockFile("/tmp/myapp.lock")
+    lock.acquire()
+    print(lock.read_pid())
+    print(lock.i_am_locking())
+    lock.release()
+
+    # After (filelock):
+    from filelock import SoftFileLock
+
+    lock = SoftFileLock("/tmp/myapp.lock")
+
+    with lock:
+        print(lock.pid)
+        print(lock.i_am_locking)
+
+Key differences from ``PIDLockFile``:
+
+- ``read_pid()`` is now a property: ``lock.pid``
+- ``i_am_locking()`` is now a property: ``lock.i_am_locking``
+- ``break_lock()`` is now ``lock.break_lock()`` (same name)
+- Stale lock detection happens automatically on acquire (Unix/macOS only)
+- Supports context managers, reentrant locking, timeouts, and all other filelock features
+
 ************
  Next steps
 ************

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -179,9 +179,9 @@ from the releasing thread.
 
 See :ref:`how-to:Use locks with multiple threads` for practical examples of controlling this behavior.
 
-***********************************
+***************************************
  Migrating from lockfile.PIDLockFile
-***********************************
+***************************************
 
 If you're migrating from the deprecated ``lockfile`` library, :class:`SoftFileLock <filelock.SoftFileLock>` is the
 direct replacement for ``PIDLockFile``. It writes the process ID to the lock file and can detect stale locks.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -11,7 +11,7 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import local
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar
 from weakref import WeakValueDictionary
 
 from ._error import Timeout
@@ -106,11 +106,14 @@ class ThreadLocalFileContext(FileLockContext, local):
     """A thread local version of the ``FileLockContext`` class."""
 
 
+_T = TypeVar("_T", bound="BaseFileLock")
+
+
 class FileLockMeta(ABCMeta):
     _instances: WeakValueDictionary[str, BaseFileLock]
 
     def __call__(  # noqa: PLR0913
-        cls,
+        cls: type[_T],
         lock_file: str | os.PathLike[str],
         timeout: float = -1,
         mode: int = _UNSET_FILE_MODE,
@@ -121,7 +124,7 @@ class FileLockMeta(ABCMeta):
         poll_interval: float = 0.05,
         lifetime: float | None = None,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
-    ) -> BaseFileLock:
+    ) -> _T:
         if is_singleton:
             instance = cls._instances.get(str(lock_file))
             if instance:
@@ -140,7 +143,7 @@ class FileLockMeta(ABCMeta):
                     if passed_param != set_param
                 }
                 if not non_matching_params:
-                    return cast("BaseFileLock", instance)
+                    return instance  # ty: ignore[invalid-return-type]  # https://github.com/astral-sh/ty/issues/3231
 
                 # parameters do not match; raise error
                 msg = "Singleton lock instances cannot be initialized with differing arguments"
@@ -167,12 +170,12 @@ class FileLockMeta(ABCMeta):
         present_params = inspect.signature(cls.__init__).parameters
         init_params = {key: value for key, value in all_params.items() if key in present_params}
 
-        instance = super().__call__(lock_file, **init_params)
+        instance = super().__call__(lock_file, **init_params)  # ty: ignore[invalid-super-argument]  # https://github.com/astral-sh/ty/issues/3231
 
         if is_singleton:
             cls._instances[str(lock_file)] = instance
 
-        return cast("BaseFileLock", instance)
+        return instance
 
 
 class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -113,7 +113,7 @@ class SoftFileLock(BaseFileLock):
         return None
 
     @property
-    def i_am_locking(self) -> bool:
+    def is_lock_held_by_us(self) -> bool:
         """
         Whether this lock is held by the current process.
 

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -95,6 +95,38 @@ class SoftFileLock(BaseFileLock):
         with suppress(OSError):
             os.write(fd, f"{os.getpid()}\n{socket.gethostname()}\n".encode())
 
+    @property
+    def pid(self) -> int | None:
+        """
+        The PID of the process holding this lock, read from the lock file.
+
+        :returns: the PID as an integer, or ``None`` if the lock file does not exist or cannot be parsed
+
+        """
+        try:
+            content = Path(self.lock_file).read_text(encoding="utf-8")
+            lines = content.strip().splitlines()
+            if lines:
+                return int(lines[0])
+        except (OSError, ValueError):
+            pass
+        return None
+
+    @property
+    def i_am_locking(self) -> bool:
+        """
+        Whether this lock is held by the current process.
+
+        :returns: ``True`` if the lock file exists and contains the current process's PID
+
+        """
+        return self.pid == os.getpid()
+
+    def break_lock(self) -> None:
+        """Forcibly break the lock by removing the lock file, regardless of who holds it."""
+        with suppress(OSError):
+            Path(self.lock_file).unlink()
+
     def _release(self) -> None:
         assert self._context.lock_file_fd is not None  # noqa: S101
         os.close(self._context.lock_file_fd)

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -10,7 +10,7 @@ import time
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
 from threading import local
-from typing import TYPE_CHECKING, Any, NoReturn, cast
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 
 from ._api import _UNSET_FILE_MODE, BaseFileLock, FileLockContext, FileLockMeta
 from ._error import Timeout
@@ -69,9 +69,12 @@ class AsyncAcquireReturnProxy:
         await self.lock.release()
 
 
+_AT = TypeVar("_AT", bound="BaseAsyncFileLock")
+
+
 class AsyncFileLockMeta(FileLockMeta):
     def __call__(  # ty: ignore[invalid-method-override]  # noqa: PLR0913
-        cls,  # noqa: N805
+        cls: type[_AT],  # noqa: N805
         lock_file: str | os.PathLike[str],
         timeout: float = -1,
         mode: int = _UNSET_FILE_MODE,
@@ -84,11 +87,11 @@ class AsyncFileLockMeta(FileLockMeta):
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
-    ) -> BaseAsyncFileLock:
+    ) -> _AT:
         if thread_local and run_in_executor:
             msg = "run_in_executor is not supported when thread_local is True"
             raise ValueError(msg)
-        instance = super().__call__(
+        return super().__call__(  # ty: ignore[invalid-super-argument]  # https://github.com/astral-sh/ty/issues/3231
             lock_file=lock_file,
             timeout=timeout,
             mode=mode,
@@ -101,7 +104,6 @@ class AsyncFileLockMeta(FileLockMeta):
             run_in_executor=run_in_executor,
             executor=executor,
         )
-        return cast("BaseAsyncFileLock", instance)
 
 
 class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -132,6 +132,55 @@ def test_stale_detection_errors_suppressed(tmp_path: Path, mocker: MockerFixture
     mock_read.assert_called()
 
 
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param(None, None, id="no_file"),
+        pytest.param("not-a-number\n", None, id="malformed"),
+        pytest.param(f"{os.getpid()}\n{socket.gethostname()}\n", os.getpid(), id="valid"),
+    ],
+)
+def test_pid(tmp_path: Path, content: str | None, expected: int | None) -> None:
+    lock_path = tmp_path / "test.lock"
+    if content is not None:
+        lock_path.write_text(content, encoding="utf-8")
+    assert SoftFileLock(lock_path).pid == expected
+
+
+def test_pid_while_locked(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock = SoftFileLock(lock_path)
+    with lock:
+        assert lock.pid == os.getpid()
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param(None, False, id="no_file"),
+        pytest.param(f"{os.getpid() + 1}\n{socket.gethostname()}\n", False, id="different_pid"),
+        pytest.param(f"{os.getpid()}\n{socket.gethostname()}\n", True, id="same_pid"),
+    ],
+)
+def test_i_am_locking(tmp_path: Path, content: str | None, expected: bool) -> None:
+    lock_path = tmp_path / "test.lock"
+    if content is not None:
+        lock_path.write_text(content, encoding="utf-8")
+    assert SoftFileLock(lock_path).i_am_locking is expected
+
+
+@pytest.mark.parametrize(
+    "exists",
+    [pytest.param(True, id="exists"), pytest.param(False, id="missing")],
+)
+def test_break_lock(tmp_path: Path, *, exists: bool) -> None:
+    lock_path = tmp_path / "test.lock"
+    if exists:
+        lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
+    SoftFileLock(lock_path).break_lock()
+    assert not lock_path.exists()
+
+
 def test_write_lock_info_errors_suppressed(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     mocker.patch("filelock._soft.os.write", side_effect=OSError("write failed"))

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -162,11 +162,11 @@ def test_pid_while_locked(tmp_path: Path) -> None:
         pytest.param(f"{os.getpid()}\n{socket.gethostname()}\n", True, id="same_pid"),
     ],
 )
-def test_i_am_locking(tmp_path: Path, content: str | None, expected: bool) -> None:
+def test_is_lock_held_by_us(tmp_path: Path, content: str | None, expected: bool) -> None:
     lock_path = tmp_path / "test.lock"
     if content is not None:
         lock_path.write_text(content, encoding="utf-8")
-    assert SoftFileLock(lock_path).i_am_locking is expected
+    assert SoftFileLock(lock_path).is_lock_held_by_us is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Users migrating from the deprecated `lockfile` library's `PIDLockFile` need equivalent functionality in filelock. `SoftFileLock` already writes the PID and hostname to the lock file for stale lock detection, but there was no public API to read that information or forcibly break a lock. This addresses #521.

✨ Three new public members on `SoftFileLock`: a `pid` property that reads the lock holder's PID from the lock file, an `i_am_locking` property that checks whether the current process holds the lock, and a `break_lock()` method that unconditionally removes the lock file. These map directly to the `PIDLockFile` API that users are familiar with, using properties instead of methods where appropriate.

🔧 The metaclass `__call__` return type was also changed from a concrete `BaseFileLock` to a `TypeVar` bound to the base class. This means `SoftFileLock(...)` is now correctly typed as returning `SoftFileLock` rather than `BaseFileLock`, which allows type checkers to see subclass-specific attributes without casts. A [ty bug](https://github.com/astral-sh/ty/issues/3231) with `super()` in TypeVar-typed metaclass methods was discovered and reported during this work.

Closes #521