### PR TITLE
🔒 fix(soft): harden stale-lock breaking and self-heal malformed locks

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -4,7 +4,6 @@ import contextlib
 import inspect
 import logging
 import os
-import pathlib
 import sys
 import time
 import warnings
@@ -15,6 +14,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from weakref import WeakValueDictionary
 
 from ._error import Timeout
+from ._util import break_lock_file
 
 #: Sentinel indicating that no explicit file permission mode was passed.
 #: When used, lock files are created with 0o666 (letting umask and default ACLs control the final permissions)
@@ -372,11 +372,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             # lock file with a symlink pointing at an old file, making stat() report the target's stale
             # mtime so a waiter breaks a live lock and two processes hold it at once. lstat reads the
             # symlink's own mtime, matching the O_NOFOLLOW reads elsewhere.
-            if time.time() - os.lstat(self.lock_file).st_mtime < lifetime:
+            mtime = os.lstat(self.lock_file).st_mtime
+            if time.time() - mtime < lifetime:
                 return
-            break_path = f"{self.lock_file}.break.{os.getpid()}"
-            pathlib.Path(self.lock_file).rename(break_path)
-            pathlib.Path(break_path).unlink()
+            break_lock_file(self.lock_file, mtime)
 
     @abstractmethod
     def _acquire(self) -> None:

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -368,7 +368,11 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         if (lifetime := self._context.lifetime) is None:
             return
         with contextlib.suppress(OSError):
-            if time.time() - pathlib.Path(self.lock_file).stat().st_mtime < lifetime:
+            # lstat, not stat: an attacker with write access to the lock directory can replace a held
+            # lock file with a symlink pointing at an old file, making stat() report the target's stale
+            # mtime so a waiter breaks a live lock and two processes hold it at once. lstat reads the
+            # symlink's own mtime, matching the O_NOFOLLOW reads elsewhere.
+            if time.time() - os.lstat(self.lock_file).st_mtime < lifetime:
                 return
             break_path = f"{self.lock_file}.break.{os.getpid()}"
             pathlib.Path(self.lock_file).rename(break_path)

--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -48,7 +48,10 @@ class AsyncReadWriteLock:
     :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable
     :param is_singleton: if ``True``, reuse existing :class:`ReadWriteLock` instances for the same resolved path
     :param loop: event loop for ``run_in_executor``; ``None`` uses the running loop
-    :param executor: executor for ``run_in_executor``; ``None`` uses the default executor
+    :param executor: executor for ``run_in_executor``. When ``None`` a dedicated single-thread executor is created
+        and owned by this lock, ensuring every operation runs on the same thread (required for SQLite affinity); it
+        is shut down by :meth:`close`. A caller-supplied executor is used as-is and never shut down here, so when no
+        executor is passed remember to call :meth:`close` to release the owned one.
 
     .. versionadded:: 3.21.0
 
@@ -90,8 +93,8 @@ class AsyncReadWriteLock:
         return self._loop
 
     @property
-    def executor(self) -> futures.Executor | None:
-        """:returns: the executor (or ``None`` for the default)."""
+    def executor(self) -> futures.Executor:
+        """:returns: the executor used for ``run_in_executor`` (a dedicated single-thread one if none was supplied)."""
         return self._executor
 
     async def _run(self, func: Callable[..., object], *args: object, **kwargs: object) -> object:
@@ -198,6 +201,12 @@ class AsyncReadWriteLock:
         """
         await self._run(self._lock.close)
         if self._owns_executor:
+            self._executor.shutdown(wait=False)
+
+    def __del__(self) -> None:
+        # Safety net: if close() was never called, still shut down the executor we created so its worker thread does
+        # not outlive the lock. A caller-supplied executor is left untouched. shutdown(wait=False) never blocks.
+        if getattr(self, "_owns_executor", False):
             self._executor.shutdown(wait=False)
 
 

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -168,7 +168,9 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         if not acquired:
             raise Timeout(self.lock_file) from None
 
-    def _validate_reentrant(self, mode: Literal["read", "write"], opposite: str, direction: str) -> AcquireReturnProxy:
+    def _validate_reentrant(self, mode: Literal["read", "write"]) -> AcquireReturnProxy:
+        opposite = "write" if mode == "read" else "read"
+        direction = "downgrade" if mode == "read" else "upgrade"
         if self._current_mode != mode:
             msg = (
                 f"Cannot acquire {mode} lock on {self.lock_file} (lock id: {id(self)}): "
@@ -210,12 +212,9 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
             self._con.execute("SELECT name FROM sqlite_schema LIMIT 1;").close()
 
     def _acquire(self, mode: Literal["read", "write"], timeout: float, *, blocking: bool) -> AcquireReturnProxy:
-        opposite = "write" if mode == "read" else "read"
-        direction = "downgrade" if mode == "read" else "upgrade"
-
         with self._internal_lock:
             if self._lock_level > 0:
-                return self._validate_reentrant(mode, opposite, direction)
+                return self._validate_reentrant(mode)
 
         start_time = time.perf_counter()
         self._acquire_transaction_lock(blocking=blocking, timeout=timeout)
@@ -236,12 +235,10 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         blocking: bool,
         start_time: float,
     ) -> AcquireReturnProxy:
-        opposite = "write" if mode == "read" else "read"
-        direction = "downgrade" if mode == "read" else "upgrade"
         # Double-check: another thread may have acquired the lock while we waited on _transaction_lock.
         with self._internal_lock:
             if self._lock_level > 0:
-                return self._validate_reentrant(mode, opposite, direction)
+                return self._validate_reentrant(mode)
         self._configure_and_begin(mode, timeout, blocking=blocking, start_time=start_time)
         with self._internal_lock:
             self._current_mode = mode

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -9,7 +9,7 @@ from errno import EACCES, EEXIST, EPERM, ESRCH
 from pathlib import Path
 
 from ._api import BaseFileLock
-from ._util import ensure_directory_exists, raise_on_not_writable_file
+from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file
 
 _WIN_SYNCHRONIZE = 0x100000
 _WIN_ERROR_INVALID_PARAMETER = 87
@@ -58,38 +58,29 @@ class SoftFileLock(BaseFileLock):
     def _try_break_stale_lock(self) -> None:
         with suppress(OSError, ValueError):
             content, mtime = _read_lock_file(self.lock_file)
-            lines = content.strip().splitlines() if content else []
+            holder = _parse_lock_holder(content)
 
-            if len(lines) not in {2, 3}:
+            if holder is None:
+                # Unparsable: wrong line count, a non-integer PID or creation time, empty, oversized or not UTF-8.
+                # Self-heal only once the file is clearly not a half-written fresh lock (a peer between O_EXCL and
+                # _write_lock_info), so the brief create-then-write window is never mistaken for a stale lock.
                 if time.time() - mtime >= _MALFORMED_LOCK_AGE_THRESHOLD:
-                    self._evict_lock_file()
+                    break_lock_file(self.lock_file, mtime)
                 return
 
-            pid_str, hostname = lines[0], lines[1]
-            creation_time_str = lines[2] if len(lines) == 3 else None  # noqa: PLR2004
-
+            pid, hostname, creation_time = holder
             if hostname != socket.gethostname():
                 return
 
-            pid = int(pid_str)
-
             if self._is_process_alive(pid):
-                if sys.platform == "win32" and creation_time_str is not None:  # pragma: win32 cover
-                    stored = int(creation_time_str)
-                    actual = self._get_process_creation_time(pid)
-                    if actual is not None and actual != stored:
-                        pass  # PID recycled, fall through to evict
-                    else:
-                        return  # same process or can't verify — don't evict
-                else:
-                    return
+                if sys.platform != "win32" or creation_time is None:  # pragma: win32 no cover
+                    return  # same process, or no creation time to disambiguate a recycled PID — don't evict
+                actual = self._get_process_creation_time(pid)  # pragma: win32 cover
+                if actual is None or actual == creation_time:  # pragma: win32 cover
+                    return  # same process or can't verify — don't evict
+                # else: PID alive but creation time differs — the PID was recycled, so the lock is stale.
 
-            self._evict_lock_file()
-
-    def _evict_lock_file(self) -> None:
-        break_path = f"{self.lock_file}.break.{os.getpid()}"
-        Path(self.lock_file).rename(break_path)
-        Path(break_path).unlink()
+            break_lock_file(self.lock_file, mtime)
 
     @staticmethod
     def _is_process_alive(pid: int) -> bool:
@@ -220,6 +211,20 @@ def _read_lock_file(path: str) -> tuple[str | None, float]:
         with suppress(UnicodeDecodeError):
             return data.decode("utf-8"), mtime
     return None, mtime
+
+
+def _parse_lock_holder(content: str | None) -> tuple[int, str, int | None] | None:
+    # A well-formed lock file is "<pid>\n<hostname>\n" with an optional "<creation_time>\n" third line on Windows.
+    # Anything else — wrong line count, a non-integer PID or creation time, empty or unreadable content — is
+    # unparsable; returning None lets the caller treat it as a malformed lock to self-heal rather than a holder.
+    if not content or len(lines := content.strip().splitlines()) not in {2, 3}:
+        return None
+    try:
+        pid = int(lines[0])
+        creation_time = int(lines[2]) if len(lines) == 3 else None  # noqa: PLR2004
+    except ValueError:
+        return None
+    return pid, lines[1], creation_time
 
 
 __all__ = [

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -405,7 +405,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         *,
         blocking: bool | None,
     ) -> AcquireReturnProxy:
-        effective_timeout = self.timeout if timeout is None else timeout
+        timeout = self.timeout if timeout is None else timeout
         blocking = self.blocking if blocking is None else blocking
 
         with self._locks.internal:
@@ -421,14 +421,14 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         start = time.perf_counter()
         if not blocking:
             acquired = self._locks.transaction.acquire(blocking=False)
-        elif effective_timeout == -1:
+        elif timeout == -1:
             acquired = self._locks.transaction.acquire(blocking=True)
         else:
-            acquired = self._locks.transaction.acquire(blocking=True, timeout=effective_timeout)
+            acquired = self._locks.transaction.acquire(blocking=True, timeout=timeout)
         if not acquired:
             raise Timeout(self.lock_file) from None
         try:
-            return self._do_acquire_inner(mode, effective_timeout, start, blocking=blocking)
+            return self._do_acquire_inner(mode, timeout, start, blocking=blocking)
         finally:
             self._locks.transaction.release()
 

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -47,7 +47,36 @@ def ensure_directory_exists(filename: Path | str) -> None:
     Path(filename).parent.mkdir(parents=True, exist_ok=True)
 
 
+def break_lock_file(lock_file: str, mtime_before: float) -> None:
+    """
+    Atomically break a stale lock file that was judged stale at modification time *mtime_before*.
+
+    The file is renamed to a process-private name before being unlinked, so two processes breaking the same lock
+    cannot delete each other's work (only one rename of a given inode succeeds; the loser gets ``OSError``). After the
+    rename the modification time is re-checked: a value newer than *mtime_before* means a peer recreated the lock
+    between the stale decision and the rename, so we grabbed a live file and must abort, leaving the renamed file in
+    place rather than rolling back (a rollback rename is itself racy — same trade-off as the soft read/write marker
+    break). ``lstat`` is used so a hostile symlink swapped in after the decision is not followed.
+
+    :param lock_file: path to the lock file to break.
+    :param mtime_before: modification time observed when the lock was judged stale.
+
+    :raises OSError: if the rename fails (e.g. the file vanished or is not owned in a sticky directory).
+
+    """
+    break_path = f"{lock_file}.break.{os.getpid()}"
+    Path(lock_file).rename(break_path)
+    try:
+        mtime_after = os.lstat(break_path).st_mtime
+    except OSError:
+        return
+    if mtime_after > mtime_before:
+        return
+    Path(break_path).unlink()
+
+
 __all__ = [
+    "break_lock_file",
     "ensure_directory_exists",
     "raise_on_not_writable_file",
 ]

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
@@ -216,6 +217,46 @@ async def test_custom_executor(lock_file: str) -> None:
     async with lock.read_lock():
         assert lock._lock._current_mode == "read"
     assert lock._lock._lock_level == 0
+    executor.shutdown(wait=False)
+
+
+@pytest.mark.asyncio
+async def test_close_shuts_down_owned_executor(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    assert lock._owns_executor is True
+    executor = lock.executor
+    await lock.close()
+    with pytest.raises(RuntimeError):  # submitting after shutdown is rejected
+        executor.submit(int)
+
+
+@pytest.mark.asyncio
+async def test_close_keeps_provided_executor_open(lock_file: str) -> None:
+    executor = ThreadPoolExecutor(max_workers=1)
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False, executor=executor)
+    assert lock._owns_executor is False
+    await lock.close()
+    assert executor.submit(int).result(timeout=5) == 0  # still usable
+    executor.shutdown(wait=False)
+
+
+def test_del_shuts_down_owned_executor(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    executor = lock.executor
+    lock._lock.close()  # close the connection so only the executor lifecycle is under test
+    del lock
+    gc.collect()
+    with pytest.raises(RuntimeError):
+        executor.submit(int)
+
+
+def test_del_keeps_provided_executor_open(lock_file: str) -> None:
+    executor = ThreadPoolExecutor(max_workers=1)
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False, executor=executor)
+    lock._lock.close()
+    del lock
+    gc.collect()
+    assert executor.submit(int).result(timeout=5) == 0
     executor.shutdown(wait=False)
 
 

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -50,7 +50,7 @@ def test_expired_lock_race_rename_fails(tmp_path: Path, mocker: MockerFixture) -
     lock_path.touch()
     os.utime(lock_path, (0, 0))
 
-    mocker.patch("filelock._api.pathlib.Path.rename", side_effect=FileNotFoundError)
+    mocker.patch("filelock._util.Path.rename", side_effect=FileNotFoundError)
 
     lock = SoftFileLock(lock_path, lifetime=0.1, timeout=0.5)
     with pytest.raises(TimeoutError):

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -100,18 +100,25 @@ def test_stale_lock_not_broken_on_kill_error(lock_path: Path, mocker: MockerFixt
         pytest.param(b"not-a-pid\n", id="malformed"),
         pytest.param(b"", id="empty"),
         pytest.param(b"x" * (_MAX_LOCK_FILE_SIZE + 1), id="oversized"),
+        pytest.param(b"not-a-pid\nhostname\n", id="two_line_bad_pid"),
+        pytest.param(f"{DEAD_PID}\nhostname\nnot-a-time\n".encode(), id="three_line_bad_creation_time"),
     ],
 )
 def test_unparseable_lock_evicted_when_old(lock_path: Path, content: bytes) -> None:
     lock_path.write_bytes(content)
     os.utime(lock_path, (0, 0))
-    # An unreadable lock (malformed, empty, or oversized) must self-heal rather than stay stuck forever.
+    # An unreadable lock (wrong line count, non-integer pid/creation time, empty, or oversized) must self-heal
+    # rather than stay stuck forever; line count alone is not enough to call a file well-formed.
     _assert_self_heals(lock_path)
 
 
 @pytest.mark.parametrize(
     "content",
-    [pytest.param(b"not-a-pid\n", id="malformed"), pytest.param(b"", id="empty")],
+    [
+        pytest.param(b"not-a-pid\n", id="malformed"),
+        pytest.param(b"", id="empty"),
+        pytest.param(b"not-a-pid\nhostname\n", id="two_line_bad_pid"),
+    ],
 )
 def test_unparseable_lock_not_evicted_when_fresh(lock_path: Path, content: bytes) -> None:
     lock_path.write_bytes(content)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock._util import break_lock_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+def test_break_lock_file_unlinks_unchanged_file(tmp_path: Path) -> None:
+    lock = tmp_path / "test.lock"
+    lock.write_text("stale", encoding="utf-8")
+    break_lock_file(str(lock), os.lstat(lock).st_mtime)
+    assert not lock.exists()
+    assert list(tmp_path.glob("test.lock.break.*")) == []
+
+
+def test_break_lock_file_preserves_file_when_mtime_advanced(tmp_path: Path) -> None:
+    lock = tmp_path / "test.lock"
+    lock.write_text("live", encoding="utf-8")
+    # A mtime_before older than the file's real mtime models a peer recreating the lock after our stale read: the
+    # live file is renamed aside but must not be unlinked, so the holder's content survives instead of two holders.
+    break_lock_file(str(lock), mtime_before=0.0)
+    assert not lock.exists()
+    leftover = list(tmp_path.glob("test.lock.break.*"))
+    assert len(leftover) == 1
+    assert leftover[0].read_text(encoding="utf-8") == "live"
+
+
+def test_break_lock_file_aborts_if_break_path_vanishes(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = tmp_path / "test.lock"
+    lock.write_text("x", encoding="utf-8")
+    mocker.patch("filelock._util.os.lstat", side_effect=FileNotFoundError)
+    break_lock_file(str(lock), 0.0)
+    assert not lock.exists()
+    assert len(list(tmp_path.glob("test.lock.break.*"))) == 1
+
+
+def test_break_lock_file_missing_source_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        break_lock_file(str(tmp_path / "nope.lock"), 0.0)


### PR DESCRIPTION
A process sharing the lock directory on the same host could swap a held soft lock file for a symlink pointing at an old file, so the lifetime check saw the target's stale mtime, a waiter broke the still-live lock, and two processes held it at once. 🔒 This builds on @dxbjavid's #550, which switched the lifetime check to `os.lstat` so it reads the symlink's own mtime, and closes the remaining gaps in the same stale-breaking path.

Breaking a stale lock now claims the file by inode before removing it. A shared `break_lock_file` helper renames the lock to a process-private name, re-checks the modification time, and unlinks only when it still matches the value seen at the stale decision. A newer time means a peer recreated the lock in the gap, so the helper leaves the file in place rather than deleting it out from under a live holder. Both the soft lock and the lifetime path use this helper, replacing the duplicated rename logic. Malformed lock files self-heal more reliably too: a non-integer PID or creation time now counts as unparseable, so a two or three line garbage file gets evicted once it ages past the safety window instead of wedging acquirers forever.

`AsyncReadWriteLock` gained a destructor that shuts down the single-thread executor it owns, so forgetting to call `close()` no longer leaks the worker thread, while a caller-supplied executor stays untouched. Reviewers should know that releasing a soft lock may now remove the lock file as part of self-healing, and that filelock evicts malformed files automatically after a brief safety window. Supersedes #550. 🙏