### PR TITLE
🐛 fix(ci): unbreak release workflow, publish to PyPI again

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -74,7 +74,7 @@ jobs:
         shell: python
       - name: "📦 Upload coverage data"
         if: ${{ !startsWith(matrix.py, 'pypy')}}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           include-hidden-files: true
           name: .coverage.${{ matrix.os }}.${{ matrix.py }}
@@ -113,7 +113,7 @@ jobs:
         env:
           UV_PYTHON_PREFERENCE: only-managed
       - name: "📤 Upload HTML report"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: html-report
           path: .tox/htmlcov

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
       - name: 🏷️ Create temporary tag for hatch-vcs
         if: github.event.inputs.release != 'no' && github.event.inputs.release != null
-        run: git tag '${STEPS_V_OUTPUTS_VERSION}'
+        run: git tag "$STEPS_V_OUTPUTS_VERSION"
         env:
           STEPS_V_OUTPUTS_VERSION: ${{ steps.v.outputs.version }}
       - name: 📦 Build package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: 📦 Build package
         run: uv build --python 3.14 --python-preference only-managed --sdist --wheel . --out-dir dist
       - name: 📤 Store the distribution packages
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ env.dists-artifact-name }}
           path: dist/*


### PR DESCRIPTION
Releases have been silently broken on PyPI since 3.26.0. Every dispatch of the release workflow since then produced a ``filelock-X.Y.Z.devN+g<sha>-py3-none-any.whl``, which PyPI rejects with ``400 Bad Request`` because local version identifiers are not allowed on the public index. 🐛 PyPI still shows 3.25.2 as the latest version while GitHub has tags and releases for 3.26.0, 3.26.1, and 3.27.0. Anyone running ``pip install filelock`` is stuck on the last working release.

Commit 8cd6bd9 (``🔒 ci(workflows): add zizmor security auditing #517``) moved the release version from a GitHub Actions template expression into a bash environment variable to harden against template injection. The move was correct, but kept the existing single quotes around the reference: ``git tag '${STEPS_V_OUTPUTS_VERSION}'``. In bash, single quotes suppress variable expansion, so ``git tag`` received the literal 28-character string ``${STEPS_V_OUTPUTS_VERSION}`` as the tag name. hatch-vcs then could not find a real version on ``HEAD``, ``uv build`` fell back to the ``.devN+g<sha>`` scheme, and PyPI rejected the upload. Double quotes preserve the env-var indirection zizmor wanted while letting bash actually read the value, so the correct version gets tagged and the wheel is built with the clean ``filelock-X.Y.Z-py3-none-any.whl`` name PyPI expects.

Why this slipped past CI: the tag-creation step is gated behind ``if: github.event.inputs.release != 'no'``, so regular push and pull-request events skip it entirely. The broken line only runs under manual workflow-dispatch, and even then the failure surfaces in the ``release`` job's PyPI-publish step, which no PR-level check watches. The last two successful CI builds of the release workflow were the ones that actually broke publishing.

The second commit aligns the ``actions/upload-artifact`` version comments with the exact tag the pinned hash resolves to (``v7.0.0`` instead of ``v7``). 🔒 Zizmor flags the mismatch as ``ref-version-mismatch`` because the moving major tag ``v7`` currently points to a different commit, and pre-commit would otherwise block this branch on its own audit. The pinned hash does not change, so there is no behavioral impact.

After merge, re-dispatch the release workflow with a ``patch`` bump (or whatever bump type makes sense) to get the currently-unpublished work onto PyPI.