### PR TITLE
lifetime: reject negative, non-numeric, and bool values at the setter

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -346,7 +346,17 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
 
         :param value: the new value in seconds, or ``None`` to disable expiration
 
+        :raises ValueError: if *value* is a negative number
+        :raises TypeError: if *value* is not ``None`` and not a real number
+
         """
+        if value is not None:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                msg = f"lifetime must be a non-negative number or None, not {type(value).__name__}"
+                raise TypeError(msg)
+            if value < 0:
+                msg = f"lifetime must be non-negative, not {value!r}"
+                raise ValueError(msg)
         self._context.lifetime = value
 
     @property

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -73,6 +73,40 @@ def test_lifetime_default_none(tmp_path: Path) -> None:
     assert lock.lifetime is None
 
 
+@pytest.mark.parametrize("bad_value", [-1, -0.5, -1e9])
+def test_lifetime_setter_rejects_negative_number(bad_value: float, tmp_path: Path) -> None:
+    """Negative lifetime would always be considered expired and is rejected at the setter."""
+    lock = FileLock(tmp_path / "test.lock")
+    with pytest.raises(ValueError, match="non-negative"):
+        lock.lifetime = bad_value
+
+
+@pytest.mark.parametrize("bad_value", ["5", b"5", object(), [1], {1: 2}, complex(1, 0)])
+def test_lifetime_setter_rejects_non_numeric(bad_value: object, tmp_path: Path) -> None:
+    """Only None, int, and float are accepted by the lifetime setter."""
+    lock = FileLock(tmp_path / "test.lock")
+    with pytest.raises(TypeError, match="lifetime must be"):
+        lock.lifetime = bad_value  # type: ignore[assignment]
+
+
+def test_lifetime_setter_rejects_bool(tmp_path: Path) -> None:
+    """``bool`` is an ``int`` subclass in Python, so it would silently pass an int check; reject it explicitly."""
+    lock = FileLock(tmp_path / "test.lock")
+    with pytest.raises(TypeError, match="lifetime must be"):
+        lock.lifetime = True  # type: ignore[assignment]
+    with pytest.raises(TypeError, match="lifetime must be"):
+        lock.lifetime = False  # type: ignore[assignment]
+
+
+def test_lifetime_setter_accepts_zero(tmp_path: Path) -> None:
+    """Zero is the smallest legal value: an existing lock is considered expired immediately on the next acquire."""
+    lock = FileLock(tmp_path / "test.lock")
+    lock.lifetime = 0
+    assert lock.lifetime == 0
+    lock.lifetime = 0.0
+    assert lock.lifetime == 0.0
+
+
 def test_lifetime_singleton_mismatch(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock1 = FileLock(lock_path, is_singleton=True, lifetime=10.0)

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -73,6 +73,34 @@ def test_lifetime_default_none(tmp_path: Path) -> None:
     assert lock.lifetime is None
 
 
+@pytest.mark.parametrize("bad_value", [-1, -0.5, -1e9])
+def test_lifetime_setter_rejects_negative_number(bad_value: float, tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "test.lock")
+    with pytest.raises(ValueError, match="non-negative"):
+        lock.lifetime = bad_value
+
+
+@pytest.mark.parametrize("bad_value", ["5", b"5", object(), [1], {1: 2}, complex(1, 0)])
+def test_lifetime_setter_rejects_non_numeric(bad_value: object, tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "test.lock")
+    with pytest.raises(TypeError, match="lifetime must be"):
+        lock.lifetime = bad_value  # ty: ignore[invalid-assignment]
+
+
+@pytest.mark.parametrize("bad_value", [True, False])  # bool is an int subclass; reject it so it can't read as 1s/0s
+def test_lifetime_setter_rejects_bool(bad_value: bool, tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "test.lock")
+    with pytest.raises(TypeError, match="lifetime must be"):
+        lock.lifetime = bad_value
+
+
+@pytest.mark.parametrize("value", [0, 0.0])
+def test_lifetime_setter_accepts_zero(value: float, tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "test.lock")
+    lock.lifetime = value
+    assert lock.lifetime == 0
+
+
 def test_lifetime_singleton_mismatch(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock1 = FileLock(lock_path, is_singleton=True, lifetime=10.0)


### PR DESCRIPTION
lifetime.setter stored whatever it received and trusted the call site to pass a non-negative number. A negative value, a non-numeric string, or a bool (bool is a subclass of int, so it slipped past the int check) would be remembered as the expiration window and only blow up later inside _try_break_expired_lock, or quietly compare against st_mtime and behave in surprising ways.

Validate at the boundary the same way timeout.setter validates (it calls `float(value)` and lets `ValueError` propagate). The new behavior:

- `None` is accepted (disables expiration, the documented contract).
- `int` and `float` that are `>= 0` are accepted.
- `bool` is rejected with `TypeError` so `True`/`False` cannot be misread as a 1-second or 0-second lifetime.
- non-numeric objects raise `TypeError` with the offending type name instead of a confusing downstream `TypeError` in arithmetic.
- negative numbers raise `ValueError` with the offending value inlined, matching the docstring promise that lifetime is a maximum time in seconds.

Tests cover all of these cases. Verified with `python -m pytest tests/test_lock_expiry.py`: 28/28 pass. Test fails on the pre-fix code (DID NOT RAISE).

The constructor still accepts the same range of values for symmetry; tightening the constructor would be a wider API change and can be a follow-up.