### PR TITLE
keep the read/write heartbeat alive on a transient touch error

### DIFF
--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -644,10 +644,14 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         # A transient touch failure (ESTALE / EIO on the NFS-style filesystems this lock targets) must not
         # kill the heartbeat thread: the read above just confirmed the marker is still ours, so swallow the
         # error and retry on the next tick rather than letting the lease lapse while we still believe we
-        # hold the lock. A marker that has genuinely vanished is caught by the next iteration's _read_marker
-        # returning None. This mirrors the OSError suppression already used around the writer-drain touch.
-        with suppress(OSError):
+        # hold the lock. FileNotFoundError is different in kind -- the marker we just read has since been
+        # unlinked, i.e. a peer evicted us -- so stop the heartbeat at once instead of waiting a tick.
+        try:
             _touch(marker_name, dir_fd=dir_fd)
+        except FileNotFoundError:
+            return False
+        except OSError:
+            pass
         return True
 
     def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - fork child not tracked

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -641,10 +641,13 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         # thread so it does not touch a stranger's file.
         if info is None or not hmac.compare_digest(info.token, token):
             return False
-        try:
+        # A transient touch failure (ESTALE / EIO on the NFS-style filesystems this lock targets) must not
+        # kill the heartbeat thread: the read above just confirmed the marker is still ours, so swallow the
+        # error and retry on the next tick rather than letting the lease lapse while we still believe we
+        # hold the lock. A marker that has genuinely vanished is caught by the next iteration's _read_marker
+        # returning None. This mirrors the OSError suppression already used around the writer-drain touch.
+        with suppress(OSError):
             _touch(marker_name, dir_fd=dir_fd)
-        except FileNotFoundError:  # pragma: no cover - race between successful read and touch
-            return False
         return True
 
     def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - fork child not tracked

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -618,11 +618,12 @@ def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: p
     lock = _make_lock(lock_file, heartbeat_interval=0.02, stale_threshold=0.2)
     lock.acquire_write(timeout=2)
     try:
-        heartbeat = lock._hold.heartbeat_thread
+        hold = lock._hold
+        assert hold is not None
         monkeypatch.setattr(sync_mod, "_touch", boom)
         time.sleep(0.2)  # ~10 ticks, all of which fail the touch
-        assert heartbeat.is_alive()
-        assert not lock._hold.heartbeat_stop.is_set()
+        assert hold.heartbeat_thread.is_alive()
+        assert not hold.heartbeat_stop.is_set()
     finally:
         lock.release(force=True)
         lock.close()

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 from contextlib import contextmanager, suppress
+from errno import EIO
 from multiprocessing import Event, Process
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -15,6 +16,7 @@ import pytest
 
 from filelock import Timeout
 from filelock._soft_rw import SoftReadWriteLock
+from filelock._soft_rw import _sync as sync_mod
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -602,6 +604,25 @@ def test_heartbeat_self_stops_on_token_replacement(lock_file: str) -> None:
         # Replace the marker content with a well-formed marker holding a different token.
         Path(f"{lock_file}.write").write_bytes(b"0" * 32 + b"\n1\nhost\n")
         time.sleep(0.15)
+    finally:
+        lock.release(force=True)
+        lock.close()
+
+
+def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # On the NFS-style filesystems this lock targets a transient ESTALE / EIO on the heartbeat touch is
+    # routine; it must not kill the heartbeat and silently drop the lease while we still believe we hold it.
+    def boom(name: str, *, dir_fd: int | None = None) -> None:  # noqa: ARG001
+        raise OSError(EIO, "Input/output error")
+
+    lock = _make_lock(lock_file, heartbeat_interval=0.02, stale_threshold=0.2)
+    lock.acquire_write(timeout=2)
+    try:
+        heartbeat = lock._hold.heartbeat_thread
+        monkeypatch.setattr(sync_mod, "_touch", boom)
+        time.sleep(0.2)  # ~10 ticks, all of which fail the touch
+        assert heartbeat.is_alive()
+        assert not lock._hold.heartbeat_stop.is_set()
     finally:
         lock.release(force=True)
         lock.close()

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import time
 from contextlib import contextmanager, suppress
-from errno import EIO
+from errno import EIO, ENOENT
 from multiprocessing import Event, Process
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -624,6 +624,26 @@ def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: p
         time.sleep(0.2)  # ~10 ticks, all of which fail the touch
         assert hold.heartbeat_thread.is_alive()
         assert not hold.heartbeat_stop.is_set()
+    finally:
+        lock.release(force=True)
+        lock.close()
+
+
+def test_heartbeat_stops_when_marker_unlinked_during_touch(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # ENOENT on the touch means the marker we just read was unlinked between the read and the touch -- a peer
+    # evicted us, not a transient hiccup -- so the heartbeat must stop at once rather than wait another tick.
+    def gone(name: str, *, dir_fd: int | None = None) -> None:  # noqa: ARG001
+        raise FileNotFoundError(ENOENT, "No such file or directory")
+
+    lock = _make_lock(lock_file, heartbeat_interval=0.02, stale_threshold=0.2)
+    lock.acquire_write(timeout=2)
+    try:
+        hold = lock._hold
+        assert hold is not None
+        monkeypatch.setattr(sync_mod, "_touch", gone)
+        assert hold.heartbeat_stop.wait(timeout=2)
+        hold.heartbeat_thread.join(timeout=2)
+        assert not hold.heartbeat_thread.is_alive()
     finally:
         lock.release(force=True)
         lock.close()


### PR DESCRIPTION
SoftReadWriteLock._refresh_marker only catches FileNotFoundError around its heartbeat touch, so a transient ESTALE or EIO (routine on the NFS-style filesystems this lock is meant for) escapes as an unhandled OSError and kills the heartbeat thread without ever setting heartbeat_stop. The holder still believes it holds the lock while the marker stops being refreshed, so it goes stale, a peer evicts it and acquires, and two processes end up holding conflicting locks. The writer-drain touch in readers_drained_touching already wraps the same call in suppress(OSError), so this just brings the heartbeat into line: a transient touch error is swallowed and retried on the next tick, since the read just above has already confirmed the marker is still ours and a genuinely vanished marker is caught by the next iteration's _read_marker.