### PR TITLE
✨ feat(soft): enable stale lock detection on Windows

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -113,8 +113,8 @@ This is the same concept as a traditional **PID lock file** (as used by Unix dae
 library's ``PIDLockFile``). The PID stored in the file enables two important capabilities: identifying the lock holder
 via the :attr:`~filelock.SoftFileLock.pid` property, and detecting stale locks when the holding process has died.
 
-On Unix/macOS, processes can check if the lock holder is still alive and break stale locks automatically. On Windows,
-stale lock breaking is skipped because the lock file cannot be atomically renamed while another process holds a handle.
+On all platforms, processes can check if the lock holder is still alive and break stale locks automatically. On Windows,
+the lock file additionally stores the process creation time to guard against PID recycling.
 
 .. list-table::
     :header-rows: 1
@@ -124,13 +124,9 @@ stale lock breaking is skipped because the lock file cannot be atomically rename
     - - ✓ Works on any filesystem, including network mounts.
       - ✗ Not enforced—requires cooperation (a buggy process can ignore it).
     - - ✓ Portable—same code works everywhere.
-      - ✗ Stale lock detection not available on Windows.
-    - - ✓ Can detect stale locks (Unix/macOS only).
       - ✗ Higher overhead than OS-level locks.
-    - -
+    - - ✓ Can detect stale locks (all platforms).
       - ✗ Cross-host detection doesn't work (stale locks from other hosts require manual cleanup).
-    - -
-      - ✗ On Windows, stale lock detection is skipped (file rename is not atomic while handle is open).
 
 ***************************
  Platform-specific details
@@ -160,8 +156,8 @@ stale lock breaking is skipped because the lock file cannot be atomically rename
 
 **Other platforms without fcntl**
     Falls back to :class:`SoftFileLock <filelock.SoftFileLock>` and emits a warning. The lock is not enforced by the OS,
-    but filelock includes stale lock detection on Unix-like systems (though without fcntl, this detection is less
-    reliable than on systems with full fcntl support).
+    but filelock includes stale lock detection (though without fcntl, this detection is less reliable than on systems
+    with full fcntl support).
 
 *******************************
  Which lock type should I use?
@@ -185,7 +181,7 @@ necessary in testing or if you need platform-specific behavior.
 
 - You're on a network filesystem where OS-level locking is unavailable (NFS).
 - You need cross-filesystem compatibility and can tolerate the overhead.
-- You need stale lock detection (Unix/macOS only).
+- You need stale lock detection.
 
 **Use ReadWriteLock** when:
 
@@ -252,7 +248,7 @@ Lock types compared
       - Works, including cross-host on multi-node clusters
     - - Stale lock detection
       - N/A (OS-enforced)
-      - Yes (Unix/macOS only, same-host)
+      - Yes (same-host, all platforms)
       - N/A
       - Yes, TTL-based heartbeat (cross-host)
     - - PID inspection
@@ -385,15 +381,16 @@ Why does SoftFileLock use a separate file instead of just checking a directory?
 A directory can't reliably be atomically created and deleted across platforms. A file can be created with ``O_EXCL``
 (atomic, all-or-nothing) to detect conflicts. This is why SoftFileLock uses files.
 
-Why is stale lock detection only on Unix/macOS?
-===============================================
+How does stale lock detection work across platforms?
+====================================================
 
 Stale lock detection requires: 1. Knowing the PID of the lock holder 2. A way to check if that process is still alive
 3. A way to atomically break the stale lock without corruption.
 
 On Unix/macOS, ``kill(pid, 0)`` checks process liveness and ``rename()`` atomically replaces the lock file. On Windows,
-process liveness can be checked via ``OpenProcess``, but the lock file cannot be atomically renamed while another process
-holds a handle to it. So stale detection is skipped on Windows to avoid corruption.
+``OpenProcess`` checks liveness and the lock file additionally stores the process creation time (via
+``GetProcessTimes``) to guard against PID recycling. If the PID is alive but the creation time doesn't match what was
+stored, the lock is recognized as stale from a recycled PID and evicted.
 
 Why is ReadWriteLock backed by SQLite?
 ======================================

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -420,8 +420,8 @@ For network filesystems, use :class:`AsyncSoftReadWriteLock <filelock.AsyncSoftR
  Detect stale locks (soft locks only)
 **************************************
 
-:class:`SoftFileLock <filelock.SoftFileLock>` stores the PID and hostname of the lock holder. On Unix and macOS, it can
-detect when the holding process has died and automatically break stale locks.
+:class:`SoftFileLock <filelock.SoftFileLock>` stores the PID and hostname of the lock holder. It can detect when the
+holding process has died and automatically break stale locks on all platforms.
 
 This happens automatically—you don't need to do anything special:
 
@@ -436,11 +436,10 @@ This happens automatically—you don't need to do anything special:
         # another process will automatically clean up the stale lock
         pass
 
-Stale lock detection only works on Unix/macOS and only detects locks from the same host. Cross-host stale locks still
-require manual removal.
+Stale lock detection only detects locks from the same host. Cross-host stale locks still require manual removal.
 
-On Windows, stale lock detection is skipped because the lock file cannot be atomically renamed while another process
-holds a handle to it.
+On Windows, the lock file additionally stores the process creation time to guard against PID recycling. Malformed lock
+files (empty or corrupted) are evicted automatically after a brief safety window.
 
 *****************************************
  Inspect and manage PID locks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,7 +77,7 @@ Choose the right lock for your use case:
         File-existence based locking. Works on any filesystem including network mounts.
 
         - ✓ Network filesystems
-        - ✓ Stale detection (Unix)
+        - ✓ Stale detection
         - ✓ Lifetime expiration, cancellable acquire
 
     .. grid-item-card::

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -211,7 +211,7 @@ Key differences from ``PIDLockFile``:
 - ``read_pid()`` is now a property: ``lock.pid``
 - ``is_lock_held_by_us()`` is now a property: ``lock.is_lock_held_by_us``
 - ``break_lock()`` is now ``lock.break_lock()`` (same name)
-- Stale lock detection happens automatically on acquire (Unix/macOS only)
+- Stale lock detection happens automatically on acquire (all platforms)
 - Supports context managers, reentrant locking, timeouts, and all other filelock features
 
 *************************************

--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -65,7 +66,8 @@ class AsyncReadWriteLock:
     ) -> None:
         self._lock = ReadWriteLock(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
         self._loop = loop
-        self._executor = executor
+        self._owns_executor = executor is None
+        self._executor = executor or ThreadPoolExecutor(max_workers=1)
 
     @property
     def lock_file(self) -> str:
@@ -195,6 +197,8 @@ class AsyncReadWriteLock:
 
         """
         await self._run(self._lock.close)
+        if self._owns_executor:
+            self._executor.shutdown(wait=False)
 
 
 __all__ = [

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -13,6 +13,8 @@ from ._util import ensure_directory_exists, raise_on_not_writable_file
 
 _WIN_SYNCHRONIZE = 0x100000
 _WIN_ERROR_INVALID_PARAMETER = 87
+_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_MALFORMED_LOCK_AGE_THRESHOLD = 2.0
 
 
 class SoftFileLock(BaseFileLock):
@@ -47,27 +49,48 @@ class SoftFileLock(BaseFileLock):
                 exception.errno == EEXIST or (exception.errno == EACCES and sys.platform == "win32")
             ):  # pragma: win32 no cover
                 raise
-            if exception.errno == EEXIST and sys.platform != "win32":  # pragma: win32 no cover
-                self._try_break_stale_lock()
+            self._try_break_stale_lock()
         else:
             self._write_lock_info(file_handler)
             self._context.lock_file_fd = file_handler
 
     def _try_break_stale_lock(self) -> None:
         with suppress(OSError, ValueError):
-            content = Path(self.lock_file).read_text(encoding="utf-8")
+            lock_path = Path(self.lock_file)
+            stat_result = lock_path.stat()
+            content = lock_path.read_text(encoding="utf-8")
             lines = content.strip().splitlines()
-            if len(lines) != 2:  # noqa: PLR2004
+
+            if len(lines) not in {2, 3}:
+                if time.time() - stat_result.st_mtime >= _MALFORMED_LOCK_AGE_THRESHOLD:
+                    self._evict_lock_file()
                 return
-            pid_str, hostname = lines
+
+            pid_str, hostname = lines[0], lines[1]
+            creation_time_str = lines[2] if len(lines) == 3 else None  # noqa: PLR2004
+
             if hostname != socket.gethostname():
                 return
+
             pid = int(pid_str)
+
             if self._is_process_alive(pid):
-                return
-            break_path = f"{self.lock_file}.break.{os.getpid()}"
-            Path(self.lock_file).rename(break_path)
-            Path(break_path).unlink()
+                if sys.platform == "win32" and creation_time_str is not None:  # pragma: win32 cover
+                    stored = int(creation_time_str)
+                    actual = self._get_process_creation_time(pid)
+                    if actual is not None and actual != stored:
+                        pass  # PID recycled, fall through to evict
+                    else:
+                        return  # same process or can't verify — don't evict
+                else:
+                    return
+
+            self._evict_lock_file()
+
+    def _evict_lock_file(self) -> None:
+        break_path = f"{self.lock_file}.break.{os.getpid()}"
+        Path(self.lock_file).rename(break_path)
+        Path(break_path).unlink()
 
     @staticmethod
     def _is_process_alive(pid: int) -> bool:
@@ -91,9 +114,41 @@ class SoftFileLock(BaseFileLock):
         return True
 
     @staticmethod
+    def _get_process_creation_time(pid: int) -> int | None:
+        """Return the process creation FILETIME as an integer on Windows, ``None`` otherwise."""
+        if sys.platform != "win32":  # pragma: win32 no cover
+            return None
+        import ctypes  # pragma: win32 cover  # noqa: PLC0415
+        from ctypes import wintypes  # noqa: PLC0415
+
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(_WIN_PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
+        if not handle:
+            return None
+        try:
+            creation = wintypes.FILETIME()
+            exit_time = wintypes.FILETIME()
+            kernel_time = wintypes.FILETIME()
+            user_time = wintypes.FILETIME()
+            if not kernel32.GetProcessTimes(
+                handle,
+                ctypes.byref(creation),
+                ctypes.byref(exit_time),
+                ctypes.byref(kernel_time),
+                ctypes.byref(user_time),
+            ):
+                return None
+        finally:
+            kernel32.CloseHandle(handle)
+        return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
+
+    @staticmethod
     def _write_lock_info(fd: int) -> None:
         with suppress(OSError):
-            os.write(fd, f"{os.getpid()}\n{socket.gethostname()}\n".encode())
+            info = f"{os.getpid()}\n{socket.gethostname()}\n"
+            if sys.platform == "win32" and (ct := SoftFileLock._get_process_creation_time(os.getpid())) is not None:
+                info += f"{ct}\n"
+            os.write(fd, info.encode())
 
     @property
     def pid(self) -> int | None:

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import socket
 import time
 from typing import TYPE_CHECKING
 
@@ -27,7 +28,7 @@ def test_expired_lock_is_broken(lock_type: type[FileLock | SoftFileLock], tmp_pa
 
 def test_soft_non_expired_lock_not_broken(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
-    lock_path.touch()
+    lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
 
     lock = SoftFileLock(lock_path, lifetime=9999, timeout=0.2)
     with pytest.raises(TimeoutError):
@@ -36,7 +37,7 @@ def test_soft_non_expired_lock_not_broken(tmp_path: Path) -> None:
 
 def test_soft_lifetime_none_no_expiry(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
-    lock_path.touch()
+    lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
     os.utime(lock_path, (0, 0))
 
     lock = SoftFileLock(lock_path, lifetime=None, timeout=0.2)

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import socket
 import sys
-from errno import ENODEV, EPERM, ESRCH
+from errno import ENODEV, EPERM
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 unix_only = pytest.mark.skipif(sys.platform == "win32", reason="unix-only stale lock detection")
+win_only = pytest.mark.skipif(sys.platform != "win32", reason="windows-only")
 
 
 def test_lock_writes_pid_and_hostname(tmp_path: Path) -> None:
@@ -24,33 +25,39 @@ def test_lock_writes_pid_and_hostname(tmp_path: Path) -> None:
     lock = SoftFileLock(lock_path)
     with lock:
         content = lock_path.read_text(encoding="utf-8")
-        assert content == f"{os.getpid()}\n{socket.gethostname()}\n"
+        lines = content.strip().splitlines()
+        assert lines[0] == str(os.getpid())
+        assert lines[1] == socket.gethostname()
+        if sys.platform == "win32":
+            assert len(lines) == 3
+            int(lines[2])  # must be parseable as int (creation FILETIME)
+        else:
+            assert len(lines) == 2
 
 
-@unix_only
 def test_stale_lock_broken_when_process_dead(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     dead_pid = 2**22 + 1
     lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n", encoding="utf-8")
 
-    mocker.patch("filelock._soft.os.kill", side_effect=OSError(ESRCH, "No such process"))
+    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=False)
 
     lock = SoftFileLock(lock_path, timeout=1)
     with lock:
         assert lock.is_locked
 
 
-@unix_only
-def test_stale_lock_not_broken_when_process_alive(tmp_path: Path) -> None:
+def test_stale_lock_not_broken_when_process_alive(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
+
+    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
 
     lock = SoftFileLock(lock_path, timeout=0.1)
     with pytest.raises(TimeoutError):
         lock.acquire()
 
 
-@unix_only
 def test_stale_lock_not_broken_different_hostname(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     dead_pid = 2**22 + 1
@@ -73,18 +80,17 @@ def test_stale_lock_not_broken_when_eperm(tmp_path: Path, mocker: MockerFixture)
         lock.acquire()
 
 
-@unix_only
-def test_stale_lock_empty_file_ignored(tmp_path: Path) -> None:
+def test_stale_lock_malformed_evicted_when_old(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
-    lock_path.write_text("", encoding="utf-8")
+    lock_path.write_text("not-a-pid\n", encoding="utf-8")
+    os.utime(lock_path, (0, 0))
 
-    lock = SoftFileLock(lock_path, timeout=0.1)
-    with pytest.raises(TimeoutError):
-        lock.acquire()
+    lock = SoftFileLock(lock_path, timeout=1)
+    with lock:
+        assert lock.is_locked
 
 
-@unix_only
-def test_stale_lock_malformed_content_ignored(tmp_path: Path) -> None:
+def test_stale_lock_malformed_not_evicted_when_fresh(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text("not-a-pid\n", encoding="utf-8")
 
@@ -93,13 +99,31 @@ def test_stale_lock_malformed_content_ignored(tmp_path: Path) -> None:
         lock.acquire()
 
 
-@unix_only
+def test_stale_lock_empty_file_evicted_when_old(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.write_text("", encoding="utf-8")
+    os.utime(lock_path, (0, 0))
+
+    lock = SoftFileLock(lock_path, timeout=1)
+    with lock:
+        assert lock.is_locked
+
+
+def test_stale_lock_empty_file_not_evicted_when_fresh(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock_path.write_text("", encoding="utf-8")
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
 def test_stale_lock_rename_race(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     dead_pid = 2**22 + 1
     lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n", encoding="utf-8")
 
-    mocker.patch("filelock._soft.os.kill", side_effect=OSError(ESRCH, "No such process"))
+    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=False)
     mocker.patch.object(Path, "rename", side_effect=FileNotFoundError("already gone"))
 
     lock = SoftFileLock(lock_path, timeout=0.1)
@@ -119,7 +143,6 @@ def test_stale_lock_unexpected_kill_error_suppressed(tmp_path: Path, mocker: Moc
         lock.acquire()
 
 
-@unix_only
 def test_stale_detection_errors_suppressed(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
@@ -130,6 +153,89 @@ def test_stale_detection_errors_suppressed(tmp_path: Path, mocker: MockerFixture
     with pytest.raises(TimeoutError):
         lock.acquire()
     mock_read.assert_called()
+
+
+def test_stale_lock_three_line_format_accepted(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    dead_pid = 2**22 + 1
+    lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n123456789\n", encoding="utf-8")
+
+    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=False)
+
+    lock = SoftFileLock(lock_path, timeout=1)
+    with lock:
+        assert lock.is_locked
+
+
+@win_only
+def test_windows_stale_lock_broken_when_pid_recycled(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    recycled_pid = 1234
+    original_creation_time = 100000000
+    new_creation_time = 999999999
+
+    lock_path.write_text(
+        f"{recycled_pid}\n{socket.gethostname()}\n{original_creation_time}\n",
+        encoding="utf-8",
+    )
+
+    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
+    mocker.patch.object(SoftFileLock, "_get_process_creation_time", return_value=new_creation_time)
+
+    lock = SoftFileLock(lock_path, timeout=1)
+    with lock:
+        assert lock.is_locked
+
+
+@win_only
+def test_windows_stale_lock_not_broken_same_creation_time(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    alive_pid = 1234
+    creation_time = 100000000
+
+    lock_path.write_text(
+        f"{alive_pid}\n{socket.gethostname()}\n{creation_time}\n",
+        encoding="utf-8",
+    )
+
+    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
+    mocker.patch.object(SoftFileLock, "_get_process_creation_time", return_value=creation_time)
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+@win_only
+def test_windows_stale_lock_conservative_without_creation_time(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "test.lock"
+    alive_pid = 1234
+    lock_path.write_text(f"{alive_pid}\n{socket.gethostname()}\n", encoding="utf-8")
+
+    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
+
+    lock = SoftFileLock(lock_path, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+
+
+@win_only
+def test_get_process_creation_time_returns_int_on_windows() -> None:
+    result = SoftFileLock._get_process_creation_time(os.getpid())
+    assert result is not None
+    assert isinstance(result, int)
+    assert result > 0
+
+
+@win_only
+def test_get_process_creation_time_returns_none_for_dead_pid() -> None:
+    result = SoftFileLock._get_process_creation_time(2**22 + 1)
+    assert result is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="unix-only")
+def test_get_process_creation_time_returns_none_on_unix() -> None:
+    assert SoftFileLock._get_process_creation_time(os.getpid()) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`SoftFileLock` disabled stale lock detection on Windows because Windows recycles PIDs aggressively. A crashed process could leave a lock file behind, and a new unrelated process inheriting the same PID would fool `OpenProcess` into thinking the lock was still held. This caused permanent deadlocks after crashes on Windows (#531).

Separately, malformed lock files (empty, partial, corrupted) were silently ignored by `_try_break_stale_lock`, also causing permanent deadlocks on all platforms (#532). `SoftReadWriteLock` already handled this correctly by evicting unparseable markers.

🔐 On Windows, the lock file now stores the process creation FILETIME (via `kernel32.GetProcessTimes`) as a third line. On contention, if the PID is alive but its creation time differs from the stored value, the lock is recognized as stale from a recycled PID and evicted. Both the old 2-line format and the new 3-line format are accepted when reading, so mixed-version deployments degrade gracefully (old processes stay conservative and never evict new-format files).

Malformed lock files are now evicted when their `mtime` exceeds 2 seconds. ✨ The gap between `os.open` (file creation) and `os.write` (content write) is nanoseconds, so any malformed file older than 2 seconds is definitively from a crashed process. Fresh malformed files are preserved to avoid racing a holder whose `_write_lock_info` silently failed.