### PR TITLE
🔧 ci(release): publish to PyPI on tag push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,65 @@
+name: 📦 Publish
+on:
+  push:
+    tags: ["[0-9]+.[0-9]+.[0-9]+"]
+
+permissions:
+  contents: read
+
+env:
+  dists-artifact-name: python-package-distributions
+
+jobs:
+  build:
+    name: 📦 build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: 📦 Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+      - name: 📦 Build package
+        run: uv build --python 3.14 --python-preference only-managed --sdist --wheel . --out-dir dist
+      - name: 📤 Store the distribution packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.dists-artifact-name }}
+          path: dist/*
+
+  publish:
+    name: 🚀 publish
+    needs: [build]
+    runs-on: ubuntu-24.04
+    environment:
+      name: release
+      url: https://pypi.org/project/filelock/${{ github.ref_name }}
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: ⬇️ Download all the dists
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ env.dists-artifact-name }}
+          path: dist/
+      - name: 🚀 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+      - name: 📢 Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Release $VERSION already exists, skipping"
+          else
+            gh release create "$VERSION" --repo "$GITHUB_REPOSITORY" --title="$VERSION" --verify-tag --generate-notes
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,15 +71,11 @@ jobs:
           path: dist/*
 
   release:
-    name: 🚀 release
+    name: 🏷️ tag
     needs: [build]
     if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
-    environment:
-      name: release
-      url: https://pypi.org/project/filelock/${{ needs.build.outputs.version }}
     permissions:
-      id-token: write
       contents: write
     steps:
       - name: 📥 Checkout
@@ -92,7 +88,7 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
-            echo "Tag $VERSION already exists, skipping changelog commit"
+            echo "Tag $VERSION already exists, nothing to do"
             exit 0
           fi
           git config user.name "${GITHUB_ACTOR}"
@@ -109,24 +105,8 @@ jobs:
           git add docs/changelog.rst
           git commit -m "Release $VERSION"
           git tag "$VERSION"
-          git push origin "$VERSION"
+          # Push the branch, then the tag. The tag is pushed with RELEASE_TOKEN (a PAT, not GITHUB_TOKEN), so it
+          # triggers publish.yaml, which builds at the tag and uploads to PyPI. Publishing lives there, not here, so
+          # any tag — including one pushed by hand — always reaches PyPI instead of silently skipping it.
           git push origin main
-      - name: ⬇️ Download all the dists
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ env.dists-artifact-name }}
-          path: dist/
-      - name: 🚀 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          skip-existing: true
-      - name: 📢 Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          if gh release view "$VERSION" > /dev/null 2>&1; then
-            echo "Release $VERSION already exists, skipping"
-          else
-            gh release create "$VERSION" --title="$VERSION" --verify-tag --generate-notes
-          fi
+          git push origin "$VERSION"


### PR DESCRIPTION
Closes #552.

The release job uploaded to PyPI only inside a `workflow_dispatch` run, so a tag created any other way (for example pushed by hand) produced a git tag and a GitHub release but never reached PyPI. 📦 That is exactly how `3.29.2` and `3.29.3` ended up tagged and GitHub-released yet missing from PyPI, which broke downstreams like pkgsrc that fetch distfiles from there.

Publishing moves into a new `publish.yaml` triggered on tag push: it builds at the tag and uploads to PyPI with `skip-existing`, then creates the GitHub release if one is absent. The dispatch job now only writes the changelog and pushes the tag, and because it pushes with `RELEASE_TOKEN` (a PAT rather than `GITHUB_TOKEN`) that push triggers `publish.yaml`. The tag becomes the single source of truth for a release, so any tag always reaches PyPI instead of silently skipping it.

The canonical way to cut a release is unchanged: run the 🚀 Release workflow with a `patch`/`minor`/`major` bump. The only behavioral change is that the upload happens in the tag-triggered run rather than in the dispatch run itself.