### PR TITLE
🔒 fix(soft_rw): refresh held marker through the verified fd

### DIFF
--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -33,6 +33,9 @@ _BREAK_SUFFIX = ".break"
 _MAX_MARKER_SIZE = 1024
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _O_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
+# Retargeting os.utime to an open fd lets the heartbeat refresh the exact inode it just verified instead of
+# re-resolving the path; Windows read-only handles cannot set times that way, so keep it Unix-only.
+_SUPPORTS_UTIME_FD = sys.platform != "win32" and os.utime in os.supports_fd
 # os.utime follows symlinks unless told not to; not every platform can refuse the follow, so probe support.
 _SUPPORTS_UTIME_NOFOLLOW = os.utime in os.supports_follow_symlinks
 # dirfd-relative I/O is a Unix-only optimization; Windows cannot ``os.open()`` a directory at all, and
@@ -635,26 +638,32 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             token = hold.token
             dir_fd = self._readers_dir_fd if hold.is_reader else None
 
-        read_result = _read_marker(marker_name, dir_fd=dir_fd)
-        if read_result is None:
+        # Open once with O_NOFOLLOW and touch that exact descriptor. Doing the refresh through the verified fd
+        # (instead of re-opening by name) closes the window where a peer unlinks our marker and drops a symlink
+        # or a different file at the path between the read and the touch: utime then lands on the inode we
+        # verified, or nowhere. A failed open means the marker is gone or was swapped out -- a peer evicted us
+        # -- so stop the heartbeat at once instead of waiting a tick.
+        fd = _open_marker(marker_name, dir_fd=dir_fd)
+        if fd is None:
             return False
-        info, _mtime = read_result
-        # Token mismatch means another process already evicted our marker and created its own; stop the
-        # thread so it does not touch a stranger's file.
-        if info is None or not hmac.compare_digest(info.token, token):
-            return False
-        # A transient touch failure (ESTALE / EIO on the NFS-style filesystems this lock targets) must not
-        # kill the heartbeat thread: the read above just confirmed the marker is still ours, so swallow the
-        # error and retry on the next tick rather than letting the lease lapse while we still believe we
-        # hold the lock. FileNotFoundError is different in kind -- the marker we just read has since been
-        # unlinked, i.e. a peer evicted us -- so stop the heartbeat at once instead of waiting a tick.
         try:
-            _touch(marker_name, dir_fd=dir_fd)
-        except FileNotFoundError:
-            return False
-        except OSError:
-            pass
-        return True
+            try:
+                data = os.read(fd, _MAX_MARKER_SIZE + 1)
+            except OSError:  # pragma: no cover - e.g. EAGAIN from a hostile FIFO that has a writer attached
+                return False
+            info = _parse_marker_bytes(data)
+            # Token mismatch means another process already evicted our marker and created its own; stop the
+            # thread so it does not keep a stranger's file alive.
+            if info is None or not hmac.compare_digest(info.token, token):
+                return False
+            # A transient touch failure (ESTALE / EIO on the NFS-style filesystems this lock targets) must not
+            # kill the heartbeat thread: the read above just confirmed the marker is still ours, so swallow the
+            # error and retry on the next tick rather than letting the lease lapse while we still hold the lock.
+            with suppress(OSError):
+                _touch(marker_name, fd=fd)
+            return True
+        finally:
+            os.close(fd)
 
     def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - fork child not tracked
         # Replace every lock this instance owns with a fresh one; the inherited locks may still be held
@@ -705,14 +714,20 @@ def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -
         os.close(fd)
 
 
-def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo | None, float] | None:
+def _open_marker(name: str, *, dir_fd: int | None = None) -> int | None:
     # The file is ours; these guard a hostile mid-flight swap. O_NOFOLLOW rejects a symlink; O_NONBLOCK keeps
     # a real FIFO from blocking the open forever, so it reads as a malformed marker instead of wedging a peer
     # that holds the state lock.
     flags = os.O_RDONLY | _O_NOFOLLOW | _O_NONBLOCK
     try:
-        fd = os.open(name, flags, dir_fd=dir_fd) if _SUPPORTS_DIR_FD and dir_fd is not None else os.open(name, flags)
+        return os.open(name, flags, dir_fd=dir_fd) if _SUPPORTS_DIR_FD and dir_fd is not None else os.open(name, flags)
     except OSError:
+        return None
+
+
+def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo | None, float] | None:
+    fd = _open_marker(name, dir_fd=dir_fd)
+    if fd is None:
         return None
     try:
         try:
@@ -809,16 +824,15 @@ def _unlink(name: str, *, dir_fd: int | None = None) -> None:
             Path(name).unlink()
 
 
-def _touch(name: str, *, dir_fd: int | None = None) -> None:
-    # Refuse to follow a symlink (where the platform allows it). Every read in this module already opens the
-    # marker with O_NOFOLLOW because a peer can swap an attacker-controlled symlink in at a marker path; the
-    # refresh touch is the one spot left following symlinks, so a marker swapped in the window after the
-    # O_NOFOLLOW read would have its link target's mtime updated instead of the swapped marker being refused.
-    follow = not _SUPPORTS_UTIME_NOFOLLOW
-    if _SUPPORTS_DIR_FD and dir_fd is not None:
-        os.utime(name, None, dir_fd=dir_fd, follow_symlinks=follow)
-    else:
-        os.utime(name, None, follow_symlinks=follow)
+def _touch(name: str, *, fd: int | None = None) -> None:
+    # Prefer the already-open, already-verified fd so a peer that swaps a symlink or a different file in at the
+    # path after our O_NOFOLLOW read cannot redirect the touch: utime then targets the inode behind the fd.
+    # Where the platform cannot utime an fd, fall back to a path-based touch that still refuses to follow a
+    # symlink where supported -- matching the O_NOFOLLOW reads used everywhere else here.
+    if fd is not None and _SUPPORTS_UTIME_FD:
+        os.utime(fd, None)
+        return
+    os.utime(name, None, follow_symlinks=not _SUPPORTS_UTIME_NOFOLLOW)
 
 
 def _file_exists(path: str) -> bool:

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -33,6 +33,8 @@ _BREAK_SUFFIX = ".break"
 _MAX_MARKER_SIZE = 1024
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _O_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
+# os.utime follows symlinks unless told not to; not every platform can refuse the follow, so probe support.
+_SUPPORTS_UTIME_NOFOLLOW = os.utime in os.supports_follow_symlinks
 # dirfd-relative I/O is a Unix-only optimization; Windows cannot ``os.open()`` a directory at all, and
 # its ``os`` module skips dir_fd support entirely. When disabled, callers fall back to full-path ops.
 _SUPPORTS_DIR_FD = sys.platform != "win32" and os.open in os.supports_dir_fd
@@ -808,10 +810,15 @@ def _unlink(name: str, *, dir_fd: int | None = None) -> None:
 
 
 def _touch(name: str, *, dir_fd: int | None = None) -> None:
+    # Refuse to follow a symlink (where the platform allows it). Every read in this module already opens the
+    # marker with O_NOFOLLOW because a peer can swap an attacker-controlled symlink in at a marker path; the
+    # refresh touch is the one spot left following symlinks, so a marker swapped in the window after the
+    # O_NOFOLLOW read would have its link target's mtime updated instead of the swapped marker being refused.
+    follow = not _SUPPORTS_UTIME_NOFOLLOW
     if _SUPPORTS_DIR_FD and dir_fd is not None:
-        os.utime(name, None, dir_fd=dir_fd)
+        os.utime(name, None, dir_fd=dir_fd, follow_symlinks=follow)
     else:
-        os.utime(name, None)
+        os.utime(name, None, follow_symlinks=follow)
 
 
 def _file_exists(path: str) -> bool:

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import time
 from contextlib import contextmanager, suppress
-from errno import EIO, ENOENT
+from errno import EIO
 from multiprocessing import Event, Process
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -612,7 +612,7 @@ def test_heartbeat_self_stops_on_token_replacement(lock_file: str) -> None:
 def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
     # On the NFS-style filesystems this lock targets a transient ESTALE / EIO on the heartbeat touch is
     # routine; it must not kill the heartbeat and silently drop the lease while we still believe we hold it.
-    def boom(name: str, *, dir_fd: int | None = None) -> None:  # noqa: ARG001
+    def boom(name: str, *, fd: int | None = None) -> None:  # noqa: ARG001
         raise OSError(EIO, "Input/output error")
 
     lock = _make_lock(lock_file, heartbeat_interval=0.02, stale_threshold=0.2)
@@ -629,18 +629,18 @@ def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: p
         lock.close()
 
 
-def test_heartbeat_stops_when_marker_unlinked_during_touch(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    # ENOENT on the touch means the marker we just read was unlinked between the read and the touch -- a peer
-    # evicted us, not a transient hiccup -- so the heartbeat must stop at once rather than wait another tick.
-    def gone(name: str, *, dir_fd: int | None = None) -> None:  # noqa: ARG001
-        raise FileNotFoundError(ENOENT, "No such file or directory")
+def test_heartbeat_stops_when_marker_evicted(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A failed O_NOFOLLOW open means the marker we held was unlinked or swapped for a symlink -- a peer
+    # evicted us, not a transient hiccup -- so the heartbeat must stop at once rather than keep retrying.
+    def gone(name: str, *, dir_fd: int | None = None) -> int | None:  # noqa: ARG001
+        return None
 
     lock = _make_lock(lock_file, heartbeat_interval=0.02, stale_threshold=0.2)
     lock.acquire_write(timeout=2)
     try:
         hold = lock._hold
         assert hold is not None
-        monkeypatch.setattr(sync_mod, "_touch", gone)
+        monkeypatch.setattr(sync_mod, "_open_marker", gone)
         assert hold.heartbeat_stop.wait(timeout=2)
         hold.heartbeat_thread.join(timeout=2)
         assert not hold.heartbeat_thread.is_alive()
@@ -722,12 +722,26 @@ def test_fifo_write_marker_does_not_block(lock_file: str) -> None:
         lock.close()
 
 
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW required")
+def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:
+    victim = tmp_path / "victim"
+    victim.write_text("do-not-touch")
+    Path(f"{lock_file}.write").symlink_to(victim)
+    lock = _make_lock(lock_file)
+    try:
+        with pytest.raises((OSError, Timeout)):
+            lock.acquire_write(timeout=0.5)
+    finally:
+        lock.close()
+    assert victim.read_text() == "do-not-touch"
+
+
 @pytest.mark.skipif(
     os.utime not in os.supports_follow_symlinks, reason="os.utime cannot refuse symlinks on this platform"
 )
 def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:
-    # A peer can swap a marker for a symlink in the window after our O_NOFOLLOW read but before the refresh
-    # touch; the touch must update the symlink itself, not the file it points at.
+    # The phase-2 writer-drain touch refreshes the .write marker by path (no held fd); if a peer swaps a
+    # symlink in, the touch must land on the link itself, not the file it points at.
     victim = tmp_path / "victim"
     victim.write_text("do-not-touch")
     past = time.time() - 1000
@@ -741,18 +755,37 @@ def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:
     assert victim.read_text() == "do-not-touch"
 
 
-@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW required")
-def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:
+@pytest.mark.skipif(not sync_mod._SUPPORTS_UTIME_FD, reason="os.utime cannot target an fd on this platform")
+def test_refresh_touches_verified_fd_not_swapped_path(
+    lock_file: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A peer can swap our marker for a symlink in the window after the heartbeat's O_NOFOLLOW open but before
+    # the touch; because the refresh touches the verified fd, the swapped symlink's target stays untouched.
     victim = tmp_path / "victim"
     victim.write_text("do-not-touch")
-    Path(f"{lock_file}.write").symlink_to(victim)
-    lock = _make_lock(lock_file)
+    past = time.time() - 1000
+    os.utime(victim, (past, past))
+
+    lock = _make_lock(lock_file, heartbeat_interval=30, stale_threshold=90)
+    lock.acquire_write(timeout=2)
     try:
-        with pytest.raises((OSError, Timeout)):
-            lock.acquire_write(timeout=0.5)
+        marker = Path(f"{lock_file}.write")
+        real_open = sync_mod._open_marker
+
+        def swap_after_open(name: str, *, dir_fd: int | None = None) -> int | None:
+            fd = real_open(name, dir_fd=dir_fd)
+            if fd is not None and Path(name) == marker:
+                marker.unlink()
+                marker.symlink_to(victim)
+            return fd
+
+        monkeypatch.setattr(sync_mod, "_open_marker", swap_after_open)
+        assert lock._refresh_marker() is True
+        assert victim.stat().st_mtime == past
+        assert victim.read_text() == "do-not-touch"
     finally:
+        lock.release(force=True)
         lock.close()
-    assert victim.read_text() == "do-not-touch"
 
 
 def test_symlinked_readers_directory_is_refused(lock_file: str, tmp_path: Path) -> None:

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -722,6 +722,25 @@ def test_fifo_write_marker_does_not_block(lock_file: str) -> None:
         lock.close()
 
 
+@pytest.mark.skipif(
+    os.utime not in os.supports_follow_symlinks, reason="os.utime cannot refuse symlinks on this platform"
+)
+def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:
+    # A peer can swap a marker for a symlink in the window after our O_NOFOLLOW read but before the refresh
+    # touch; the touch must update the symlink itself, not the file it points at.
+    victim = tmp_path / "victim"
+    victim.write_text("do-not-touch")
+    past = time.time() - 1000
+    os.utime(victim, (past, past))
+    marker = Path(f"{lock_file}.write")
+    marker.symlink_to(victim)
+
+    sync_mod._touch(str(marker))
+
+    assert victim.stat().st_mtime == past
+    assert victim.read_text() == "do-not-touch"
+
+
 @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW required")
 def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:
     victim = tmp_path / "victim"


### PR DESCRIPTION
The heartbeat that keeps a soft read/write lock alive refreshed its marker by re-opening the path, so a same-uid peer could replace the marker in the window between the verified read and the refresh and redirect the timestamp update onto a file the lock never owned. 🔒 Every other marker access in this module opens with `O_NOFOLLOW` to refuse a swapped symlink, and the refresh was the one place that trusted the path a second time.

The refresh now opens the marker once with `O_NOFOLLOW`, confirms the stored token on that descriptor, and runs `os.utime` against the same descriptor. Because the touch targets the open inode instead of re-resolving the name, the swap window closes for a regular-file replacement as well as a symlink, going beyond the `follow_symlinks=False` guard that covered only the symlink case. A failed open now counts as eviction and stops the heartbeat rather than retrying.

Where `os.utime` cannot operate on a descriptor the refresh falls back to the path-based call that still refuses to follow a symlink, so behavior on those platforms is unchanged. There are no API or configuration changes.