### PR TITLE
docs: clarify per-thread scope of FileLock configuration

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -477,14 +477,24 @@ overrides any default ACLs on the directory.
  Thread-local vs shared state
 *****************************
 
-Each ``FileLock`` instance tracks its lock counter and file descriptor in a context object. By default
-(``thread_local=True``), each thread gets its own context via ``threading.local``. This means:
+Each ``FileLock`` instance tracks its lock counter, file descriptor, and
+configured defaults (``poll_interval``, ``timeout``, ``blocking``, ``mode``,
+``lifetime``) in a single context object. By default (``thread_local=True``),
+each thread gets its own context via ``threading.local``. This means:
 
-- Two threads holding the same ``FileLock`` object each maintain independent lock counters.
+- Two threads holding the same ``FileLock`` object each maintain
+  independent lock counters.
 - Thread A releasing the lock doesn't affect Thread B's counter.
+- Setting a configuration property (for example ``lock.poll_interval = 0.5``)
+  affects only the thread that performed the write. Other threads continue
+  to see the value supplied to the lock's constructor; ``threading.local``
+  re-applies the original constructor arguments the first time each new
+  thread accesses the context.
 
-When ``thread_local=False``, all threads share the same context. This is useful for objects passed between threads, but
-requires external coordination to avoid counter mismatches.
+When ``thread_local=False``, all threads share the same context, including
+configuration values. This is useful for objects passed between threads or
+for cases where you want a property setter to affect all threads, but it
+requires external coordination to avoid lock-counter mismatches.
 
 Async locks default to ``thread_local=False`` because the thread that calls ``acquire()`` (via
 ``run_in_executor``) may differ from the thread that calls ``release()``. Using ``thread_local=True`` with

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -218,7 +218,12 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         :param mode: file permissions for the lockfile. When not specified, the OS controls permissions via umask and
             default ACLs, preserving POSIX default ACL inheritance in shared directories.
         :param thread_local: Whether this object's internal context should be thread local or not. If this is set to
-            ``False`` then the lock will be reentrant across threads.
+            ``False`` then the lock will be reentrant across threads. When ``True`` (the default), **all fields of the
+            lock's internal context are per-thread**, including the configuration values ``poll_interval``, ``timeout``,
+            ``blocking``, ``mode``, and ``lifetime``. Setting one of these properties from one thread does not change
+            the value seen by another thread; threads that did not perform the write continue to see the value supplied
+            at construction time. If you need configuration values to be visible across threads, construct the lock
+            with ``thread_local=False``.
         :param blocking: whether the lock should be blocking or not
         :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per lock
             file. This is useful if you want to use the lock object for reentrant locking without needing to pass the

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -139,7 +139,12 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         :param mode: file permissions for the lockfile. When not specified, the OS controls permissions via umask and
             default ACLs, preserving POSIX default ACL inheritance in shared directories.
         :param thread_local: Whether this object's internal context should be thread local or not. If this is set to
-            ``False`` then the lock will be reentrant across threads.
+            ``False`` then the lock will be reentrant across threads. When ``True`` (the default), **all fields of the
+            lock's internal context are per-thread**, including the configuration values ``poll_interval``, ``timeout``,
+            ``blocking``, ``mode``, and ``lifetime``. Setting one of these properties from one thread does not change
+            the value seen by another thread; threads that did not perform the write continue to see the value supplied
+            at construction time. If you need configuration values to be visible across threads, construct the lock
+            with ``thread_local=False``.
         :param blocking: whether the lock should be blocking or not
         :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per lock
             file. This is useful if you want to use the lock object for reentrant locking without needing to pass the

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -739,6 +739,46 @@ def test_lock_can_be_non_thread_local(
     lock.release(force=True)
 
 
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_thread_local_setter_visibility(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    """Document that property setters are per-thread when thread_local=True.
+
+    Setting ``poll_interval`` on the constructing thread must not affect the
+    value observed from a different thread. The other thread sees the value
+    supplied to the constructor (``threading.local`` re-applies the original
+    constructor arguments the first time each new thread accesses the
+    context).
+    """
+    lock = lock_type(tmp_path / "x.lock", thread_local=True, poll_interval=0.05)
+    lock.poll_interval = 0.5
+
+    observed: list[float] = []
+
+    def read_from_thread() -> None:
+        observed.append(lock.poll_interval)
+
+    t = threading.Thread(target=read_from_thread)
+    t.start()
+    t.join()
+
+    # setter is local to the writing thread; reader sees the constructor default
+    assert observed == [pytest.approx(0.05)]
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_non_thread_local_setter_visibility(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    """With thread_local=False, property setters are visible across threads."""
+    lock = lock_type(tmp_path / "x.lock", thread_local=False, poll_interval=0.05)
+    lock.poll_interval = 0.5
+
+    observed: list[float] = []
+    t = threading.Thread(target=lambda: observed.append(lock.poll_interval))
+    t.start()
+    t.join()
+
+    assert observed == [pytest.approx(0.5)]
+
+
 def test_subclass_compatibility(tmp_path: Path) -> None:
     class MyFileLock(FileLock):
         def __init__(


### PR DESCRIPTION
Clarifies that when `thread_local=True` (the default for sync `FileLock`/ `SoftFileLock`), every field of the internal `FileLockContext` lives on `threading.local`, including the configuration values `poll_interval`, `timeout`, `blocking`, `mode`, and `lifetime` — not only the lock counter and file descriptor that the existing docs name.

Updates:

- `BaseFileLock.__init__` and `BaseAsyncFileLock.__init__` docstrings.
- `docs/concepts.rst` "Thread-local vs shared state" section.
- Two behaviour-pinning tests in `tests/test_filelock.py` covering  setter visibility under both `thread_local=True` and `thread_local=False`.

No behaviour change; documentation and tests only.

## Test plan

- [x] `tox run` / `pytest tests/` passes locally (440 passed, 25 skipped on Python 3.12 / Linux).
- [x] `pre-commit run --all-files` passes.
- [x] New tests `test_thread_local_setter_visibility` and `test_non_thread_local_setter_visibility` pass for both `FileLock` and `SoftFileLock`. 