### PR TITLE
Keep Unix lock files after release

### DIFF
--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -38,9 +38,9 @@ else:  # pragma: win32 no cover
         """
         Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems.
 
-        Lock file cleanup: Unix and macOS delete the lock file reliably after release, even in
-        multi-threaded scenarios. Unlike Windows, Unix allows unlinking files that other processes
-        have open.
+        The lock file is intentionally left in place after release. Unlinking a locked file on Unix
+        can split waiters across different inodes and break mutual exclusion for processes that
+        coordinate via the same path.
         """
 
         def _acquire(self) -> None:  # noqa: C901, PLR0912
@@ -103,10 +103,8 @@ else:  # pragma: win32 no cover
         def _release(self) -> None:
             fd = cast("int", self._context.lock_file_fd)
             self._context.lock_file_fd = None
-            with suppress(OSError):
-                Path(self.lock_file).unlink()
             fcntl.flock(fd, fcntl.LOCK_UN)
-            with suppress(OSError):  # close can raise EIO on FUSE/Docker bind-mount filesystems after unlink
+            with suppress(OSError):  # close can raise EIO on FUSE/Docker bind-mount filesystems
                 os.close(fd)
 
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -945,7 +945,7 @@ def test_mtime_zero_exit_branch(
         lock.acquire(timeout=0)
 
 
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+@pytest.mark.parametrize("lock_type", [SoftFileLock])
 def test_lock_file_removed_after_release(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     lock_path = tmp_path / "test.lock"
     lock = lock_type(str(lock_path))
@@ -955,7 +955,7 @@ def test_lock_file_removed_after_release(tmp_path: Path, lock_type: type[BaseFil
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
-def test_concurrent_acquire_release_removes_lock_file(tmp_path: Path) -> None:
+def test_concurrent_acquire_release_keeps_lock_file(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     errors: list[Exception] = []
 
@@ -974,11 +974,11 @@ def test_concurrent_acquire_release_removes_lock_file(tmp_path: Path) -> None:
     for thread in threads:
         thread.join(timeout=30)
     assert not errors, errors
-    assert not lock_path.exists()
+    assert lock_path.exists()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
-def test_lock_acquired_after_release_unlinks(tmp_path: Path) -> None:
+def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     first = FileLock(str(lock_path), is_singleton=False)
     second = FileLock(str(lock_path), is_singleton=False)
@@ -986,12 +986,39 @@ def test_lock_acquired_after_release_unlinks(tmp_path: Path) -> None:
     first.acquire()
     assert lock_path.exists()
     first.release()
-    assert not lock_path.exists()
+    assert lock_path.exists()
 
     second.acquire()
     assert lock_path.exists()
     second.release()
-    assert not lock_path.exists()
+    assert lock_path.exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
+def test_waiter_fd_cannot_split_lock_after_release(tmp_path: Path) -> None:
+    import fcntl
+    from errno import EAGAIN, EWOULDBLOCK
+
+    lock_path = tmp_path / "test.lock"
+    first = FileLock(str(lock_path), is_singleton=False)
+    replacement = FileLock(str(lock_path), is_singleton=False)
+
+    first.acquire()
+    waiter_fd = os.open(lock_path, os.O_RDWR)
+
+    try:
+        first.release()
+        assert lock_path.exists()
+
+        replacement.acquire()
+        try:
+            with pytest.raises(BlockingIOError) as exc_info:
+                fcntl.flock(waiter_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            assert exc_info.value.errno in {EAGAIN, EWOULDBLOCK}
+        finally:
+            replacement.release()
+    finally:
+        os.close(waiter_fd)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")


### PR DESCRIPTION
## Problem

Since `03b0ab7` (`feat(unix): delete lock file on release`), `UnixFileLock._release()` unlinks the path before unlocking and closing the fd. That lets a process that already opened the old inode keep waiting on that deleted file while another process recreates the filename and locks a new inode, so both can believe they hold the same lock.

Fixes #574.

## Solution

- stop unlinking the Unix lock file on release
- keep the Unix-specific expectations aligned with the persistent-path behavior
- add a regression that proves a waiter fd cannot acquire a different inode after another lock instance reacquires the same path

## Testing

- `.venv-ci/bin/python -m pytest tests/test_filelock.py tests/test_unix_fallback.py tests/test_self_deadlock.py -q`
- `.venv-ci/bin/python -m ruff check src/filelock/_unix.py tests/test_filelock.py tests/test_unix_fallback.py tests/test_self_deadlock.py`
- `.venv-ci/bin/python -m ruff format --check src/filelock/_unix.py tests/test_filelock.py tests/test_unix_fallback.py tests/test_self_deadlock.py`
