### PR TITLE
open marker reads non-blocking to refuse attacker-placed fifo

### DIFF
--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -697,8 +697,9 @@ def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -
 
 def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo | None, float] | None:
     # O_NOFOLLOW is defense in depth: we already created this file, but a hostile replacement by symlink
-    # between create and read would be caught here.
-    flags = os.O_RDONLY | _O_NOFOLLOW
+    # between create and read would be caught here. O_NONBLOCK stops an attacker-placed FIFO at the marker
+    # path from stalling the open indefinitely (O_NOFOLLOW alone rejects a symlink, not a real FIFO).
+    flags = os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
     try:
         fd = os.open(name, flags, dir_fd=dir_fd) if _SUPPORTS_DIR_FD and dir_fd is not None else os.open(name, flags)
     except OSError:

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -32,6 +32,7 @@ _Mode = Literal["read", "write"]
 _BREAK_SUFFIX = ".break"
 _MAX_MARKER_SIZE = 1024
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_O_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
 # dirfd-relative I/O is a Unix-only optimization; Windows cannot ``os.open()`` a directory at all, and
 # its ``os`` module skips dir_fd support entirely. When disabled, callers fall back to full-path ops.
 _SUPPORTS_DIR_FD = sys.platform != "win32" and os.open in os.supports_dir_fd
@@ -696,10 +697,10 @@ def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -
 
 
 def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo | None, float] | None:
-    # O_NOFOLLOW is defense in depth: we already created this file, but a hostile replacement by symlink
-    # between create and read would be caught here. O_NONBLOCK stops an attacker-placed FIFO at the marker
-    # path from stalling the open indefinitely (O_NOFOLLOW alone rejects a symlink, not a real FIFO).
-    flags = os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
+    # The file is ours; these guard a hostile mid-flight swap. O_NOFOLLOW rejects a symlink; O_NONBLOCK keeps
+    # a real FIFO from blocking the open forever, so it reads as a malformed marker instead of wedging a peer
+    # that holds the state lock.
+    flags = os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK
     try:
         fd = os.open(name, flags, dir_fd=dir_fd) if _SUPPORTS_DIR_FD and dir_fd is not None else os.open(name, flags)
     except OSError:
@@ -708,7 +709,7 @@ def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo |
         try:
             st = os.fstat(fd)
             data = os.read(fd, _MAX_MARKER_SIZE + 1)
-        except OSError:  # pragma: no cover - fstat/read after a successful open is hard to provoke
+        except OSError:  # pragma: no cover - e.g. EAGAIN from a hostile FIFO that has a writer attached
             return None
     finally:
         os.close(fd)

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -664,6 +664,22 @@ def test_stale_malformed_marker_is_evicted(lock_file: str, content: bytes) -> No
         lock.close()
 
 
+def test_fifo_write_marker_does_not_block(lock_file: str) -> None:
+    if sys.platform == "win32":
+        pytest.skip("os.mkfifo is unix-only")
+    marker = f"{lock_file}.write"
+    os.mkfifo(marker)
+    past = time.time() - 1000
+    os.utime(marker, (past, past))
+    # Without O_NONBLOCK this open blocks forever; the FIFO instead reads as a stale marker and is evicted.
+    lock = _make_lock(lock_file)
+    try:
+        with lock.write_lock(timeout=2):
+            pass
+    finally:
+        lock.close()
+
+
 @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW required")
 def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:
     victim = tmp_path / "victim"


### PR DESCRIPTION
_read_marker in the soft read/write lock opens marker files with O_RDONLY | O_NOFOLLOW but no O_NONBLOCK, which is the same gap #548 closed in _soft._read_lock_file. I was going through the soft_rw markers after that change and noticed O_NOFOLLOW only rejects a symlink, not a real FIFO, so a non-cooperating same-UID process can pre-create a named pipe at a predictable marker path like foo.lock.write and any peer that reads it during stale-break or slot-claim blocks forever on the open, all while holding the state SoftFileLock. Adding O_NONBLOCK makes the open return at once so a hostile FIFO reads as a malformed marker and gets evicted like any other stale entry.