### PR TITLE
validate pid range in _parse_lock_holder

### DIFF
--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -149,9 +149,9 @@ class SoftFileLock(BaseFileLock):
 
         """
         with suppress(OSError, ValueError):
-            content, _ = _read_lock_file(self.lock_file)
-            if content and (lines := content.strip().splitlines()):
-                return int(lines[0])
+            holder = _parse_lock_holder(_read_lock_file(self.lock_file)[0])
+            if holder is not None:
+                return holder[0]
         return None
 
     @property

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -229,6 +229,12 @@ def _parse_lock_holder(content: str | None) -> tuple[int, str, int | None] | Non
         creation_time = int(lines[2]) if len(lines) == 3 else None  # noqa: PLR2004
     except ValueError:
         return None
+    # A pid outside the valid range is a malformed lock, not a holder. Without this, a non-positive pid
+    # reaches os.kill() where 0 / -1 mean "the caller's own process group / every process" so a dead
+    # holder reads as alive and the lock is never reclaimed, while an oversized pid raises OverflowError
+    # (not OSError/ValueError) out of the self-heal path. _parse_marker_bytes already enforces this range.
+    if not 1 <= pid <= 2**31 - 1:
+        return None
     return pid, lines[1], creation_time
 
 

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -125,6 +125,23 @@ def test_unparseable_lock_not_evicted_when_fresh(lock_path: Path, content: bytes
     _assert_times_out(lock_path)
 
 
+@pytest.mark.parametrize(
+    "pid",
+    [
+        pytest.param(0, id="zero"),
+        pytest.param(-1, id="negative"),
+        pytest.param(2**31, id="oversized"),
+    ],
+)
+def test_out_of_range_pid_self_heals_when_old(lock_path: Path, pid: int) -> None:
+    lock_path.write_text(_holder(pid), encoding="utf-8")
+    os.utime(lock_path, (0, 0))
+    # A pid of 0 or -1 makes os.kill() probe the caller's own process group (read as alive) so the lock is
+    # never reclaimed, and an oversized pid raises OverflowError out of stale detection. Such a holder is
+    # malformed and must self-heal like any other unparseable one, matching what _parse_marker_bytes rejects.
+    _assert_self_heals(lock_path)
+
+
 def test_stale_lock_rename_race(lock_path: Path, mocker: MockerFixture) -> None:
     lock_path.write_text(_holder(DEAD_PID), encoding="utf-8")
     mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=False)

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -138,8 +138,15 @@ def test_out_of_range_pid_self_heals_when_old(lock_path: Path, pid: int) -> None
     os.utime(lock_path, (0, 0))
     # A pid of 0 or -1 makes os.kill() probe the caller's own process group (read as alive) so the lock is
     # never reclaimed, and an oversized pid raises OverflowError out of stale detection. Such a holder is
-    # malformed and must self-heal like any other unparseable one, matching what _parse_marker_bytes rejects.
+    # malformed and must self-heal like any other unparsable one, matching what _parse_marker_bytes rejects.
     _assert_self_heals(lock_path)
+
+
+def test_out_of_range_pid_not_evicted_when_fresh(lock_path: Path) -> None:
+    lock_path.write_text(_holder(0), encoding="utf-8")
+    # A fresh out-of-range pid is malformed too, but like any malformed lock it is left alone until it ages
+    # past the threshold, so a peer mid-write is never mistaken for a stale lock.
+    _assert_times_out(lock_path)
 
 
 def test_stale_lock_rename_race(lock_path: Path, mocker: MockerFixture) -> None:
@@ -224,6 +231,8 @@ def test_get_process_creation_time_returns_none_on_unix() -> None:
         pytest.param(b"not-a-number\n", None, id="malformed"),
         pytest.param(b"\xff\xfe\n", None, id="non_utf8"),
         pytest.param(b"x" * (_MAX_LOCK_FILE_SIZE + 1), None, id="oversized"),
+        pytest.param(b"42\n", None, id="single_line"),
+        pytest.param(_holder(0).encode(), None, id="out_of_range_pid"),
         pytest.param(_holder(os.getpid()).encode(), os.getpid(), id="valid"),
     ],
 )


### PR DESCRIPTION
a soft lock file lives in a shared directory that a same-uid or cross-host peer can write, and _parse_lock_holder turns its first line into a pid with int() but never checks the range, unlike _parse_marker_bytes which already rejects anything outside 1..2**31-1. a holder line of 0 or -1 parses fine, so _is_process_alive ends up calling os.kill(0, 0) or os.kill(-1, 0), and those probe the caller's own process group rather than a real holder and report success, so a long-dead lock reads as still held and is never reclaimed. a pid too large for the C pid_t is worse: os.kill raises OverflowError, which is neither OSError nor ValueError, so it slips past the suppress() guard and aborts acquire() instead of letting the malformed lock self-heal.

the fix range-checks the parsed pid against the same window the marker parser uses, so an out-of-range value is treated as an unparseable holder and self-heals after the age threshold like any other malformed file. added a regression covering 0, -1 and an oversized pid.