### PR TITLE
use a private break name in break_lock_file

### DIFF
--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 import stat
 import sys
 from errno import EACCES, EISDIR
@@ -65,6 +66,12 @@ def break_lock_file(lock_file: str, mtime_before: float, ino_before: int) -> Non
     be unlinked; the inode is the reliable identity, mirroring the token re-check in the soft read/write marker break.
     ``lstat`` is used so a hostile symlink swapped in after the decision is not followed.
 
+    The break name carries a random token so it is unguessable and unique per attempt. Without it two breakers in the
+    same process share ``<lock>.break.<pid>``, and a second break can rename a freshly recreated live lock onto that
+    path in the window between the re-verify ``lstat`` above and the ``unlink`` below, so we would delete a live lock
+    the inode check just approved. A private name means nobody else can target our break path, matching the soft
+    read/write marker break.
+
     :param lock_file: path to the lock file to break.
     :param mtime_before: modification time observed when the lock was judged stale.
     :param ino_before: inode number observed when the lock was judged stale.
@@ -72,7 +79,7 @@ def break_lock_file(lock_file: str, mtime_before: float, ino_before: int) -> Non
     :raises OSError: if the rename fails (e.g. the file vanished or is not owned in a sticky directory).
 
     """
-    break_path = f"{lock_file}.break.{os.getpid()}"
+    break_path = f"{lock_file}.break.{os.getpid()}.{secrets.token_hex(16)}"
     Path(lock_file).rename(break_path)
     try:
         st_after = os.lstat(break_path)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -78,12 +78,10 @@ def test_break_lock_file_break_path_not_targetable_by_a_peer(tmp_path: Path, moc
     # re-verify lstat and the unlink, and we would delete a live lock the inode check just approved.
     predictable = tmp_path / f"test.lock.break.{os.getpid()}"
     real_lstat = os.lstat
-    fired = {"x": False}
 
     def lstat_hook(path: str) -> os.stat_result:
         result = real_lstat(path)
-        if not fired["x"] and ".break." in path:
-            fired["x"] = True
+        if ".break." in path and not predictable.exists():  # once: the peer recreates a live lock at its own name
             lock.write_text("live", encoding="utf-8")
             lock.rename(predictable)
         return result

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -68,6 +68,32 @@ def test_break_lock_file_missing_source_raises(tmp_path: Path) -> None:
         break_lock_file(str(tmp_path / "nope.lock"), 0.0, 0)
 
 
+def test_break_lock_file_break_path_not_targetable_by_a_peer(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = tmp_path / "test.lock"
+    lock.write_text("stale", encoding="utf-8")
+    st = os.lstat(lock)
+
+    # A second breaker in the same process independently computes this name (no random token). If break_lock_file
+    # used it too, the peer could rename a freshly recreated live lock onto our break path in the window between the
+    # re-verify lstat and the unlink, and we would delete a live lock the inode check just approved.
+    predictable = tmp_path / f"test.lock.break.{os.getpid()}"
+    real_lstat = os.lstat
+    fired = {"x": False}
+
+    def lstat_hook(path: str) -> os.stat_result:
+        result = real_lstat(path)
+        if not fired["x"] and ".break." in path:
+            fired["x"] = True
+            lock.write_text("live", encoding="utf-8")
+            lock.rename(predictable)
+        return result
+
+    mocker.patch("filelock._util.os.lstat", side_effect=lstat_hook)
+    break_lock_file(str(lock), st.st_mtime, st.st_ino)
+
+    assert predictable.read_text(encoding="utf-8") == "live"
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="symlink-to-dir raises IsADirectoryError only on Unix")
 def test_raise_on_not_writable_file_does_not_follow_symlink_to_dir(tmp_path: Path) -> None:
     target = tmp_path / "targetdir"


### PR DESCRIPTION
Supersedes #576 — that PR had maintainer edits disabled on the fork, so I could not push the follow-up. This keeps @dxbjavid's original commit and adds a small test tidy on top.

`break_lock_file` renamed a stale lock aside to a fixed `<lock>.break.<pid>` before re-checking and unlinking it. Two breakers in the same process share that name, so a second break can rename a freshly recreated live lock onto that path in the window between the re-verify `lstat` and the `unlink`, and the first breaker then deletes a live lock the inode check just approved. This appends a random token to the break name (matching the soft read/write marker break) so no peer can target our break path.