### PR TITLE
test: fix Windows type check broken by #577

### DIFF
--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -7,7 +7,7 @@ import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from errno import ENOSYS
+from errno import EAGAIN, ENOSYS, EWOULDBLOCK
 from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
@@ -994,10 +994,10 @@ def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
     assert lock_path.exists()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
 def test_waiter_fd_cannot_split_lock_after_release(tmp_path: Path) -> None:
+    if sys.platform == "win32":  # pragma: win32 cover  # Unix flock semantics; also narrows fcntl for the type checker
+        return
     import fcntl
-    from errno import EAGAIN, EWOULDBLOCK
 
     lock_path = tmp_path / "test.lock"
     first = FileLock(str(lock_path), is_singleton=False)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -78,12 +78,10 @@ def test_break_lock_file_break_path_not_targetable_by_a_peer(tmp_path: Path, moc
     # re-verify lstat and the unlink, and we would delete a live lock the inode check just approved.
     predictable = tmp_path / f"test.lock.break.{os.getpid()}"
     real_lstat = os.lstat
-    fired = {"x": False}
 
     def lstat_hook(path: str) -> os.stat_result:
         result = real_lstat(path)
-        if not fired["x"] and ".break." in path:
-            fired["x"] = True
+        if ".break." in path and not predictable.exists():  # once: the peer recreates a live lock at its own name
             lock.write_text("live", encoding="utf-8")
             lock.rename(predictable)
         return result


### PR DESCRIPTION
#577's waiter-fd test was merged without the full type matrix running, and it broke `main`'s `type - windows-2025` job: the test calls `fcntl.flock` / `LOCK_EX` / `LOCK_NB`, which `ty` rejects on Windows because `pytest.mark.skipif` doesn't narrow the platform for the type checker. Every PR built against `main` (e.g. #573, #575) now inherits that red Windows type job.

Fix: guard the Unix-only body behind a static `if sys.platform == "win32": return`, so `ty` narrows `fcntl` away on Windows — the same pattern `src/filelock/_unix.py` already uses. Verified with `ty check --python-platform win32` and `--python-platform linux`.

Two small test tidies folded in while here:
- hoist the cross-platform `errno` constants to the module imports (only `fcntl` needs to stay local)
- drop the mutable `fired` dict flag from the break-name test; the peer's recreated lock is the one-shot guard

No behavior change; the break-name test still fails on pre-#576 code and passes on `main`.