### PR TITLE
🐛 fix(ci): restore release environment on tag job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,10 @@ jobs:
     needs: [build]
     if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
+    # RELEASE_TOKEN is an environment-scoped secret; without selecting the environment it resolves empty and the
+    # checkout fails with "Input required and not supplied: token".
+    environment:
+      name: release
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The first dispatch release after #557 failed at checkout with `Input required and not supplied: token` (run https://github.com/tox-dev/filelock/actions/runs/27292630778).

`RELEASE_TOKEN` is an environment-scoped secret on the `release` environment. #557 moved publishing into `publish.yaml` and, in trimming the tag job down to just commit-changelog-and-push, dropped its `environment: release`. Without selecting the environment the secret resolves empty, so the `actions/checkout` `token` input is blank and the job dies before tagging anything (nothing partial was released).

Re-selecting `environment: release` on the tag job restores `RELEASE_TOKEN` access. The environment has no protection rules, so this adds no approval step, and `publish.yaml` already selects the same environment for the PyPI upload.