### PR TITLE
docs: fix API docs of `release()`

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -527,7 +527,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
         """
         Release the file lock. The lock is only completely released when the lock counter reaches 0. The lock file
-        itself is not automatically deleted.
+        itself may be deleted automatically, the behavior is platform-specific.
 
         :param force: If true, the lock counter is ignored and the lock is released in every case.
 

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -283,7 +283,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     async def release(self, force: bool = False) -> None:  # ty: ignore[invalid-method-override]  # noqa: FBT001, FBT002
         """
         Release the file lock. The lock is only completely released when the lock counter reaches 0. The lock file
-        itself is not automatically deleted.
+        itself may be deleted automatically, the behavior is platform-specific.
 
         :param force: If true, the lock counter is ignored and the lock is released in every case.
 


### PR DESCRIPTION
A tiny follow-up for #408.