### PR TITLE
serialise read/write release rollback against a concurrent acquire

### DIFF
--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -312,7 +312,14 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
                 self._write_thread_id = None
                 should_rollback = True
         if should_rollback:
-            self._con.rollback()
+            # The rollback ends the transaction on the shared connection, so it has to be serialised against
+            # acquire()'s BEGIN the same way acquire() already serialises itself with _transaction_lock. Without
+            # this, another thread that sees lock_level back at 0 can start its BEGIN while this rollback's
+            # transaction is still open (raising "cannot start a transaction within a transaction") or, in the
+            # other ordering, have its freshly started transaction rolled back here, dropping the database lock
+            # while it still believes it holds it.
+            with self._transaction_lock:
+                self._con.rollback()
 
     @contextmanager
     def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> Generator[None]:

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -312,8 +312,8 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
                 self._write_thread_id = None
                 should_rollback = True
         if should_rollback:
-            # The rollback ends the transaction on the shared connection, so it has to be serialised against
-            # acquire()'s BEGIN the same way acquire() already serialises itself with _transaction_lock. Without
+            # The rollback ends the transaction on the shared connection, so it has to be serialized against
+            # acquire()'s BEGIN the same way acquire() already serializes itself with _transaction_lock. Without
             # this, another thread that sees lock_level back at 0 can start its BEGIN while this rollback's
             # transaction is still open (raising "cannot start a transaction within a transaction") or, in the
             # other ordering, have its freshly started transaction rolled back here, dropping the database lock

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -577,6 +577,53 @@ def test_cleanup_connections_closes_all(tmp_path: Path) -> None:
         con2.execute("SELECT 1;")
 
 
+def test_release_rollback_serialised_against_concurrent_acquire(lock_file: str) -> None:
+    # release() rolls back the transaction on the shared connection; a concurrent acquire on another thread
+    # must not be able to BEGIN while that rollback is still in flight. Park the rollback with the lock level
+    # already back at 0 and confirm the racing acquire waits for it instead of erroring with "cannot start a
+    # transaction within a transaction".
+    lock = ReadWriteLock(lock_file, is_singleton=False)
+    lock.acquire_read()
+
+    started = threading.Event()
+    proceed = threading.Event()
+    real_con = lock._con
+
+    class _SlowRollbackCon:
+        def rollback(self) -> None:
+            started.set()
+            proceed.wait(timeout=5)
+            real_con.rollback()
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(real_con, name)
+
+    lock._con = _SlowRollbackCon()  # type: ignore[assignment]
+    threading.Thread(target=lock.release, daemon=True).start()
+    assert started.wait(timeout=5)
+
+    result: dict[str, object] = {}
+
+    def acquirer() -> None:
+        try:
+            lock.acquire_read()
+            result["ok"] = True
+        except BaseException as exc:  # noqa: BLE001
+            result["exc"] = exc
+
+    thread = threading.Thread(target=acquirer, daemon=True)
+    thread.start()
+    thread.join(timeout=1)
+    assert thread.is_alive()  # blocked on _transaction_lock, not racing the rollback
+
+    proceed.set()
+    thread.join(timeout=5)
+    lock._con = real_con  # type: ignore[assignment]
+    assert result.get("ok") is True
+    assert "exc" not in result
+    lock.release()
+
+
 def test_pytest_session_finish_calls_cleanup(mocker: MockerFixture) -> None:
     mock = mocker.patch("conftest._cleanup_connections")
     pytest_sessionfinish()

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -608,7 +608,7 @@ def test_release_rollback_serialised_against_concurrent_acquire(lock_file: str) 
         try:
             lock.acquire_read()
             result["ok"] = True
-        except BaseException as exc:  # noqa: BLE001
+        except BaseException as exc:
             result["exc"] = exc
 
     thread = threading.Thread(target=acquirer, daemon=True)

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -590,7 +590,7 @@ def test_release_rollback_serialised_against_concurrent_acquire(lock_file: str) 
     real_con = lock._con
 
     class _SlowRollbackCon:
-        def rollback(self) -> None:
+        def rollback(self) -> None:  # noqa: PLR6301
             started.set()
             proceed.wait(timeout=5)
             real_con.rollback()
@@ -598,7 +598,7 @@ def test_release_rollback_serialised_against_concurrent_acquire(lock_file: str) 
         def __getattr__(self, name: str) -> object:
             return getattr(real_con, name)
 
-    lock._con = _SlowRollbackCon()  # type: ignore[assignment]
+    lock._con = _SlowRollbackCon()  # ty: ignore[invalid-assignment]
     threading.Thread(target=lock.release, daemon=True).start()
     assert started.wait(timeout=5)
 
@@ -618,7 +618,7 @@ def test_release_rollback_serialised_against_concurrent_acquire(lock_file: str) 
 
     proceed.set()
     thread.join(timeout=5)
-    lock._con = real_con  # type: ignore[assignment]
+    lock._con = real_con
     assert result.get("ok") is True
     assert "exc" not in result
     lock.release()


### PR DESCRIPTION
ReadWriteLock.release() rolls back the transaction on the shared sqlite3 connection outside _transaction_lock, even though acquire() runs its own BEGIN under that lock. Once release has put lock_level back to 0 inside the internal lock but has not yet rolled back, another thread acquiring on the same instance sees the level at 0, takes _transaction_lock and issues BEGIN against the connection whose transaction is still open, which raises "cannot start a transaction within a transaction" (re-raised, since it is not a "database is locked" timeout); in the reverse ordering the rollback instead ends the new holder's freshly started transaction and quietly drops the database lock while it still thinks it holds it. The added test parks the rollback with the level already at 0 and shows the racing acquirer now waits rather than erroring. Wrapping the rollback in _transaction_lock keeps it serialised against acquire the same way the rest of the transaction work already is.