### PR TITLE
only unlink the writer marker on release if it is still ours

### DIFF
--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -386,7 +386,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         # enough (a stop-the-world GC pause, SIGSTOP, a suspended VM) for a peer to evict the marker as
         # stale and claim the writer slot itself, the file now at <path>.write is the peer's live marker;
         # unlinking it by path would let a second writer through and break mutual exclusion. The state lock
-        # serialises this against a concurrent break/claim, and the heartbeat is already stopped, so the
+        # serializes this against a concurrent break/claim, and the heartbeat is already stopped, so the
         # token we read is authoritative. Mirrors the token re-check the stale-break path already does.
         with self._locks.state:
             read = _read_marker(self._paths.write)

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -379,7 +379,23 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         if hold.is_reader:
             _unlink(hold.marker_name, dir_fd=self._readers_dir_fd)
         else:
-            _unlink(hold.marker_name)
+            self._unlink_writer_marker_if_ours(hold.token)
+
+    def _unlink_writer_marker_if_ours(self, token: str) -> None:
+        # Remove the writer marker only while it still carries our token. If this holder was paused long
+        # enough (a stop-the-world GC pause, SIGSTOP, a suspended VM) for a peer to evict the marker as
+        # stale and claim the writer slot itself, the file now at <path>.write is the peer's live marker;
+        # unlinking it by path would let a second writer through and break mutual exclusion. The state lock
+        # serialises this against a concurrent break/claim, and the heartbeat is already stopped, so the
+        # token we read is authoritative. Mirrors the token re-check the stale-break path already does.
+        with self._locks.state:
+            read = _read_marker(self._paths.write)
+            if read is None:
+                return
+            info, _ = read
+            if info is None or not hmac.compare_digest(info.token, token):
+                return
+            _unlink(self._paths.write)
 
     @classmethod
     def get_lock(
@@ -530,8 +546,9 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         try:
             self._wait_for(readers_drained_touching, deadline=deadline, blocking=blocking)
         except Timeout:
-            # Give up our writer claim so readers can make progress again.
-            _unlink(self._paths.write)
+            # Give up our writer claim so readers can make progress again, but only while the marker is
+            # still ours: a peer may have evicted it as stale and claimed the slot while phase 2 waited.
+            self._unlink_writer_marker_if_ours(token)
             raise
         return self._paths.write, False
 

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -609,6 +609,22 @@ def test_heartbeat_self_stops_on_token_replacement(lock_file: str) -> None:
         lock.close()
 
 
+def test_release_keeps_a_peers_writer_marker(lock_file: str) -> None:
+    # A holder paused long enough (a stop-the-world GC pause, SIGSTOP, a suspended VM) for a peer to evict
+    # its stale marker and claim the writer slot must not unlink that peer's live marker on release: doing so
+    # would let a second writer through and break mutual exclusion.
+    lock = _make_lock(lock_file, heartbeat_interval=10, stale_threshold=40)
+    lock.acquire_write(timeout=2)
+    try:
+        write_marker = f"{lock_file}.write"
+        peer_marker = b"a" * 32 + b"\n1\npeerhost\n"
+        Path(write_marker).write_bytes(peer_marker)
+        lock.release()
+        assert Path(write_marker).read_bytes() == peer_marker
+    finally:
+        lock.close()
+
+
 def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
     # On the NFS-style filesystems this lock targets a transient ESTALE / EIO on the heartbeat touch is
     # routine; it must not kill the heartbeat and silently drop the lease while we still believe we hold it.


### PR DESCRIPTION
If a writer is paused past stale_threshold (a long GC pause, SIGSTOP, a suspended VM) a peer evicts its now-stale .write marker, claims the writer slot and writes its own marker at the same path; the original holder still has _hold set, so on release it unlinks .write by path and deletes the peer's live marker, letting a second writer in and breaking mutual exclusion. The phase-2 timeout cleanup in _acquire_writer_slot has the same shape. Both now read the marker under the state lock and unlink only when the stored token is still ours, which is the same token re-check the stale-break path already relies on.