### PR TITLE
🐛 fix(async): use single-thread executor for lock consistency

### DIFF
--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -65,7 +66,8 @@ class AsyncReadWriteLock:
     ) -> None:
         self._lock = ReadWriteLock(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
         self._loop = loop
-        self._executor = executor
+        self._owns_executor = executor is None
+        self._executor = executor or ThreadPoolExecutor(max_workers=1)
 
     @property
     def lock_file(self) -> str:
@@ -195,6 +197,8 @@ class AsyncReadWriteLock:
 
         """
         await self._run(self._lock.close)
+        if self._owns_executor:
+            self._executor.shutdown(wait=False)
 
 
 __all__ = [


### PR DESCRIPTION
`AsyncReadWriteLock` dispatches each operation to the event loop's default executor via `run_in_executor`. The default executor is a multi-threaded pool, so consecutive `acquire_write()` calls can land on different threads. When the second call hits the reentrant path in `_validate_reentrant`, it compares `threading.get_ident()` against the stored `_write_thread_id` from the first call and raises `RuntimeError` if they differ. This is a race condition that surfaces intermittently in CI. 🐛

The fix creates a dedicated `ThreadPoolExecutor(max_workers=1)` when no executor is provided. This guarantees all lock operations run on the same thread, making the thread identity check deterministic. A single-threaded executor is the correct semantic choice here anyway since all operations go through the same SQLite connection. ✨ Users who provide their own executor retain full control.

The internally-created executor is shut down in `close()` to avoid thread leaks. User-provided executors are left alone.