### PR TITLE
check hostname in is_lock_held_by_us

### DIFF
--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -159,10 +159,15 @@ class SoftFileLock(BaseFileLock):
         """
         Whether this lock is held by the current process.
 
-        :returns: ``True`` if the lock file exists and contains the current process's PID
+        :returns: ``True`` if the lock file exists and names the current process's PID and hostname
 
         """
-        return self.pid == os.getpid()
+        with suppress(OSError, ValueError):
+            holder = _parse_lock_holder(_read_lock_file(self.lock_file)[0])
+            if holder is not None:
+                pid, hostname, _ = holder
+                return pid == os.getpid() and hostname == socket.gethostname()
+        return False
 
     def break_lock(self) -> None:
         """Forcibly break the lock by removing the lock file, regardless of who holds it."""

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -228,6 +228,7 @@ def test_pid_while_locked(lock_path: Path) -> None:
         pytest.param(None, False, id="no_file"),
         pytest.param(_holder(os.getpid() + 1), False, id="different_pid"),
         pytest.param(_holder(os.getpid()), True, id="same_pid"),
+        pytest.param(_holder(os.getpid(), host="other-host"), False, id="same_pid_different_host"),
     ],
 )
 def test_is_lock_held_by_us(lock_path: Path, content: str | None, expected: bool) -> None:


### PR DESCRIPTION
is_lock_held_by_us compares only the pid from the lock file against os.getpid() and ignores the hostname stored alongside it, so on a shared filesystem where the same pid is live on two hosts a lock genuinely held by another node is reported as held by us, and a caller acting on that by releasing or breaking it can drop a lock another host still holds. the lock file already records the hostname for exactly this disambiguation and the stale-break path checks it, so this reads the holder through _parse_lock_holder and requires both the pid and the hostname to match before returning true. added a regression case to the existing is_lock_held_by_us parametrisation covering a same-pid, different-host file.