### PR TITLE
✨ feat(rw): add SoftReadWriteLock for NFS and HPC clusters

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -192,6 +192,13 @@ necessary in testing or if you need platform-specific behavior.
 - Your workload is read-heavy with occasional writes.
 - Multiple processes need to read simultaneously.
 - You want a single writer while no readers are active.
+- The lock file lives on a **local** filesystem. ``ReadWriteLock`` is SQLite-backed and is unsafe on NFS.
+
+**Use SoftReadWriteLock** when:
+
+- You want reader/writer semantics on a **network filesystem** (NFS, Lustre with ``-o flock``, HPC shared storage).
+- You need cross-host stale detection so a crash on one compute node does not wedge readers on other nodes.
+- You are running on a multi-node slurm/HPC cluster.
 
 Lock selection flowchart:
 
@@ -199,7 +206,9 @@ Lock selection flowchart:
 
     flowchart TD
         start["Choose a lock type"] --> question1{"Read-heavy workload?"}
-        question1 -->|Yes| questionAsync{"Async code?"}
+        question1 -->|Yes| questionRwNet{"Network<br/>filesystem?"}
+        questionRwNet -->|Yes| srw["Use SoftReadWriteLock"]
+        questionRwNet -->|No| questionAsync{"Async code?"}
         questionAsync -->|Yes| arw["Use AsyncReadWriteLock"]
         questionAsync -->|No| rw["Use ReadWriteLock"]
         question1 -->|No| question2{"Need network<br/>filesystem support?"}
@@ -212,7 +221,7 @@ Lock selection flowchart:
         classDef alternative fill:#fef3c7,stroke:#f59e0b,stroke-width:2px,color:#78350f
         classDef special fill:#dbeafe,stroke:#3b82f6,stroke-width:2px,color:#1e3a5f
         class default recommended
-        class soft,platform alternative
+        class soft,platform,srw alternative
         class rw,arw special
 
 Lock types compared
@@ -225,35 +234,44 @@ Lock types compared
       - FileLock
       - SoftFileLock
       - ReadWriteLock
+      - SoftReadWriteLock
     - - Exclusive/shared
       - Exclusive only
       - Exclusive only
+      - Both (separate context managers)
       - Both (separate context managers)
     - - Platform enforcement
       - OS-level (Windows/Unix)
       - No (file-based)
       - File-based (SQLite)
+      - No (file-based, ``O_CREAT|O_EXCL|O_NOFOLLOW``)
     - - Network filesystem
       - Not reliable
       - Works (if you accept the limitations)
       - Not reliable
+      - Works, including cross-host on multi-node clusters
     - - Stale lock detection
       - N/A (OS-enforced)
-      - Yes (Unix/macOS only)
+      - Yes (Unix/macOS only, same-host)
       - N/A
-    - - PID inspection (``pid``, ``is_lock_held_by_us``)
+      - Yes, TTL-based heartbeat (cross-host)
+    - - PID inspection
       - No
-      - Yes
+      - Yes (``pid``, ``is_lock_held_by_us``)
       - No
+      - No (content is not a public API)
     - - Lifetime expiration
       - Yes
       - Yes
       - No
+      - Yes (``heartbeat_interval`` / ``stale_threshold``)
     - - Cancel acquisition
       - Yes (``cancel_check``)
       - Yes (``cancel_check``)
       - No
+      - No
     - - Force release
+      - Yes (``force=True``)
       - Yes (``force=True``)
       - Yes (``force=True``)
       - Yes (``force=True``)
@@ -261,14 +279,17 @@ Lock types compared
       - AsyncFileLock
       - AsyncSoftFileLock
       - AsyncReadWriteLock
+      - AsyncSoftReadWriteLock
     - - Singleton default
       - No
       - No
+      - Yes
       - Yes
     - - Overhead
       - Low
       - High
       - Medium (SQLite)
+      - Medium (daemon heartbeat thread + dirfd scans)
 
 **********************
  TOCTOU vulnerability
@@ -321,12 +342,15 @@ On older platforms without ``O_NOFOLLOW``, prefer :class:`UnixFileLock <filelock
     OS-level locks (FileLock on Windows/Unix) are unreliable on network filesystems (NFS, SMB). This is a fundamental
     limitation of how network filesystems work—they don't reliably support locking semantics.
 
-    If you need locking on network filesystems, consider: - Using SoftFileLock (less efficient but more portable) -
-    Switching to a centralized lock service (Redis, Consul, etc.) - Using a database with transactions
+    For **exclusive locking** on NFS, use :class:`SoftFileLock <filelock.SoftFileLock>`. For **reader/writer
+    locking** (shared readers + exclusive writers) on NFS, use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>`,
+    which is the only variant in filelock that also handles cross-host stale detection. ``ReadWriteLock`` is SQLite-backed
+    and is unsafe on NFS because SQLite itself warns against running on network filesystems.
 
 **Locks across different machines**
     A lock on one machine doesn't stop another machine from accessing the resource unless they use a centralized locking
-    service. Filelock is for inter-process coordination on the same machine (or at least the same shared filesystem).
+    service — or a shared filesystem plus filelock's soft locks. On a multi-node slurm/HPC cluster,
+    :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` is correct across compute nodes sharing an NFS mount.
 
 **Read-write semantics**
     FileLock is exclusive only—readers block writers and vice versa. If you need multiple readers with occasional
@@ -384,6 +408,62 @@ The async variant (:class:`AsyncReadWriteLock <filelock.AsyncReadWriteLock>`) wr
 implementation. Because Python's :mod:`sqlite3` module has no async API, all blocking operations are dispatched to a
 thread pool via ``loop.run_in_executor``. This is the same approach used by :class:`BaseAsyncFileLock
 <filelock.BaseAsyncFileLock>`.
+
+How does SoftReadWriteLock work on NFS?
+=======================================
+
+:class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` fills the gap left by ``ReadWriteLock`` on network filesystems.
+It stores state as a small directory tree next to the lock file:
+
+- ``<path>.state`` — a short-held :class:`SoftFileLock <filelock.SoftFileLock>` used as the state mutex during transitions.
+- ``<path>.write`` — the writer marker; its presence blocks readers and other writers.
+- ``<path>.readers/<host>.<pid>.<uuid>`` — one marker file per active reader.
+
+Each marker stores a random 128-bit token, the holder's pid, and the holder's hostname. Every acquire uses
+``O_CREAT | O_EXCL | O_NOFOLLOW`` with mode ``0o600``; the readers directory uses mode ``0o700`` and a ``lstat``
+check plus a dirfd-relative open to close symlink races (which ``mkdir`` alone cannot).
+
+Writer acquisition is two-phase and writer-preferring: phase one atomically claims ``<path>.write`` (which blocks
+any new reader as soon as it exists), phase two polls the ``readers/`` directory until every reader has exited.
+Writer starvation is impossible, which matters under read-heavy workloads such as the 99/1 reader-to-writer mix
+typical of slurm job queues.
+
+Cross-host stale detection
+==========================
+
+On a multi-node cluster, a process on ``node-42`` that crashes while holding a lock cannot be detected via
+``kill(pid, 0)`` from ``node-17`` — the pid means nothing to a different kernel. ``SoftReadWriteLock`` therefore
+uses a **TTL with a heartbeat** rather than ``SoftFileLock``'s PID-alive check:
+
+- Each lock instance starts a daemon thread on acquire. The thread refreshes the marker's ``mtime`` every
+  ``heartbeat_interval`` seconds (default 30 s).
+- Any process on any host may evict a marker whose ``mtime`` has not advanced in ``stale_threshold`` seconds
+  (default 90 s, ratio borrowed from etcd's ``LeaseKeepAlive``).
+- Eviction is atomic: read → rename to a unique ``.break.<pid>.<nonce>`` file → re-verify token and mtime →
+  unlink. On verification failure the ``.break.*`` file stays for TTL or atexit cleanup; rollback-rename is itself
+  racy and is not attempted.
+- The heartbeat thread stops itself on token mismatch or a vanished marker, so a replaced or evicted marker
+  never gets accidentally refreshed.
+
+The trade-off: ``stale_threshold`` must be larger than any realistic pause a holder might hit (GC, syscall delay,
+NFS hiccup). Pick it generously. Clock synchronization across compute nodes is assumed — every HPC cluster runs
+NTP or chrony, so this is not an additional constraint in the target environment.
+
+Fork semantics
+==============
+
+Python threads do not survive ``fork()``. A process that forks while holding a ``SoftReadWriteLock`` would leave
+the child with the marker files, the lock-level state, and no heartbeat thread; the parent would keep
+refreshing while the child would not, and both would believe they hold the lock. ``SoftReadWriteLock`` registers
+an ``os.register_at_fork(after_in_child=...)`` hook that replaces the inherited ``threading.Lock`` objects with
+fresh ones and marks the instance fork-invalidated. ``release()`` on an invalidated instance is a no-op, so an
+inherited ``with lock.read_lock():`` block can unwind in the child without raising. The child must construct a
+fresh ``SoftReadWriteLock(path)`` before it can acquire again. This matches PyMongo's connection-pool semantics.
+
+**Trust boundary.** The class protects against same-UID non-cooperating processes (one host or cross-host) and
+same-host different-UID users via the ``0o600`` / ``0o700`` permissions on markers and the readers directory.
+It does not protect against root compromise, NTP tampering on same-UID cross-host nodes, or multi-tenant mounts
+where hostile co-tenants share the UID.
 
 ****************************
  File permissions and mode

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -308,6 +308,60 @@ When you're done with a ``ReadWriteLock``, close it to release the underlying SQ
     finally:
         rw.close()  # releases any held lock and closes the SQLite connection
 
+***************************************************
+ Use read/write locks on network filesystems (NFS)
+***************************************************
+
+:class:`ReadWriteLock <filelock.ReadWriteLock>` is SQLite-backed and requires a local filesystem: SQLite's own
+docs warn against running on NFS because POSIX ``fcntl`` locks are unreliable there. For HPC clusters, slurm
+deployments, or any multi-host shared storage, use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>`
+instead. It is built on :class:`SoftFileLock <filelock.SoftFileLock>` primitives (atomic ``O_CREAT | O_EXCL | O_NOFOLLOW``) and runs a
+daemon heartbeat thread that refreshes each held marker's ``mtime`` so any host on any node can evict a stale
+marker when the holder crashes.
+
+.. code-block:: python
+
+    from filelock import SoftReadWriteLock
+
+    rw = SoftReadWriteLock("/shared/nfs/data.lock")
+
+    with rw.read_lock():
+        data = get_shared_data()
+
+    with rw.write_lock():
+        update_shared_data()
+
+The defaults (``heartbeat_interval=30`` s, ``stale_threshold=90`` s, ``poll_interval=0.25`` s) fit workloads
+that hold locks for seconds-to-minutes. Tune them for your deployment:
+
+.. code-block:: python
+
+    rw = SoftReadWriteLock(
+        "/shared/nfs/data.lock",
+        heartbeat_interval=30,   # how often to refresh the marker's mtime
+        stale_threshold=90,      # declare a marker stale after this many seconds of no refresh
+        poll_interval=0.25,      # how long to sleep between acquire retries
+    )
+
+Pick ``stale_threshold`` larger than any realistic pause a holder could experience (GC, disk flush, kernel
+preemption). ``heartbeat_interval`` should be roughly ``stale_threshold / 3``; that is the ratio etcd uses for
+its ``LeaseKeepAlive``. Lower ``poll_interval`` reduces acquire latency under contention at the cost of more
+NFS ``stat`` calls per waiting client.
+
+Writer acquisition is two-phase and writer-preferring: phase one claims the writer marker (which immediately
+blocks any new reader), phase two waits for existing readers to drain. This rules out writer starvation even
+under a read-heavy workload like the 99/1 reader-to-writer mix typical of slurm job queues.
+
+**Fork caveat.** A process that forks while holding a ``SoftReadWriteLock`` loses the lock in the child. The
+inherited instance is marked fork-invalidated; ``release()`` on it becomes a no-op, and the child must call
+``SoftReadWriteLock(path)`` again to get a fresh instance before acquiring. Matches the semantics of
+:class:`threading.Lock` and PyMongo's connection pools.
+
+**Trust boundary.** The class protects against same-UID non-cooperating processes on one host, cross-host
+same-UID processes, and same-host different-UID users (via ``0o600`` / ``0o700`` permissions). It does not
+protect against root compromise, NTP tampering on same-UID cross-host nodes, or multi-tenant mounts where
+hostile co-tenants share the UID.
+
 ***********************************
  Use async read / write locks
 ***********************************
@@ -349,6 +403,18 @@ Low-level ``acquire_read``/``acquire_write``/``release`` methods are also availa
 
 The same reentrancy and upgrade/downgrade rules as the synchronous :class:`ReadWriteLock <filelock.ReadWriteLock>`
 apply — see :ref:`how-to:Use shared read / exclusive write locks` for details.
+
+For network filesystems, use :class:`AsyncSoftReadWriteLock <filelock.AsyncSoftReadWriteLock>`, which wraps
+:class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` the same way:
+
+.. code-block:: python
+
+    from filelock import AsyncSoftReadWriteLock
+
+    rw = AsyncSoftReadWriteLock("/shared/nfs/data.lock")
+
+    async with rw.read_lock():
+        data = await get_shared_data()
 
 **************************************
  Detect stale locks (soft locks only)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,16 @@ Choose the right lock for your use case:
         - ✓ Async via AsyncReadWriteLock
 
     .. grid-item-card::
+        **SoftReadWriteLock**
+
+        NFS and HPC-cluster reader/writer lock with TTL-based cross-host stale detection.
+
+        - ✓ Works on NFS / Lustre / shared storage
+        - ✓ Cross-host stale detection via heartbeat
+        - ✓ Writer-preferring, starvation-free
+        - ✓ Async via AsyncSoftReadWriteLock
+
+    .. grid-item-card::
         **AsyncFileLock**
 
         Async-compatible variants. Run blocking I/O in thread pool or custom executor.

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -214,6 +214,53 @@ Key differences from ``PIDLockFile``:
 - Stale lock detection happens automatically on acquire (Unix/macOS only)
 - Supports context managers, reentrant locking, timeouts, and all other filelock features
 
+*************************************
+ Reader/writer locks on a shared NFS
+*************************************
+
+If your lock file lives on a network filesystem — a slurm-mounted home directory, a Lustre cluster scratch
+space, or any NFS share — use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` rather than
+:class:`ReadWriteLock <filelock.ReadWriteLock>`. ``ReadWriteLock`` is SQLite-backed and unsafe on NFS.
+``SoftReadWriteLock`` is built on :class:`SoftFileLock <filelock.SoftFileLock>` primitives and handles cross-host stale detection via a
+background heartbeat thread.
+
+.. code-block:: python
+
+    from filelock import SoftReadWriteLock
+
+    rw = SoftReadWriteLock("/shared/nfs/work.lock")
+
+    with rw.read_lock():
+        # Any number of processes on any host can be here at the same time.
+        data = open("/shared/nfs/data.json").read()
+
+    with rw.write_lock():
+        # Exactly one process anywhere can be here. New readers wait behind a pending writer.
+        open("/shared/nfs/data.json", "w").write(new_data)
+
+While the lock is held, you will see a few sidecar files on disk next to ``work.lock``:
+
+.. code-block:: text
+
+    work.lock.state         # short-lived state mutex, exists only during transitions
+    work.lock.write         # writer marker, exists while a writer is claiming or holding
+    work.lock.readers/      # directory with one file per active reader
+
+A daemon heartbeat thread refreshes each marker's ``mtime`` every ``heartbeat_interval`` seconds (default 30).
+If a compute node crashes while holding a lock, any other node will evict the stale marker after
+``stale_threshold`` seconds of no refresh (default 90, following etcd's ``LeaseKeepAlive`` convention of
+``TTL / 3``). Both values are constructor arguments, so HPC deployments that hold locks for hours can raise them:
+
+.. code-block:: python
+
+    rw = SoftReadWriteLock(
+        "/shared/nfs/work.lock",
+        heartbeat_interval=120,
+        stale_threshold=360,
+    )
+
+See :doc:`concepts` for the full explanation of the heartbeat + TTL model.
+
 ************
  Next steps
 ************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ test = [
   "virtualenv>=21.2",
 ]
 type = [
-  "ty>=0.0.29",
+  "ty>=0.0.30",
   { include-group = "docs" },
   { include-group = "release" },
   { include-group = "test" },

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -31,6 +31,7 @@ else:
         ReadWriteLock = None
 
 from ._soft import SoftFileLock
+from ._soft_rw import AsyncAcquireSoftReadWriteReturnProxy, AsyncSoftReadWriteLock, SoftReadWriteLock
 from ._unix import UnixFileLock, has_fcntl
 from ._windows import WindowsFileLock
 from .asyncio import (
@@ -72,9 +73,11 @@ __all__ = [
     "AcquireReturnProxy",
     "AsyncAcquireReadWriteReturnProxy",
     "AsyncAcquireReturnProxy",
+    "AsyncAcquireSoftReadWriteReturnProxy",
     "AsyncFileLock",
     "AsyncReadWriteLock",
     "AsyncSoftFileLock",
+    "AsyncSoftReadWriteLock",
     "AsyncUnixFileLock",
     "AsyncWindowsFileLock",
     "BaseAsyncFileLock",
@@ -82,6 +85,7 @@ __all__ = [
     "FileLock",
     "ReadWriteLock",
     "SoftFileLock",
+    "SoftReadWriteLock",
     "Timeout",
     "UnixFileLock",
     "WindowsFileLock",

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from ._read_write import ReadWriteLock
+    from ._soft_rw import SoftReadWriteLock
 
     if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
         from typing import Self
@@ -55,10 +56,10 @@ _registry = _ThreadLocalRegistry()
 class AcquireReturnProxy:
     """A context-aware object that will release the lock file when exiting."""
 
-    def __init__(self, lock: BaseFileLock | ReadWriteLock) -> None:
-        self.lock: BaseFileLock | ReadWriteLock = lock
+    def __init__(self, lock: BaseFileLock | ReadWriteLock | SoftReadWriteLock) -> None:
+        self.lock: BaseFileLock | ReadWriteLock | SoftReadWriteLock = lock
 
-    def __enter__(self) -> BaseFileLock | ReadWriteLock:
+    def __enter__(self) -> BaseFileLock | ReadWriteLock | SoftReadWriteLock:
         return self.lock
 
     def __exit__(
@@ -170,7 +171,7 @@ class FileLockMeta(ABCMeta):
         present_params = inspect.signature(cls.__init__).parameters
         init_params = {key: value for key, value in all_params.items() if key in present_params}
 
-        instance = super().__call__(lock_file, **init_params)  # ty: ignore[invalid-super-argument]  # https://github.com/astral-sh/ty/issues/3231
+        instance = super().__call__(lock_file, **init_params)
 
         if is_singleton:
             cls._instances[str(lock_file)] = instance

--- a/src/filelock/_soft_rw/__init__.py
+++ b/src/filelock/_soft_rw/__init__.py
@@ -1,0 +1,12 @@
+"""Cross-process and cross-host reader/writer lock on :class:`~filelock.SoftFileLock` primitives."""
+
+from __future__ import annotations
+
+from ._async import AsyncAcquireSoftReadWriteReturnProxy, AsyncSoftReadWriteLock
+from ._sync import SoftReadWriteLock
+
+__all__ = [
+    "AsyncAcquireSoftReadWriteReturnProxy",
+    "AsyncSoftReadWriteLock",
+    "SoftReadWriteLock",
+]

--- a/src/filelock/_soft_rw/_async.py
+++ b/src/filelock/_soft_rw/_async.py
@@ -1,0 +1,213 @@
+"""Async wrapper around :class:`SoftReadWriteLock` for use with ``asyncio``."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from ._sync import SoftReadWriteLock
+
+if TYPE_CHECKING:
+    import os
+    from collections.abc import AsyncGenerator, Callable
+    from concurrent import futures
+    from types import TracebackType
+
+
+class AsyncAcquireSoftReadWriteReturnProxy:
+    """Async context-aware object that releases an :class:`AsyncSoftReadWriteLock` on exit."""
+
+    def __init__(self, lock: AsyncSoftReadWriteLock) -> None:
+        self.lock = lock
+
+    async def __aenter__(self) -> AsyncSoftReadWriteLock:
+        return self.lock
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.lock.release()
+
+
+class AsyncSoftReadWriteLock:
+    """
+    Async wrapper around :class:`SoftReadWriteLock` for ``asyncio`` applications.
+
+    The sync class's blocking filesystem operations run on a thread pool via ``loop.run_in_executor()``.
+    Reentrancy, upgrade/downgrade rules, fork handling, heartbeat and TTL stale detection, and singleton
+    behavior are delegated to the underlying :class:`SoftReadWriteLock`.
+
+    :param lock_file: path to the lock file; sidecar state/write/readers live next to it
+    :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
+    :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately on contention
+    :param is_singleton: if ``True``, reuse existing :class:`SoftReadWriteLock` instances per resolved path
+    :param heartbeat_interval: seconds between heartbeat refreshes; default 30 s
+    :param stale_threshold: seconds of mtime inactivity before a marker is stale; defaults to ``3 * heartbeat_interval``
+    :param poll_interval: seconds between acquire retries under contention; default 0.25 s
+    :param loop: event loop for ``run_in_executor``; ``None`` uses the running loop
+    :param executor: executor for ``run_in_executor``; ``None`` uses the default executor
+
+    .. versionadded:: 3.27.0
+
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+        is_singleton: bool = True,
+        heartbeat_interval: float = 30.0,
+        stale_threshold: float | None = None,
+        poll_interval: float = 0.25,
+        loop: asyncio.AbstractEventLoop | None = None,
+        executor: futures.Executor | None = None,
+    ) -> None:
+        self._lock = SoftReadWriteLock(
+            lock_file,
+            timeout,
+            blocking=blocking,
+            is_singleton=is_singleton,
+            heartbeat_interval=heartbeat_interval,
+            stale_threshold=stale_threshold,
+            poll_interval=poll_interval,
+        )
+        self._loop = loop
+        self._executor = executor
+
+    @property
+    def lock_file(self) -> str:
+        """:returns: the path to the lock file passed to the constructor."""
+        return self._lock.lock_file
+
+    @property
+    def timeout(self) -> float:
+        """:returns: the default timeout applied when ``acquire_read`` / ``acquire_write`` is called without one."""
+        return self._lock.timeout
+
+    @property
+    def blocking(self) -> bool:
+        """:returns: whether ``acquire_*`` defaults to blocking; ``False`` makes contention raise immediately."""
+        return self._lock.blocking
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop | None:
+        """:returns: the event loop used for ``run_in_executor``, or ``None`` for the running loop."""
+        return self._loop
+
+    @property
+    def executor(self) -> futures.Executor | None:
+        """:returns: the executor used for ``run_in_executor``, or ``None`` for the default executor."""
+        return self._executor
+
+    async def acquire_read(
+        self, timeout: float | None = None, *, blocking: bool | None = None
+    ) -> AsyncAcquireSoftReadWriteReturnProxy:
+        """
+        Acquire a shared read lock.
+
+        See :meth:`SoftReadWriteLock.acquire_read` for the full reentrancy / upgrade / fork semantics. The blocking
+        work runs inside ``run_in_executor`` so other coroutines on the same loop continue to progress while this
+        call waits.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        :returns: a proxy usable as an async context manager to release the lock
+
+        :raises RuntimeError: if a write lock is already held, if this instance was invalidated by
+            :func:`os.fork`, or if :meth:`close` was called
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        await self._run(self._lock.acquire_read, timeout, blocking=blocking)
+        return AsyncAcquireSoftReadWriteReturnProxy(lock=self)
+
+    async def acquire_write(
+        self, timeout: float | None = None, *, blocking: bool | None = None
+    ) -> AsyncAcquireSoftReadWriteReturnProxy:
+        """
+        Acquire an exclusive write lock.
+
+        See :meth:`SoftReadWriteLock.acquire_write` for the two-phase writer-preferring semantics. The blocking
+        work runs inside ``run_in_executor``.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        :returns: a proxy usable as an async context manager to release the lock
+
+        :raises RuntimeError: if a read lock is already held, if a write lock is held by a different thread, if
+            this instance was invalidated by :func:`os.fork`, or if :meth:`close` was called
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        await self._run(self._lock.acquire_write, timeout, blocking=blocking)
+        return AsyncAcquireSoftReadWriteReturnProxy(lock=self)
+
+    async def release(self, *, force: bool = False) -> None:
+        """
+        Release one level of the current lock.
+
+        :param force: if ``True``, release the lock completely regardless of the current lock level
+
+        :raises RuntimeError: if no lock is currently held and *force* is ``False``
+
+        """
+        await self._run(self._lock.release, force=force)
+
+    @asynccontextmanager
+    async def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
+        """
+        Async context manager that acquires and releases a shared read lock.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        :raises RuntimeError: if a write lock is already held on this instance
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        await self.acquire_read(timeout, blocking=blocking)
+        try:
+            yield
+        finally:
+            await self.release()
+
+    @asynccontextmanager
+    async def write_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
+        """
+        Async context manager that acquires and releases an exclusive write lock.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        :raises RuntimeError: if a read lock is already held, or a write lock is held by a different thread
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        await self.acquire_write(timeout, blocking=blocking)
+        try:
+            yield
+        finally:
+            await self.release()
+
+    async def close(self) -> None:
+        """Release any held lock and release the underlying filesystem resources. Idempotent."""
+        await self._run(self._lock.close)
+
+    async def _run(self, func: Callable[..., object], *args: object, **kwargs: object) -> object:
+        loop = self._loop or asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, functools.partial(func, *args, **kwargs))
+
+
+__all__ = [
+    "AsyncAcquireSoftReadWriteReturnProxy",
+    "AsyncSoftReadWriteLock",
+]

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -1,0 +1,847 @@
+"""Cross-process and cross-host reader/writer lock built on :class:`SoftFileLock` primitives."""
+
+from __future__ import annotations
+
+import atexit
+import hmac
+import os
+import re
+import secrets
+import socket
+import stat
+import sys
+import threading
+import time
+import uuid
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+from weakref import WeakValueDictionary
+
+from filelock._api import AcquireReturnProxy
+from filelock._error import Timeout
+from filelock._soft import SoftFileLock
+from filelock._util import ensure_directory_exists
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
+
+_Mode = Literal["read", "write"]
+_BREAK_SUFFIX = ".break"
+_MAX_MARKER_SIZE = 1024
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+# dirfd-relative I/O is a Unix-only optimization; Windows cannot ``os.open()`` a directory at all, and
+# its ``os`` module skips dir_fd support entirely. When disabled, callers fall back to full-path ops.
+_SUPPORTS_DIR_FD = sys.platform != "win32" and os.open in os.supports_dir_fd
+
+_all_instances: WeakValueDictionary[Path, SoftReadWriteLock] = WeakValueDictionary()
+_all_instances_lock = threading.Lock()
+_atexit_registered = False
+_fork_registered = False
+
+
+@dataclass(frozen=True)
+class _Paths:
+    state: str
+    write: str
+    readers: str
+
+
+@dataclass
+class _Locks:
+    internal: threading.Lock
+    transaction: threading.Lock
+    state: SoftFileLock
+
+
+@dataclass(frozen=True)
+class _MarkerInfo:
+    token: str
+    pid: int
+    hostname: str
+
+
+@dataclass
+class _Hold:
+    """Everything that exists only while a lock is held; ``None`` when the instance has no lock."""
+
+    level: int
+    mode: _Mode
+    write_thread_id: int | None
+    marker_name: str
+    is_reader: bool
+    token: str
+    heartbeat_thread: _HeartbeatThread
+    heartbeat_stop: threading.Event
+
+
+class _SoftRWMeta(type):
+    _instances: WeakValueDictionary[Path, SoftReadWriteLock]
+    _instances_lock: threading.Lock
+
+    def __call__(  # noqa: PLR0913
+        cls,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+        is_singleton: bool = True,
+        heartbeat_interval: float = 30.0,
+        stale_threshold: float | None = None,
+        poll_interval: float = 0.25,
+    ) -> SoftReadWriteLock:
+        if not is_singleton:
+            return super().__call__(
+                lock_file,
+                timeout,
+                blocking=blocking,
+                is_singleton=is_singleton,
+                heartbeat_interval=heartbeat_interval,
+                stale_threshold=stale_threshold,
+                poll_interval=poll_interval,
+            )
+
+        normalized = Path(lock_file).resolve()
+        with cls._instances_lock:
+            instance = cls._instances.get(normalized)
+            if instance is None:
+                instance = super().__call__(
+                    lock_file,
+                    timeout,
+                    blocking=blocking,
+                    is_singleton=is_singleton,
+                    heartbeat_interval=heartbeat_interval,
+                    stale_threshold=stale_threshold,
+                    poll_interval=poll_interval,
+                )
+                cls._instances[normalized] = instance
+            elif instance.timeout != timeout or instance.blocking != blocking:
+                msg = (
+                    f"Singleton lock created with timeout={instance.timeout}, blocking={instance.blocking},"
+                    f" cannot be changed to timeout={timeout}, blocking={blocking}"
+                )
+                raise ValueError(msg)
+            return instance
+
+
+class SoftReadWriteLock(metaclass=_SoftRWMeta):
+    """
+    Cross-process and cross-host reader/writer lock built on :class:`SoftFileLock` primitives.
+
+    Use this class instead of :class:`~filelock.ReadWriteLock` when the lock file lives on a network
+    filesystem (NFS, Lustre with ``-o flock``, HPC cluster shared storage). ``ReadWriteLock`` is backed
+    by SQLite and cannot run on NFS because SQLite's ``fcntl`` locking is unreliable there.
+
+    Layout on disk for a lock at ``foo.lock``:
+
+    - ``foo.lock.state`` — a :class:`SoftFileLock` taken only during state transitions (microseconds).
+    - ``foo.lock.write`` — writer marker; its presence means a writer is claiming or holding the lock.
+    - ``foo.lock.readers/<host>.<pid>.<uuid>`` — one file per reader.
+
+    Each marker stores a random token (``secrets.token_hex(16)``), the holder's pid, and the holder's
+    hostname. A daemon heartbeat thread refreshes ``mtime`` on every held marker. A marker whose mtime
+    has not advanced in ``stale_threshold`` seconds may be evicted by any process on any host, giving
+    correct behavior when a compute node crashes with a lock held.
+
+    Writer acquire is two-phase and writer-preferring: phase 1 claims ``.write`` (blocking any new
+    reader), phase 2 waits for existing readers to drain. Writer starvation is impossible.
+
+    Reentrancy, upgrade/downgrade rules, thread pinning, and singleton caching by resolved path match
+    :class:`~filelock.ReadWriteLock`.
+
+    Forking while holding a lock invalidates the inherited instance in the child so the child cannot
+    double-own the lock with its parent; ``release()`` on a fork-invalidated instance is a no-op, and
+    the child must re-acquire if it needs a lock.
+
+    Trust boundary: protects against same-UID non-cooperating processes (one host or cross-host) and
+    same-host different-UID users via ``0o600`` / ``0o700`` permissions. Does not protect against root
+    compromise, NTP tampering on same-UID cross-host nodes, or multi-tenant mounts where hostile
+    co-tenants share the UID.
+
+    :param lock_file: path to the lock file; sidecar state/write/readers live next to it
+    :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
+    :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately on contention
+    :param is_singleton: if ``True``, reuse existing instances for the same resolved path
+    :param heartbeat_interval: seconds between heartbeat refreshes; default 30 s
+    :param stale_threshold: seconds of ``mtime`` inactivity before a marker is stale; defaults to
+        ``3 * heartbeat_interval``, matching etcd's ``LeaseKeepAlive`` convention
+    :param poll_interval: seconds between acquire retries under contention; default 0.25 s
+
+    .. versionadded:: 3.27.0
+
+    """
+
+    _instances: WeakValueDictionary[Path, SoftReadWriteLock] = WeakValueDictionary()
+    _instances_lock = threading.Lock()
+
+    def __init__(  # noqa: PLR0913
+        self,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+        is_singleton: bool = True,  # noqa: ARG002
+        heartbeat_interval: float = 30.0,
+        stale_threshold: float | None = None,
+        poll_interval: float = 0.25,
+    ) -> None:
+        if heartbeat_interval <= 0:
+            msg = f"heartbeat_interval must be positive, got {heartbeat_interval}"
+            raise ValueError(msg)
+        if stale_threshold is None:
+            stale_threshold = heartbeat_interval * 3
+        if stale_threshold <= heartbeat_interval:
+            msg = f"stale_threshold must exceed heartbeat_interval ({stale_threshold} <= {heartbeat_interval})"
+            raise ValueError(msg)
+        if poll_interval <= 0:
+            msg = f"poll_interval must be positive, got {poll_interval}"
+            raise ValueError(msg)
+
+        self.lock_file: str = os.fspath(lock_file)
+        self.timeout: float = timeout
+        self.blocking: bool = blocking
+        self.heartbeat_interval: float = heartbeat_interval
+        self.stale_threshold: float = stale_threshold
+        self.poll_interval: float = poll_interval
+
+        self._paths = _Paths(
+            state=f"{self.lock_file}.state",
+            write=f"{self.lock_file}.write",
+            readers=f"{self.lock_file}.readers",
+        )
+        ensure_directory_exists(self.lock_file)
+        self._locks = _Locks(
+            internal=threading.Lock(),
+            transaction=threading.Lock(),
+            state=SoftFileLock(self._paths.state, timeout=-1),
+        )
+        self._readers_dir_fd: int | None = None
+        self._hold: _Hold | None = None
+        self._fork_invalidated: bool = False
+        self._closed: bool = False
+
+        with _all_instances_lock:
+            _all_instances[Path(self.lock_file).resolve()] = self
+            _register_hooks()
+
+    @contextmanager
+    def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> Generator[None]:
+        """
+        Context manager that acquires and releases a shared read lock.
+
+        Falls back to instance defaults for *timeout* and *blocking* when ``None``.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        :raises RuntimeError: if a write lock is already held on this instance
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        self.acquire_read(timeout, blocking=blocking)
+        try:
+            yield
+        finally:
+            self.release()
+
+    @contextmanager
+    def write_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> Generator[None]:
+        """
+        Context manager that acquires and releases an exclusive write lock.
+
+        Falls back to instance defaults for *timeout* and *blocking* when ``None``.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        :raises RuntimeError: if a read lock is already held, or a write lock is held by a different thread
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        self.acquire_write(timeout, blocking=blocking)
+        try:
+            yield
+        finally:
+            self.release()
+
+    def acquire_read(self, timeout: float | None = None, *, blocking: bool | None = None) -> AcquireReturnProxy:
+        """
+        Acquire a shared read lock.
+
+        If this instance already holds a read lock, the lock level is incremented (reentrant). Attempting to acquire a
+        read lock while holding a write lock raises :class:`RuntimeError` (downgrade not allowed). On the 0→1
+        transition a daemon heartbeat thread is started that refreshes the reader marker's ``mtime`` every
+        ``heartbeat_interval`` seconds so peers on other hosts do not evict the marker as stale.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default; ``-1`` means block
+            indefinitely
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable;
+            ``None`` uses the instance default
+
+        :returns: a proxy that can be used as a context manager to release the lock
+
+        :raises RuntimeError: if a write lock is already held on this instance, if this instance was invalidated by
+            :func:`os.fork`, or if :meth:`close` was called
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        return self._acquire("read", timeout, blocking=blocking)
+
+    def acquire_write(self, timeout: float | None = None, *, blocking: bool | None = None) -> AcquireReturnProxy:
+        """
+        Acquire an exclusive write lock.
+
+        If this instance already holds a write lock from the same thread, the lock level is incremented (reentrant).
+        Attempting to acquire a write lock while holding a read lock raises :class:`RuntimeError` (upgrade not
+        allowed). Write locks are pinned to the acquiring thread: a different thread trying to re-enter also raises
+        :class:`RuntimeError`.
+
+        Writer acquisition runs in two phases. Phase 1 atomically claims ``<path>.write`` via ``O_CREAT | O_EXCL``,
+        which immediately blocks any new reader on any host. Phase 2 waits for existing readers to drain. Writer
+        starvation is impossible: new readers see ``<path>.write`` during phase 2 and wait behind the pending writer.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default; ``-1`` means block
+            indefinitely
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable;
+            ``None`` uses the instance default
+
+        :returns: a proxy that can be used as a context manager to release the lock
+
+        :raises RuntimeError: if a read lock is already held, if a write lock is held by a different thread, if this
+            instance was invalidated by :func:`os.fork`, or if :meth:`close` was called
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        return self._acquire("write", timeout, blocking=blocking)
+
+    def close(self) -> None:
+        """
+        Release any held lock and release internal filesystem resources.
+
+        Idempotent. After calling this method the instance can no longer acquire locks — subsequent acquires raise
+        :class:`RuntimeError`. A fork-invalidated instance is closed without raising.
+        """
+        self.release(force=True)
+        with self._locks.internal:
+            if self._closed:
+                return
+            self._closed = True
+            if self._readers_dir_fd is not None:
+                with suppress(OSError):
+                    os.close(self._readers_dir_fd)
+                self._readers_dir_fd = None
+
+    def release(self, *, force: bool = False) -> None:
+        """
+        Release one level of the current lock.
+
+        When the lock level reaches zero the heartbeat thread is stopped and the held marker file is unlinked. On a
+        fork-invalidated instance (that is, the child of a :func:`os.fork` call made while the parent held a lock)
+        this method is a no-op so inherited ``with`` blocks can unwind cleanly in the child.
+
+        :param force: if ``True``, release the lock completely regardless of the current lock level
+
+        :raises RuntimeError: if no lock is currently held and *force* is ``False``
+
+        """
+        with self._locks.internal:
+            if self._fork_invalidated:
+                # Inherited state from the parent is meaningless in the child; clear any counters and return.
+                self._hold = None
+                return
+            hold = self._hold
+            if hold is None:
+                if force:
+                    return
+                msg = f"Cannot release a lock on {self.lock_file} (lock id: {id(self)}) that is not held"
+                raise RuntimeError(msg)
+            if force:
+                hold.level = 0
+            else:
+                hold.level -= 1
+            if hold.level > 0:
+                return
+            self._hold = None
+
+        # Order matters: signal → join → unlink. A late tick on a deleted marker is harmless, and the
+        # token check in the heartbeat callback would catch any re-acquisition race, but joining first
+        # removes even that theoretical race.
+        hold.heartbeat_stop.set()
+        hold.heartbeat_thread.join(timeout=self.heartbeat_interval + 1.0)
+        if hold.is_reader:
+            _unlink(hold.marker_name, dir_fd=self._readers_dir_fd)
+        else:
+            _unlink(hold.marker_name)
+
+    @classmethod
+    def get_lock(
+        cls,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+    ) -> SoftReadWriteLock:
+        """
+        Return the singleton :class:`SoftReadWriteLock` for *lock_file*.
+
+        :param lock_file: path to the lock file; sidecar state/write/readers live next to it
+        :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable
+
+        :returns: the singleton lock instance
+
+        :raises ValueError: if an instance already exists for this path with different *timeout* or *blocking* values
+
+        """
+        return cls(lock_file, timeout, blocking=blocking)
+
+    def _acquire(
+        self,
+        mode: _Mode,
+        timeout: float | None,
+        *,
+        blocking: bool | None,
+    ) -> AcquireReturnProxy:
+        effective_timeout = self.timeout if timeout is None else timeout
+        effective_blocking = self.blocking if blocking is None else blocking
+
+        with self._locks.internal:
+            if self._fork_invalidated:
+                msg = f"SoftReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
+                raise RuntimeError(msg)
+            if self._closed:
+                msg = f"SoftReadWriteLock on {self.lock_file} has been closed"
+                raise RuntimeError(msg)
+            if self._hold is not None:
+                return self._validate_reentrant(mode)
+
+        start = time.perf_counter()
+        if not effective_blocking:
+            acquired = self._locks.transaction.acquire(blocking=False)
+        elif effective_timeout == -1:
+            acquired = self._locks.transaction.acquire(blocking=True)
+        else:
+            acquired = self._locks.transaction.acquire(blocking=True, timeout=effective_timeout)
+        if not acquired:
+            raise Timeout(self.lock_file) from None
+        try:
+            with self._locks.internal:
+                if self._hold is not None:
+                    return self._validate_reentrant(mode)
+
+            deadline = None if effective_timeout == -1 else start + effective_timeout
+            token = secrets.token_hex(16)
+            if mode == "write":
+                marker_name, is_reader = self._acquire_writer_slot(
+                    token, deadline=deadline, blocking=effective_blocking
+                )
+            else:
+                marker_name, is_reader = self._acquire_reader_slot(
+                    token, deadline=deadline, blocking=effective_blocking
+                )
+
+            stop_event = threading.Event()
+            heartbeat = _HeartbeatThread(
+                refresh=self._refresh_marker,
+                interval=self.heartbeat_interval,
+                stop_event=stop_event,
+                name=f"filelock-heartbeat-{id(self):x}",
+            )
+
+            with self._locks.internal:
+                self._hold = _Hold(
+                    level=1,
+                    mode=mode,
+                    write_thread_id=threading.get_ident() if mode == "write" else None,
+                    marker_name=marker_name,
+                    is_reader=is_reader,
+                    token=token,
+                    heartbeat_thread=heartbeat,
+                    heartbeat_stop=stop_event,
+                )
+
+            heartbeat.start()
+            return AcquireReturnProxy(lock=self)
+        finally:
+            self._locks.transaction.release()
+
+    def _validate_reentrant(self, mode: _Mode) -> AcquireReturnProxy:
+        hold = self._hold
+        assert hold is not None  # noqa: S101
+        if hold.mode != mode:
+            opposite = "write" if mode == "read" else "read"
+            direction = "downgrade" if mode == "read" else "upgrade"
+            msg = (
+                f"Cannot acquire {mode} lock on {self.lock_file} (lock id: {id(self)}): "
+                f"already holding a {opposite} lock ({direction} not allowed)"
+            )
+            raise RuntimeError(msg)
+        if mode == "write" and (cur := threading.get_ident()) != hold.write_thread_id:
+            msg = (
+                f"Cannot acquire write lock on {self.lock_file} (lock id: {id(self)}) "
+                f"from thread {cur} while it is held by thread {hold.write_thread_id}"
+            )
+            raise RuntimeError(msg)
+        hold.level += 1
+        return AcquireReturnProxy(lock=self)
+
+    def _acquire_writer_slot(
+        self,
+        token: str,
+        *,
+        deadline: float | None,
+        blocking: bool,
+    ) -> tuple[str, bool]:
+        # Phase 2 scans readers/ via dirfd (where supported), so we need it open even though writers never
+        # create files inside.
+        self._open_readers_dir()
+
+        def try_claim_writer() -> bool:
+            with self._locks.state:
+                _break_stale_marker(self._paths.write, stale_threshold=self.stale_threshold, now=time.time())
+                if _file_exists(self._paths.write):
+                    return False
+                try:
+                    _atomic_create_marker(self._paths.write, token)
+                except FileExistsError:
+                    return False
+            return True
+
+        def readers_drained_touching() -> bool:
+            with self._locks.state:
+                # Refresh our writer marker on every scan iteration. Otherwise phase 2 can exceed
+                # ``stale_threshold`` under contention and a peer would treat us as stale and evict us.
+                with suppress(OSError):
+                    _touch(self._paths.write)
+                self._break_stale_readers(time.time())
+                return not self._any_readers()
+
+        self._wait_for(try_claim_writer, deadline=deadline, blocking=blocking)
+        try:
+            self._wait_for(readers_drained_touching, deadline=deadline, blocking=blocking)
+        except Timeout:
+            # Give up our writer claim so readers can make progress again.
+            _unlink(self._paths.write)
+            raise
+        return self._paths.write, False
+
+    def _acquire_reader_slot(
+        self,
+        token: str,
+        *,
+        deadline: float | None,
+        blocking: bool,
+    ) -> tuple[str, bool]:
+        self._open_readers_dir()
+        reader_name = f"{uuid.uuid4().hex}.{os.getpid()}"
+        dir_fd = self._readers_dir_fd
+        full_reader_path = str(Path(self._paths.readers) / reader_name)
+
+        def try_claim_reader() -> bool:
+            with self._locks.state:
+                _break_stale_marker(self._paths.write, stale_threshold=self.stale_threshold, now=time.time())
+                if _file_exists(self._paths.write):
+                    return False
+                if dir_fd is not None:
+                    _atomic_create_marker(reader_name, token, dir_fd=dir_fd)
+                else:  # pragma: win32 cover
+                    _atomic_create_marker(full_reader_path, token)
+                return True
+
+        self._wait_for(try_claim_reader, deadline=deadline, blocking=blocking)
+        return (reader_name if dir_fd is not None else full_reader_path), True
+
+    def _wait_for(
+        self,
+        predicate: Callable[[], bool],
+        *,
+        deadline: float | None,
+        blocking: bool,
+    ) -> None:
+        while True:
+            if predicate():
+                return
+            now = time.perf_counter()
+            if not blocking:
+                raise Timeout(self.lock_file)
+            if deadline is not None and now >= deadline:
+                raise Timeout(self.lock_file)
+            sleep_for = self.poll_interval
+            if deadline is not None:
+                sleep_for = min(sleep_for, max(deadline - now, 0.0))
+            time.sleep(sleep_for)
+
+    def _open_readers_dir(self) -> None:
+        readers_path = Path(self._paths.readers)
+        with suppress(FileExistsError):
+            readers_path.mkdir(mode=0o700)
+        # mkdir has no O_NOFOLLOW, so verify via lstat that we did not land on an attacker-placed symlink
+        # or a regular file before we open or scan inside.
+        st = os.lstat(self._paths.readers)
+        if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
+            msg = f"{self._paths.readers} exists but is not a directory or is a symlink; refusing to use it"
+            raise RuntimeError(msg)
+        if self._readers_dir_fd is None and _SUPPORTS_DIR_FD:
+            flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
+            self._readers_dir_fd = os.open(self._paths.readers, flags)
+
+    def _any_readers(self) -> bool:
+        for _ in self._iter_reader_entries():
+            return True
+        return False
+
+    def _iter_reader_entries(self) -> Generator[tuple[str, bool]]:
+        """
+        Yield ``(name, dirfd_relative)`` pairs for every live reader marker.
+
+        ``dirfd_relative`` is ``True`` when *name* should be passed to ``dir_fd=``-aware syscalls; ``False``
+        when *name* is a full path because dirfd-relative I/O is unavailable on this platform.
+        """
+        if self._readers_dir_fd is not None:
+            with os.scandir(self._readers_dir_fd) as it:
+                for entry in it:
+                    if not _is_housekeeping_name(entry.name):
+                        yield entry.name, True
+            return
+        readers_path = Path(self._paths.readers)  # pragma: win32 cover
+        with os.scandir(readers_path) as it:  # pragma: win32 cover
+            for entry in it:  # pragma: win32 cover
+                if not _is_housekeeping_name(entry.name):  # pragma: win32 cover
+                    yield str(readers_path / entry.name), False  # pragma: win32 cover
+
+    def _break_stale_readers(self, now: float) -> None:
+        names: list[tuple[str, int | None]] = []
+        try:
+            for name, dirfd_relative in self._iter_reader_entries():
+                names.append((name, self._readers_dir_fd if dirfd_relative else None))
+        except OSError:  # pragma: no cover - transient NFS scandir hiccup
+            return
+        for name, fd in names:
+            _break_stale_marker(name, stale_threshold=self.stale_threshold, now=now, dir_fd=fd)
+
+    def _refresh_marker(self) -> bool:
+        with self._locks.internal:
+            hold = self._hold
+            if hold is None:  # pragma: no cover - race between stop_event.set and join
+                return False
+            marker_name = hold.marker_name
+            token = hold.token
+            dir_fd = self._readers_dir_fd if hold.is_reader else None
+
+        read_result = _read_marker(marker_name, dir_fd=dir_fd)
+        if read_result is None:
+            return False
+        info, _mtime = read_result
+        # Token mismatch means another process already evicted our marker and created its own; stop the
+        # thread so it does not touch a stranger's file.
+        if info is None or not hmac.compare_digest(info.token, token):
+            return False
+        try:
+            _touch(marker_name, dir_fd=dir_fd)
+        except FileNotFoundError:  # pragma: no cover - race between successful read and touch
+            return False
+        return True
+
+    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - fork child not tracked
+        # Replace every lock this instance owns with a fresh one; the inherited locks may still be held
+        # by threads that no longer exist in the child. The readers dirfd and the SoftFileLock state
+        # mutex both get dropped for the same reason — the child re-creates them on its next acquire.
+        self._locks = _Locks(
+            internal=threading.Lock(),
+            transaction=threading.Lock(),
+            state=SoftFileLock(self._paths.state, timeout=-1),
+        )
+        self._hold = None
+        self._readers_dir_fd = None
+        self._fork_invalidated = True
+
+
+class _HeartbeatThread(threading.Thread):
+    def __init__(
+        self,
+        refresh: Callable[[], bool],
+        interval: float,
+        stop_event: threading.Event,
+        name: str,
+    ) -> None:
+        super().__init__(name=name, daemon=True)
+        self._refresh = refresh
+        self._interval = interval
+        self._stop_event = stop_event
+
+    def run(self) -> None:
+        while not self._stop_event.wait(self._interval):
+            if not self._refresh():
+                self._stop_event.set()
+                return
+
+
+def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -> None:
+    # O_NOFOLLOW blocks the symlink-overwrite attack where an attacker pre-creates the marker path as a
+    # symlink pointing at a victim file. Mode 0o600 keeps the token unreadable to other users.
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _O_NOFOLLOW
+    if _SUPPORTS_DIR_FD and dir_fd is not None:
+        fd = os.open(name, flags, 0o600, dir_fd=dir_fd)
+    else:
+        fd = os.open(name, flags, 0o600)
+    try:
+        content = f"{token}\n{os.getpid()}\n{socket.gethostname()}\n".encode("ascii")
+        os.write(fd, content)
+    finally:
+        os.close(fd)
+
+
+def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo | None, float] | None:
+    # O_NOFOLLOW is defense in depth: we already created this file, but a hostile replacement by symlink
+    # between create and read would be caught here.
+    flags = os.O_RDONLY | _O_NOFOLLOW
+    try:
+        fd = os.open(name, flags, dir_fd=dir_fd) if _SUPPORTS_DIR_FD and dir_fd is not None else os.open(name, flags)
+    except OSError:
+        return None
+    try:
+        try:
+            st = os.fstat(fd)
+            data = os.read(fd, _MAX_MARKER_SIZE + 1)
+        except OSError:  # pragma: no cover - fstat/read after a successful open is hard to provoke
+            return None
+    finally:
+        os.close(fd)
+    return _parse_marker_bytes(data), st.st_mtime
+
+
+def _parse_marker_bytes(data: bytes) -> _MarkerInfo | None:
+    # Trust nothing about attacker-controlled markers; any deviation returns None so callers fall through
+    # to stale cleanup. ``re.match`` caches compiled patterns internally, so the regex is built only once
+    # despite being defined inline.
+    if not data or len(data) > _MAX_MARKER_SIZE:
+        return None
+    try:
+        text = data.decode("ascii")
+    except UnicodeDecodeError:
+        return None
+    match = re.match(
+        r"""
+        \A                                  # start of string
+        (?P<token>    [0-9a-f]{32}     ) \n # 128-bit hex token
+        (?P<pid>      [1-9][0-9]{0,9}  ) \n # decimal pid: no leading zero, ≤ 10 digits
+        (?P<hostname> [\x21-\x7e]{1,253})   # printable non-whitespace ASCII (RFC 1123 hostname limit)
+        \n*                                 # tolerate sloppy writers that append extra newlines
+        \Z                                  # end of string
+        """,
+        text,
+        re.VERBOSE,
+    )
+    if match is None:
+        return None
+    pid = int(match["pid"], 10)
+    if pid > 2**31 - 1:
+        return None
+    return _MarkerInfo(token=match["token"], pid=pid, hostname=match["hostname"])
+
+
+def _break_stale_marker(  # noqa: PLR0911
+    name: str,
+    *,
+    stale_threshold: float,
+    now: float,
+    dir_fd: int | None = None,
+) -> bool:
+    # Atomic break pattern: read → rename to unique break-name → re-verify → unlink. The rename gives us a
+    # private name nobody else can touch; if the re-verify sees a newer mtime or a different token, the
+    # legitimate holder's heartbeat fired between read and rename and we must abort (leaving the .break.*
+    # file behind rather than rollback-renaming, because rollback is itself racy).
+    read_result = _read_marker(name, dir_fd=dir_fd)
+    if read_result is None:
+        return False
+    info_before, mtime_before = read_result
+    if now - mtime_before <= stale_threshold:
+        return False
+    if info_before is None:
+        _unlink(name, dir_fd=dir_fd)
+        return True
+
+    break_name = f"{name}{_BREAK_SUFFIX}.{os.getpid()}.{secrets.token_hex(16)}"
+    try:
+        if _SUPPORTS_DIR_FD and dir_fd is not None:
+            os.rename(name, break_name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        else:
+            Path(name).rename(break_name)
+    except OSError:  # pragma: no cover - race where the marker vanishes between read and rename
+        return False
+
+    read_after = _read_marker(break_name, dir_fd=dir_fd)
+    if read_after is None:  # pragma: no cover - race where a peer unlinks the break-name file
+        return False
+    info_after, mtime_after = read_after
+    if info_after is None:  # pragma: no cover - content replaced post-rename by a racing peer
+        _unlink(break_name, dir_fd=dir_fd)
+        return True
+    if not hmac.compare_digest(info_before.token, info_after.token):  # pragma: no cover - race only
+        return False
+    if mtime_after > mtime_before:  # pragma: no cover - heartbeat raced our rename
+        return False
+    _unlink(break_name, dir_fd=dir_fd)
+    return True
+
+
+def _unlink(name: str, *, dir_fd: int | None = None) -> None:
+    with suppress(FileNotFoundError):
+        if _SUPPORTS_DIR_FD and dir_fd is not None:
+            # Path.unlink has no dir_fd support, so we stay on os.unlink for the dirfd path.
+            os.unlink(name, dir_fd=dir_fd)
+        else:
+            Path(name).unlink()
+
+
+def _touch(name: str, *, dir_fd: int | None = None) -> None:
+    if _SUPPORTS_DIR_FD and dir_fd is not None:
+        os.utime(name, None, dir_fd=dir_fd)
+    else:
+        os.utime(name, None)
+
+
+def _file_exists(path: str) -> bool:
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return False
+    return stat.S_ISREG(st.st_mode)
+
+
+def _is_housekeeping_name(name: str) -> bool:
+    return name.startswith(".") or _BREAK_SUFFIX in name
+
+
+def _reset_all_after_fork() -> None:  # pragma: no cover - fork child, not tracked by coverage
+    global _all_instances_lock  # noqa: PLW0603
+    # User-created threading locks do not auto-reset across fork: any lock held by a parent thread stays
+    # locked in the child with no owner to release it. Replace the module-level lock and every instance's
+    # locks with fresh ones; the child is single-threaded at this point so no synchronization is needed.
+    _all_instances_lock = threading.Lock()
+    for instance in list(_all_instances.values()):
+        instance._reset_after_fork_in_child()  # noqa: SLF001
+
+
+def _cleanup_all_instances() -> None:  # pragma: no cover - runs from atexit at interpreter shutdown
+    for instance in list(_all_instances.values()):
+        with suppress(Exception):
+            instance.release(force=True)
+
+
+def _register_hooks() -> None:
+    global _atexit_registered, _fork_registered  # noqa: PLW0603
+    if not _atexit_registered:
+        atexit.register(_cleanup_all_instances)
+        _atexit_registered = True
+    # after_in_child replaces inherited state so the child cannot double-own any lock the parent held.
+    if not _fork_registered and hasattr(os, "register_at_fork"):
+        os.register_at_fork(after_in_child=_reset_all_after_fork)
+        _fork_registered = True
+
+
+__all__ = [
+    "SoftReadWriteLock",
+]

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -91,7 +91,7 @@ class AsyncFileLockMeta(FileLockMeta):
         if thread_local and run_in_executor:
             msg = "run_in_executor is not supported when thread_local is True"
             raise ValueError(msg)
-        return super().__call__(  # ty: ignore[invalid-super-argument]  # https://github.com/astral-sh/ty/issues/3231
+        return super().__call__(
             lock_file=lock_file,
             timeout=timeout,
             mode=mode,

--- a/tests/soft_rw/test_soft_rw_async.py
+++ b/tests/soft_rw/test_soft_rw_async.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import Timeout
+from filelock._soft_rw import AsyncSoftReadWriteLock, SoftReadWriteLock
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from concurrent.futures import Executor
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clear_singletons() -> Generator[None]:
+    SoftReadWriteLock._instances.clear()
+    yield
+    for ref in list(SoftReadWriteLock._instances.valuerefs()):
+        if (lock := ref()) is not None:
+            lock.close()
+    SoftReadWriteLock._instances.clear()
+
+
+def _make(
+    tmp_path: Path,
+    name: str = "foo.lock",
+    *,
+    timeout: float = -1,
+    blocking: bool = True,
+    heartbeat_interval: float = 0.1,
+    stale_threshold: float = 0.5,
+    poll_interval: float = 0.02,
+    loop: asyncio.AbstractEventLoop | None = None,
+    executor: Executor | None = None,
+) -> AsyncSoftReadWriteLock:
+    return AsyncSoftReadWriteLock(
+        str(tmp_path / name),
+        timeout=timeout,
+        blocking=blocking,
+        is_singleton=False,
+        heartbeat_interval=heartbeat_interval,
+        stale_threshold=stale_threshold,
+        poll_interval=poll_interval,
+        loop=loop,
+        executor=executor,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_write_lock_context_manager(tmp_path: Path) -> None:
+    lock = _make(tmp_path)
+    try:
+        async with lock.write_lock(timeout=2):
+            pass
+    finally:
+        await lock.close()
+
+
+@pytest.mark.asyncio
+async def test_async_read_lock_context_manager(tmp_path: Path) -> None:
+    lock = _make(tmp_path)
+    try:
+        async with lock.read_lock(timeout=2):
+            pass
+    finally:
+        await lock.close()
+
+
+@pytest.mark.asyncio
+async def test_async_exposes_configuration(tmp_path: Path) -> None:
+    lock = _make(tmp_path, timeout=5, blocking=False)
+    try:
+        assert lock.lock_file.endswith("foo.lock")
+        assert lock.timeout == 5
+        assert lock.blocking is False
+        assert lock.loop is None
+        assert lock.executor is None
+    finally:
+        await lock.close()
+
+
+@pytest.mark.asyncio
+async def test_async_raw_acquire_release_round_trip(tmp_path: Path) -> None:
+    lock = _make(tmp_path)
+    try:
+        proxy = await lock.acquire_write(timeout=2)
+        async with proxy:
+            pass
+        proxy = await lock.acquire_read(timeout=2)
+        async with proxy:
+            pass
+    finally:
+        await lock.close()
+
+
+@pytest.mark.asyncio
+async def test_async_custom_loop_and_executor(tmp_path: Path) -> None:
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        loop = asyncio.get_running_loop()
+        lock = _make(tmp_path, loop=loop, executor=executor)
+        try:
+            assert lock.loop is loop
+            assert lock.executor is executor
+            async with lock.write_lock(timeout=2):
+                pass
+        finally:
+            await lock.close()
+
+
+@pytest.mark.asyncio
+async def test_async_release_force(tmp_path: Path) -> None:
+    lock = _make(tmp_path)
+    try:
+        await lock.acquire_read(timeout=2)
+        await lock.release(force=True)
+    finally:
+        await lock.close()
+
+
+@pytest.mark.asyncio
+async def test_async_writer_times_out_behind_reader(tmp_path: Path) -> None:
+    reader = _make(tmp_path)
+    await reader.acquire_read(timeout=2)
+    try:
+        writer = _make(tmp_path)
+        try:
+            with pytest.raises(Timeout):
+                await writer.acquire_write(timeout=0.3)
+        finally:
+            await writer.close()
+    finally:
+        await reader.release()
+        await reader.close()

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -1,0 +1,909 @@
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import stat
+import sys
+import threading
+import time
+from contextlib import contextmanager, suppress
+from multiprocessing import Event, Process
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import pytest
+
+from filelock import Timeout
+from filelock._soft_rw import SoftReadWriteLock
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+    from multiprocessing.synchronize import Event as EventType
+
+
+requires_posix_signals = pytest.mark.skipif(sys.platform == "win32", reason="POSIX signals required")
+requires_posix_permissions = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX file-mode bits not meaningful on Windows"
+)
+requires_fork = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
+
+
+def _worker(
+    lock_file: str,
+    mode: Literal["read", "write"],
+    acquired_event: EventType,
+    release_event: EventType | None = None,
+    timeout: float = -1,
+    blocking: bool = True,
+    heartbeat_interval: float = 0.1,
+    stale_threshold: float = 1.0,
+    poll_interval: float = 0.02,
+) -> None:
+    lock = SoftReadWriteLock(
+        lock_file,
+        timeout=timeout,
+        blocking=blocking,
+        is_singleton=False,
+        heartbeat_interval=heartbeat_interval,
+        stale_threshold=stale_threshold,
+        poll_interval=poll_interval,
+    )
+    ctx = lock.read_lock() if mode == "read" else lock.write_lock()
+    try:
+        with ctx:
+            acquired_event.set()
+            if release_event is not None:
+                release_event.wait(timeout=10)
+            else:
+                time.sleep(0.2)
+    finally:
+        lock.close()
+
+
+def _sigkill_worker(
+    lock_file: str,
+    mode: Literal["read", "write"],
+    acquired_event: EventType,
+    heartbeat_interval: float,
+    stale_threshold: float,
+) -> None:
+    lock = SoftReadWriteLock(
+        lock_file,
+        is_singleton=False,
+        heartbeat_interval=heartbeat_interval,
+        stale_threshold=stale_threshold,
+        poll_interval=0.05,
+    )
+    if mode == "read":
+        lock.acquire_read()
+    else:
+        lock.acquire_write()
+    acquired_event.set()
+    time.sleep(60)
+
+
+@contextmanager
+def _cleanup(processes: list[Process]) -> Generator[None]:
+    try:
+        yield
+    finally:
+        for proc in processes:
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=2)
+
+
+@pytest.fixture(autouse=True)
+def _clear_singletons() -> Generator[None]:
+    SoftReadWriteLock._instances.clear()
+    yield
+    for ref in list(SoftReadWriteLock._instances.valuerefs()):
+        if (lock := ref()) is not None:
+            lock.close()
+    SoftReadWriteLock._instances.clear()
+
+
+@pytest.fixture
+def lock_file(tmp_path: Path) -> str:
+    return str(tmp_path / "test.lock")
+
+
+def _make_lock(
+    path: str,
+    *,
+    heartbeat_interval: float = 0.1,
+    stale_threshold: float = 0.5,
+    poll_interval: float = 0.02,
+    is_singleton: bool = False,
+) -> SoftReadWriteLock:
+    return SoftReadWriteLock(
+        path,
+        heartbeat_interval=heartbeat_interval,
+        stale_threshold=stale_threshold,
+        poll_interval=poll_interval,
+        is_singleton=is_singleton,
+    )
+
+
+def test_rejects_non_positive_heartbeat_interval(lock_file: str) -> None:
+    with pytest.raises(ValueError, match="heartbeat_interval must be positive"):
+        SoftReadWriteLock(lock_file, heartbeat_interval=0, is_singleton=False)
+
+
+def test_rejects_stale_threshold_not_greater_than_heartbeat(lock_file: str) -> None:
+    with pytest.raises(ValueError, match="stale_threshold must exceed"):
+        SoftReadWriteLock(lock_file, heartbeat_interval=10, stale_threshold=5, is_singleton=False)
+
+
+def test_rejects_non_positive_poll_interval(lock_file: str) -> None:
+    with pytest.raises(ValueError, match="poll_interval must be positive"):
+        SoftReadWriteLock(lock_file, poll_interval=0, is_singleton=False)
+
+
+def test_public_attributes(lock_file: str) -> None:
+    lock = SoftReadWriteLock(
+        lock_file,
+        timeout=5,
+        blocking=False,
+        heartbeat_interval=10,
+        stale_threshold=45,
+        poll_interval=0.5,
+        is_singleton=False,
+    )
+    try:
+        assert lock.lock_file == lock_file
+        assert lock.timeout == 5
+        assert lock.blocking is False
+        assert lock.heartbeat_interval == 10
+        assert lock.stale_threshold == 45
+        assert lock.poll_interval == pytest.approx(0.5)
+    finally:
+        lock.close()
+
+
+def test_default_stale_threshold_is_triple_heartbeat(lock_file: str) -> None:
+    lock = SoftReadWriteLock(lock_file, heartbeat_interval=12, is_singleton=False)
+    try:
+        assert lock.stale_threshold == 36
+    finally:
+        lock.close()
+
+
+def test_singleton_returns_same_instance(lock_file: str) -> None:
+    first = SoftReadWriteLock(lock_file)
+    second = SoftReadWriteLock(lock_file)
+    try:
+        assert first is second
+    finally:
+        first.close()
+
+
+def test_non_singleton_returns_distinct_instances(lock_file: str) -> None:
+    first = SoftReadWriteLock(lock_file, is_singleton=False)
+    second = SoftReadWriteLock(lock_file, is_singleton=False)
+    try:
+        assert first is not second
+    finally:
+        first.close()
+        second.close()
+
+
+def test_singleton_mismatch_raises(lock_file: str) -> None:
+    first = SoftReadWriteLock(lock_file, timeout=5)
+    try:
+        with pytest.raises(ValueError, match="cannot be changed"):
+            SoftReadWriteLock(lock_file, timeout=10)
+    finally:
+        first.close()
+
+
+def test_get_lock_returns_singleton(lock_file: str) -> None:
+    first = SoftReadWriteLock.get_lock(lock_file)
+    second = SoftReadWriteLock.get_lock(lock_file)
+    try:
+        assert first is second
+    finally:
+        first.close()
+
+
+def test_reentrant_read_holds_and_releases(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    try:
+        with lock.read_lock(timeout=2), lock.read_lock(timeout=2):
+            pass
+        # After two releases the marker is gone.
+        with lock.read_lock(timeout=2):
+            pass
+    finally:
+        lock.close()
+
+
+def test_reentrant_write_holds_and_releases(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    try:
+        with lock.write_lock(timeout=2), lock.write_lock(timeout=2):
+            assert Path(f"{lock_file}.write").exists()
+        assert not Path(f"{lock_file}.write").exists()
+    finally:
+        lock.close()
+
+
+def test_upgrade_from_read_to_write_raises(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    try:
+        with lock.read_lock(timeout=2), pytest.raises(RuntimeError, match="upgrade not allowed"):
+            lock.acquire_write(timeout=1)
+    finally:
+        lock.close()
+
+
+def test_downgrade_from_write_to_read_raises(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    try:
+        with lock.write_lock(timeout=2), pytest.raises(RuntimeError, match="downgrade not allowed"):
+            lock.acquire_read(timeout=1)
+    finally:
+        lock.close()
+
+
+def test_write_lock_is_thread_pinned(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    errors: list[BaseException] = []
+    lock.acquire_write(timeout=2)
+
+    def other() -> None:
+        try:
+            lock.acquire_write(timeout=1, blocking=False)
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=other)
+    thread.start()
+    thread.join()
+    lock.release()
+    lock.close()
+    assert len(errors) == 1
+    assert isinstance(errors[0], (RuntimeError, Timeout))
+
+
+def test_release_without_hold_raises(lock_file: str) -> None:
+    lock = SoftReadWriteLock(lock_file)
+    try:
+        with pytest.raises(RuntimeError, match="not held"):
+            lock.release()
+    finally:
+        lock.close()
+
+
+def test_release_force_without_hold_is_noop(lock_file: str) -> None:
+    lock = SoftReadWriteLock(lock_file)
+    try:
+        lock.release(force=True)
+    finally:
+        lock.close()
+
+
+def test_release_force_on_reentrant_lock_drops_all(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    try:
+        lock.acquire_read(timeout=2)
+        lock.acquire_read(timeout=2)
+        lock.release(force=True)
+        with lock.write_lock(timeout=2):
+            pass
+    finally:
+        lock.close()
+
+
+def test_close_is_idempotent(lock_file: str) -> None:
+    lock = SoftReadWriteLock(lock_file)
+    lock.close()
+    lock.close()
+
+
+def test_acquire_on_closed_raises(lock_file: str) -> None:
+    lock = SoftReadWriteLock(lock_file)
+    lock.close()
+    with pytest.raises(RuntimeError, match="has been closed"):
+        lock.acquire_read(timeout=1)
+    with pytest.raises(RuntimeError, match="has been closed"):
+        lock.acquire_write(timeout=1)
+
+
+@pytest.mark.timeout(15)
+def test_multiple_readers_can_hold_simultaneously(lock_file: str) -> None:
+    r1, r2, release = Event(), Event(), Event()
+    p1 = Process(target=_worker, args=(lock_file, "read", r1, release))
+    p2 = Process(target=_worker, args=(lock_file, "read", r2, release))
+    with _cleanup([p1, p2]):
+        p1.start()
+        p2.start()
+        assert r1.wait(timeout=5)
+        assert r2.wait(timeout=5)
+        release.set()
+        p1.join(timeout=5)
+        p2.join(timeout=5)
+
+
+@pytest.mark.timeout(15)
+def test_write_lock_excludes_writers(lock_file: str) -> None:
+    held, release = Event(), Event()
+    second = Event()
+    holder = Process(target=_worker, args=(lock_file, "write", held, release))
+    contender = Process(target=_worker, args=(lock_file, "write", second, None, 0.3, True))
+    with _cleanup([holder, contender]):
+        holder.start()
+        assert held.wait(timeout=5)
+        contender.start()
+        assert not second.wait(timeout=0.5)
+        release.set()
+        holder.join(timeout=5)
+        contender.join(timeout=5)
+
+
+@pytest.mark.timeout(15)
+def test_write_lock_excludes_readers(lock_file: str) -> None:
+    held, release = Event(), Event()
+    reader_acquired = Event()
+    writer = Process(target=_worker, args=(lock_file, "write", held, release))
+    reader = Process(target=_worker, args=(lock_file, "read", reader_acquired, None, 0.3, True))
+    with _cleanup([writer, reader]):
+        writer.start()
+        assert held.wait(timeout=5)
+        reader.start()
+        assert not reader_acquired.wait(timeout=0.5)
+        release.set()
+        writer.join(timeout=5)
+        reader.join(timeout=5)
+
+
+@pytest.mark.timeout(20)
+def test_writer_drains_existing_readers(lock_file: str) -> None:
+    r_held, r_release = Event(), Event()
+    w_held = Event()
+    reader = Process(target=_worker, args=(lock_file, "read", r_held, r_release))
+    writer = Process(target=_worker, args=(lock_file, "write", w_held))
+    with _cleanup([reader, writer]):
+        reader.start()
+        assert r_held.wait(timeout=5)
+        writer.start()
+        assert not w_held.wait(timeout=0.5)
+        r_release.set()
+        reader.join(timeout=5)
+        assert w_held.wait(timeout=5)
+        writer.join(timeout=5)
+
+
+@pytest.mark.timeout(20)
+def test_writer_preference_blocks_new_readers(lock_file: str) -> None:
+    r1_held, r1_release = Event(), Event()
+    w_held, w_release = Event(), Event()
+    r2_held = Event()
+    reader1 = Process(target=_worker, args=(lock_file, "read", r1_held, r1_release))
+    writer = Process(target=_worker, args=(lock_file, "write", w_held, w_release))
+    reader2 = Process(target=_worker, args=(lock_file, "read", r2_held, None, 10, True))
+    with _cleanup([reader1, writer, reader2]):
+        reader1.start()
+        assert r1_held.wait(timeout=5)
+        writer.start()
+        time.sleep(0.3)
+        reader2.start()
+        assert not r2_held.wait(timeout=0.5)
+        r1_release.set()
+        assert w_held.wait(timeout=5)
+        assert not r2_held.wait(timeout=0.3)
+        w_release.set()
+        assert r2_held.wait(timeout=5)
+        reader1.join(timeout=5)
+        writer.join(timeout=5)
+        reader2.join(timeout=5)
+
+
+@pytest.mark.timeout(10)
+def test_transaction_lock_timeout_across_threads(lock_file: str) -> None:
+    # Two threads share one lock instance. Thread A grabs the transaction lock while spinning on a peer
+    # writer (phase 1 waits), thread B times out on the transaction lock, hitting the in-process Timeout
+    # path distinct from cross-process contention.
+    peer = SoftReadWriteLock(
+        lock_file,
+        is_singleton=False,
+        heartbeat_interval=0.1,
+        stale_threshold=0.5,
+        poll_interval=0.02,
+    )
+    peer.acquire_write(timeout=2)
+    try:
+        lock = SoftReadWriteLock(
+            lock_file,
+            is_singleton=False,
+            heartbeat_interval=0.1,
+            stale_threshold=0.5,
+            poll_interval=0.02,
+        )
+        try:
+            thread_ready = threading.Event()
+            release_thread = threading.Event()
+
+            def target_a() -> None:
+                thread_ready.set()
+                with suppress(Timeout):
+                    lock.acquire_write(timeout=2)
+                release_thread.wait(timeout=5)
+
+            thread_a = threading.Thread(target=target_a)
+            thread_a.start()
+            try:
+                thread_ready.wait(timeout=2)
+                time.sleep(0.05)
+                with pytest.raises(Timeout):
+                    lock.acquire_write(timeout=0.1)
+            finally:
+                release_thread.set()
+                thread_a.join(timeout=5)
+        finally:
+            lock.close()
+    finally:
+        peer.release()
+        peer.close()
+
+
+@pytest.mark.timeout(10)
+def test_two_readers_in_same_process_share_slot(lock_file: str) -> None:
+    # Multiple threads acquiring a read lock on the same instance; one of them inevitably takes the
+    # inner reentrant branch (lock level observed > 0 after waiting on the transaction lock).
+    lock = SoftReadWriteLock(
+        lock_file,
+        is_singleton=False,
+        heartbeat_interval=0.1,
+        stale_threshold=0.5,
+        poll_interval=0.02,
+    )
+    try:
+        barrier = threading.Barrier(8)
+
+        def target() -> None:
+            barrier.wait(timeout=2)
+            with lock.read_lock(timeout=5):
+                time.sleep(0.05)
+
+        threads = [threading.Thread(target=target) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+    finally:
+        lock.close()
+
+
+@pytest.mark.timeout(10)
+def test_timeout_raises(lock_file: str) -> None:
+    held, release = Event(), Event()
+    holder = Process(target=_worker, args=(lock_file, "write", held, release))
+    with _cleanup([holder]):
+        holder.start()
+        assert held.wait(timeout=5)
+        lock = _make_lock(lock_file)
+        try:
+            with pytest.raises(Timeout):
+                lock.acquire_write(timeout=0.3)
+        finally:
+            lock.close()
+        release.set()
+        holder.join(timeout=5)
+
+
+@pytest.mark.timeout(10)
+def test_non_blocking_writer_contended_raises(lock_file: str) -> None:
+    held, release = Event(), Event()
+    holder = Process(target=_worker, args=(lock_file, "write", held, release))
+    with _cleanup([holder]):
+        holder.start()
+        assert held.wait(timeout=5)
+        lock = _make_lock(lock_file)
+        try:
+            with pytest.raises(Timeout):
+                lock.acquire_write(timeout=1, blocking=False)
+            with pytest.raises(Timeout):
+                lock.acquire_read(timeout=1, blocking=False)
+        finally:
+            lock.close()
+        release.set()
+        holder.join(timeout=5)
+
+
+@pytest.mark.timeout(10)
+def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
+    # A live reader with an always-fresh heartbeat makes phase-2 drain impossible; the writer must
+    # abandon its phase-1 claim so the next writer can try again.
+    reader = _make_lock(lock_file)
+    reader.acquire_read(timeout=2)
+    try:
+        writer = _make_lock(lock_file)
+        try:
+            with pytest.raises(Timeout):
+                writer.acquire_write(timeout=0.3)
+        finally:
+            writer.close()
+        assert not Path(f"{lock_file}.write").exists()
+    finally:
+        reader.release()
+        reader.close()
+
+
+@requires_posix_signals
+@pytest.mark.timeout(20)
+def test_dead_writer_evicted_by_reader(lock_file: str) -> None:
+    import signal
+
+    held = Event()
+    holder = Process(target=_sigkill_worker, args=(lock_file, "write", held, 0.1, 0.5))
+    with _cleanup([holder]):
+        holder.start()
+        assert held.wait(timeout=5)
+        pid = holder.pid
+        assert pid is not None
+        os.kill(pid, getattr(signal, "SIGKILL"))  # noqa: B009 - signal.SIGKILL is POSIX-only
+        holder.join(timeout=5)
+        time.sleep(0.8)
+        lock = _make_lock(lock_file)
+        try:
+            with lock.read_lock(timeout=5):
+                pass
+        finally:
+            lock.close()
+        assert not Path(f"{lock_file}.write").exists()
+
+
+@requires_posix_signals
+@pytest.mark.timeout(20)
+def test_dead_reader_evicted_by_writer(lock_file: str) -> None:
+    import signal
+
+    held = Event()
+    holder = Process(target=_sigkill_worker, args=(lock_file, "read", held, 0.1, 0.5))
+    with _cleanup([holder]):
+        holder.start()
+        assert held.wait(timeout=5)
+        pid = holder.pid
+        assert pid is not None
+        os.kill(pid, getattr(signal, "SIGKILL"))  # noqa: B009 - signal.SIGKILL is POSIX-only
+        holder.join(timeout=5)
+        time.sleep(0.8)
+        lock = _make_lock(lock_file)
+        try:
+            with lock.write_lock(timeout=5):
+                pass
+        finally:
+            lock.close()
+
+
+def test_heartbeat_self_stops_when_marker_vanishes(lock_file: str) -> None:
+    lock = _make_lock(lock_file, heartbeat_interval=0.05, stale_threshold=0.2)
+    lock.acquire_write(timeout=2)
+    try:
+        Path(f"{lock_file}.write").unlink()
+        time.sleep(0.15)  # give the heartbeat at least two ticks to observe and self-stop
+    finally:
+        lock.release(force=True)
+        lock.close()
+    # After the vanishing marker, a peer can acquire immediately because nothing is left to evict.
+    peer = _make_lock(lock_file, heartbeat_interval=0.05, stale_threshold=0.2)
+    try:
+        with peer.write_lock(timeout=1):
+            pass
+    finally:
+        peer.close()
+
+
+def test_heartbeat_self_stops_on_token_replacement(lock_file: str) -> None:
+    lock = _make_lock(lock_file, heartbeat_interval=0.05, stale_threshold=0.2)
+    lock.acquire_write(timeout=2)
+    try:
+        # Replace the marker content with a well-formed marker holding a different token.
+        Path(f"{lock_file}.write").write_bytes(b"0" * 32 + b"\n1\nhost\n")
+        time.sleep(0.15)
+    finally:
+        lock.release(force=True)
+        lock.close()
+
+
+@pytest.mark.timeout(15)
+def test_live_heartbeat_keeps_lock_alive_past_stale_threshold(lock_file: str) -> None:
+    # Generous timing here so the test stays stable on slow Windows runners where the holder's
+    # multiprocessing.spawn startup, the heartbeat thread scheduling, and the parent's mtime resolution
+    # can all introduce sub-second jitter.
+    heartbeat, stale = 0.3, 1.5
+    held, release = Event(), Event()
+    holder = Process(
+        target=_worker,
+        args=(lock_file, "write", held, release, -1, True, heartbeat, stale, 0.05),
+    )
+    with _cleanup([holder]):
+        holder.start()
+        assert held.wait(timeout=5)
+        time.sleep(stale * 2)
+        lock = _make_lock(lock_file, heartbeat_interval=heartbeat, stale_threshold=stale)
+        try:
+            with pytest.raises(Timeout):
+                lock.acquire_write(timeout=0.5)
+        finally:
+            lock.close()
+        release.set()
+        holder.join(timeout=5)
+
+
+def _write_stale_marker(path: str, content: bytes) -> None:
+    Path(path).write_bytes(content)
+    past = time.time() - 1000
+    os.utime(path, (past, past))
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(b"deadbeefdeadbeefdeadbeefdeadbeef\nnotanumber\nhost\n", id="non-numeric-pid"),
+        pytest.param(b"deadbeefdeadbeefdeadbeefdeadbeef\n0\nhost\n", id="zero-pid"),
+        pytest.param(b"deadbeefdeadbeefdeadbeefdeadbeef\n9999999999\nhost\n", id="pid-too-large"),
+        pytest.param(b"bogus\n4711\nhost\n", id="wrong-length-token"),
+        pytest.param(b"ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ\n4711\nhost\n", id="non-hex-token"),
+        pytest.param(b"deadbeefdeadbeefdeadbeefdeadbeef\n4711\nhost with space\n", id="hostname-space"),
+        pytest.param(b"deadbeefdeadbeefdeadbeefdeadbeef\n4711\nhost\n\n\n", id="trailing-blank-lines"),
+        pytest.param(b"only one line\n", id="too-few-lines"),
+        pytest.param(b"a\nb\nc\nd\n", id="too-many-lines"),
+        pytest.param(b"x" * 2048, id="oversized"),
+        pytest.param("ééé\n4711\nhost\n".encode(), id="non-ascii"),
+    ],
+)
+def test_stale_malformed_marker_is_evicted(lock_file: str, content: bytes) -> None:
+    _write_stale_marker(f"{lock_file}.write", content)
+    lock = _make_lock(lock_file)
+    try:
+        with lock.write_lock(timeout=2):
+            pass
+    finally:
+        lock.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW required")
+def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:
+    victim = tmp_path / "victim"
+    victim.write_text("do-not-touch")
+    Path(f"{lock_file}.write").symlink_to(victim)
+    lock = _make_lock(lock_file)
+    try:
+        with pytest.raises((OSError, Timeout)):
+            lock.acquire_write(timeout=0.5)
+    finally:
+        lock.close()
+    assert victim.read_text() == "do-not-touch"
+
+
+def test_symlinked_readers_directory_is_refused(lock_file: str, tmp_path: Path) -> None:
+    victim_dir = tmp_path / "victim_dir"
+    victim_dir.mkdir()
+    Path(f"{lock_file}.readers").symlink_to(victim_dir)
+    lock = _make_lock(lock_file)
+    try:
+        with pytest.raises(RuntimeError, match="not a directory or is a symlink"):
+            lock.acquire_read(timeout=0.5)
+    finally:
+        lock.close()
+    assert list(victim_dir.iterdir()) == []
+
+
+def test_readers_path_as_regular_file_is_refused(lock_file: str) -> None:
+    Path(f"{lock_file}.readers").write_bytes(b"x")
+    lock = _make_lock(lock_file)
+    try:
+        with pytest.raises(RuntimeError, match="not a directory or is a symlink"):
+            lock.acquire_read(timeout=0.5)
+    finally:
+        lock.close()
+
+
+@requires_posix_permissions
+def test_write_marker_is_created_with_0600(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    try:
+        with lock.write_lock(timeout=2):
+            mode = stat.S_IMODE(Path(f"{lock_file}.write").lstat().st_mode)
+            assert mode == 0o600
+    finally:
+        lock.close()
+
+
+@requires_posix_permissions
+def test_readers_directory_is_created_with_0700(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    try:
+        with lock.read_lock(timeout=2):
+            mode = stat.S_IMODE(Path(f"{lock_file}.readers").lstat().st_mode)
+            assert mode == 0o700
+    finally:
+        lock.close()
+
+
+def test_writer_ignores_housekeeping_files_in_readers_dir(lock_file: str) -> None:
+    # Dotfiles and leftover .break.* files from previous aborted evictions must not be mistaken for
+    # live readers by a writer doing its phase-2 drain scan.
+    readers = Path(f"{lock_file}.readers")
+    readers.mkdir(mode=0o700, exist_ok=True)
+    (readers / ".hidden").write_bytes(b"ignored")
+    (readers / "stale.break.12345.abcdef").write_bytes(b"also ignored")
+    lock = _make_lock(lock_file)
+    try:
+        with lock.write_lock(timeout=2):
+            pass
+    finally:
+        lock.close()
+
+
+@requires_posix_permissions
+def test_reader_file_is_created_with_0600(lock_file: str) -> None:
+    lock = _make_lock(lock_file)
+    try:
+        with lock.read_lock(timeout=2):
+            entries = list(Path(f"{lock_file}.readers").iterdir())
+            assert len(entries) == 1
+            mode = stat.S_IMODE(entries[0].lstat().st_mode)
+            assert mode == 0o600
+    finally:
+        lock.close()
+
+
+def _fork_process(target: Callable[..., object], args: tuple[object, ...] = ()) -> mp.process.BaseProcess:
+    if sys.platform == "win32":
+        msg = "fork context is POSIX only"
+        raise RuntimeError(msg)
+    return mp.get_context("fork").Process(target=target, args=args)
+
+
+def _fork_event() -> EventType:
+    if sys.platform == "win32":
+        msg = "fork context is POSIX only"
+        raise RuntimeError(msg)
+    return mp.get_context("fork").Event()
+
+
+def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:
+    lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
+    lock.acquire_write(timeout=5)
+    ok = _fork_event()
+
+    def child_entry() -> None:
+        try:
+            lock.acquire_read(timeout=1)
+        except RuntimeError as exc:
+            if "invalidated by fork" in str(exc):
+                ok.set()
+
+    child = _fork_process(target=child_entry)
+    child.start()
+    child.join(timeout=5)
+    if ok.is_set():
+        result.set()
+    else:
+        failure.set()
+    lock.release()
+    lock.close()
+
+
+def _release_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:
+    lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
+    lock.acquire_read(timeout=5)
+    ok = _fork_event()
+
+    def child_entry() -> None:
+        try:
+            lock.release()
+        except RuntimeError:
+            return
+        ok.set()
+
+    child = _fork_process(target=child_entry)
+    child.start()
+    child.join(timeout=5)
+    if ok.is_set():
+        result.set()
+    else:
+        failure.set()
+    lock.release()
+    lock.close()
+
+
+def _reacquire_fresh_lock_in_child(lock_file: str, child_path: str, result: EventType, failure: EventType) -> None:
+    parent_lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
+    parent_lock.acquire_write(timeout=5)
+    ok = _fork_event()
+
+    def child_entry() -> None:
+        child_lock = SoftReadWriteLock(
+            child_path,
+            is_singleton=False,
+            heartbeat_interval=0.2,
+            stale_threshold=1.0,
+            poll_interval=0.02,
+        )
+        try:
+            with child_lock.read_lock(timeout=2):
+                ok.set()
+        finally:
+            child_lock.close()
+
+    child = _fork_process(target=child_entry)
+    child.start()
+    child.join(timeout=5)
+    if ok.is_set():
+        result.set()
+    else:
+        failure.set()
+    parent_lock.release()
+    parent_lock.close()
+
+
+@requires_fork
+@pytest.mark.timeout(15)
+def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:
+    ctx = mp.get_context("spawn")
+    result, failure = ctx.Event(), ctx.Event()
+    proc = ctx.Process(target=_reuse_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
+    proc.start()
+    proc.join(timeout=10)
+    assert not failure.is_set()
+    assert result.is_set()
+
+
+@requires_fork
+@pytest.mark.timeout(15)
+def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:
+    ctx = mp.get_context("spawn")
+    result, failure = ctx.Event(), ctx.Event()
+    proc = ctx.Process(target=_release_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
+    proc.start()
+    proc.join(timeout=10)
+    assert not failure.is_set()
+    assert result.is_set()
+
+
+@requires_fork
+@pytest.mark.timeout(15)
+def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:
+    ctx = mp.get_context("spawn")
+    result, failure = ctx.Event(), ctx.Event()
+    proc = ctx.Process(
+        target=_reacquire_fresh_lock_in_child,
+        args=(str(tmp_path / "parent.lock"), str(tmp_path / "child.lock"), result, failure),
+    )
+    proc.start()
+    proc.join(timeout=10)
+    assert not failure.is_set()
+    assert result.is_set()
+
+
+@requires_fork
+@pytest.mark.timeout(15)
+def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:
+    path = str(tmp_path / "foo.lock")
+    lock = SoftReadWriteLock(path, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
+    lock.acquire_write(timeout=5)
+    try:
+        child = _fork_process(target=time.sleep, args=(0.05,))
+        child.start()
+        child.join(timeout=5)
+        assert Path(f"{path}.write").exists()
+        peer = SoftReadWriteLock(
+            path,
+            heartbeat_interval=0.2,
+            stale_threshold=1.0,
+            poll_interval=0.02,
+            is_singleton=False,
+        )
+        try:
+            with pytest.raises(Timeout):
+                peer.acquire_write(timeout=0.3)
+        finally:
+            peer.close()
+    finally:
+        lock.release()
+        lock.close()
+    assert not Path(f"{path}.write").exists()


### PR DESCRIPTION
Slurm and other HPC deployments run across multiple compute nodes sharing an NFS mount and need reader/writer locking semantics there. The existing `ReadWriteLock` is SQLite-backed and cannot run on NFS because `sqlite.org` itself warns against POSIX `fcntl` locking on network filesystems. `SoftFileLock` works on NFS but is exclusive-only, and its pid+hostname stale check only evicts crashes on the same host, so a dead writer on `node-42` would wedge readers on every other node until manual cleanup. Closes #526.

`SoftReadWriteLock` fills both gaps. It stores state as sidecar files next to the lock path: a short-held `.state` `SoftFileLock` mutex, a `.write` marker for the exclusive writer, and a `.readers/` directory with one file per active reader. Each marker carries a random 128-bit token plus the holder's pid and hostname; a daemon heartbeat thread refreshes `mtime` every `heartbeat_interval` seconds (default 30), and any process on any host may evict a marker whose `mtime` has not advanced in `stale_threshold` seconds (default 90, the etcd `LeaseKeepAlive` ratio of TTL/3). 🩺 Eviction uses an atomic read → rename-to-unique-break-name → re-verify → unlink pattern borrowed from `SoftFileLock._try_break_stale_lock`, so a heartbeat firing mid-break cannot double-own the lock. Writer acquisition is two-phase and writer-preferring: phase one atomically claims `.write` (which immediately blocks new readers), phase two waits for existing readers to drain. A 99/1 reader-heavy workload cannot starve a writer.

Every marker open uses `O_CREAT | O_EXCL | O_NOFOLLOW` with mode `0o600` to block the symlink-overwrite attack where an attacker pre-creates the marker as a symlink to a victim file. 🔒 The readers directory gets `0o700` plus an `lstat` check and a dirfd-relative open, because `mkdir` has no `O_NOFOLLOW` equivalent; every subsequent reader-file operation flows through the dirfd. The marker parser is bounded (1 KiB cap, regex-validated token, bounded pid, ASCII hostname) so attacker-controlled content cannot crash the library or mis-authenticate as a live holder. The class runs the same three trust-boundary classes `SoftFileLock` already handles (same-UID non-cooperating processes, cross-host same-UID, same-host different-UID via permissions) and does not claim protection against root compromise, NTP tampering, or multi-tenant mounts where hostile co-tenants share the UID.

Fork safety was the last hazard worth calling out. Python threads do not survive `fork()`, so a child would inherit the marker files and the lock-level state without the heartbeat thread; the parent would keep refreshing while the child would not, and both processes would believe they hold the lock. 🍴 `os.register_at_fork(after_in_child=...)` replaces the inherited `threading.Lock` objects with fresh ones and marks the instance fork-invalidated, so `release()` on an inherited `with` block is a silent no-op and the child must call `SoftReadWriteLock(path)` again before acquiring. This matches PyMongo's connection-pool semantics and is documented in the concepts page alongside the heartbeat/TTL explanation.

For reviewers: the docs touch all four Diátaxis dimensions (tutorials, how-to, concepts, autodoc-driven API reference) plus a new card in the lock-types grid on `docs/index.rst`. The changelog file is intentionally not edited — the release workflow regenerates it from PR titles at tag time.

Context and design discussion lives in the issue thread: https://github.com/tox-dev/filelock/issues/526