### PR TITLE
use lstat when checking lifetime so a symlinked lock file is not followed

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -368,7 +368,11 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         if (lifetime := self._context.lifetime) is None:
             return
         with contextlib.suppress(OSError):
-            if time.time() - pathlib.Path(self.lock_file).stat().st_mtime < lifetime:
+            # lstat, not stat: an attacker with write access to the lock directory can replace a held
+            # lock file with a symlink pointing at an old file, making stat() report the target's stale
+            # mtime so a waiter breaks a live lock and two processes hold it at once. lstat reads the
+            # symlink's own mtime, matching the O_NOFOLLOW reads elsewhere.
+            if time.time() - os.lstat(self.lock_file).st_mtime < lifetime:
                 return
             break_path = f"{self.lock_file}.break.{os.getpid()}"
             pathlib.Path(self.lock_file).rename(break_path)


### PR DESCRIPTION
reading the code I noticed _try_break_expired_lock uses Path(self.lock_file).stat() to decide if a lock is expired, which follows symlinks. a same-host process with write access to the lock directory can swap a held lock file for a symlink onto an old file, so stat sees the stale target mtime and a waiter breaks the live lock and acquires it, so two holders coexist. lstat reads the symlink's own mtime instead, matching the O_NOFOLLOW lock-file reads already in _soft.py and _soft_rw.