### PR TITLE
serialise singleton construction in FileLockMeta

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -9,7 +9,7 @@ import time
 import warnings
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from threading import local
+from threading import Lock, local
 from typing import TYPE_CHECKING, Any, TypeVar
 from weakref import WeakValueDictionary
 
@@ -112,6 +112,7 @@ _T = TypeVar("_T", bound="BaseFileLock")
 
 class FileLockMeta(ABCMeta):
     _instances: WeakValueDictionary[str, BaseFileLock]
+    _instances_lock: Lock
 
     def __call__(  # noqa: PLR0913
         cls: type[_T],
@@ -126,33 +127,79 @@ class FileLockMeta(ABCMeta):
         lifetime: float | None = None,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
-        if is_singleton:
+        if not is_singleton:
+            return cls._create_instance(
+                lock_file,
+                timeout,
+                mode,
+                thread_local,
+                blocking=blocking,
+                is_singleton=is_singleton,
+                poll_interval=poll_interval,
+                lifetime=lifetime,
+                **kwargs,
+            )
+
+        # The lookup, construction and store have to happen under one lock. Without it two threads racing the
+        # first construction for a path each miss the cache and build their own instance, so callers that pass
+        # is_singleton to get reentrant locking across instances end up holding two different "singletons" and
+        # the deadlock check in acquire() then rejects a legitimate reentrant acquire. The unguarded writes to
+        # the shared WeakValueDictionary are a data race in their own right. ReadWriteLock and SoftReadWriteLock
+        # already serialise their singleton caches this way.
+        with cls._instances_lock:
             instance = cls._instances.get(str(lock_file))
-            if instance:
-                params_to_check = {
-                    "thread_local": (thread_local, instance.is_thread_local()),
-                    "timeout": (timeout, instance.timeout),
-                    "mode": (mode, instance._context.mode),  # noqa: SLF001
-                    "blocking": (blocking, instance.blocking),
-                    "poll_interval": (poll_interval, instance.poll_interval),
-                    "lifetime": (lifetime, instance.lifetime),
-                }
+            if instance is None:
+                instance = cls._create_instance(
+                    lock_file,
+                    timeout,
+                    mode,
+                    thread_local,
+                    blocking=blocking,
+                    is_singleton=is_singleton,
+                    poll_interval=poll_interval,
+                    lifetime=lifetime,
+                    **kwargs,
+                )
+                cls._instances[str(lock_file)] = instance
+                return instance
 
-                non_matching_params = {
-                    name: (passed_param, set_param)
-                    for name, (passed_param, set_param) in params_to_check.items()
-                    if passed_param != set_param
-                }
-                if not non_matching_params:
-                    return instance  # ty: ignore[invalid-return-type]  # https://github.com/astral-sh/ty/issues/3231
+        params_to_check = {
+            "thread_local": (thread_local, instance.is_thread_local()),
+            "timeout": (timeout, instance.timeout),
+            "mode": (mode, instance._context.mode),  # noqa: SLF001
+            "blocking": (blocking, instance.blocking),
+            "poll_interval": (poll_interval, instance.poll_interval),
+            "lifetime": (lifetime, instance.lifetime),
+        }
 
-                # parameters do not match; raise error
-                msg = "Singleton lock instances cannot be initialized with differing arguments"
-                msg += "\nNon-matching arguments: "
-                for param_name, (passed_param, set_param) in non_matching_params.items():
-                    msg += f"\n\t{param_name} (existing lock has {set_param} but {passed_param} was passed)"
-                raise ValueError(msg)
+        non_matching_params = {
+            name: (passed_param, set_param)
+            for name, (passed_param, set_param) in params_to_check.items()
+            if passed_param != set_param
+        }
+        if not non_matching_params:
+            return instance  # ty: ignore[invalid-return-type]  # https://github.com/astral-sh/ty/issues/3231
 
+        # parameters do not match; raise error
+        msg = "Singleton lock instances cannot be initialized with differing arguments"
+        msg += "\nNon-matching arguments: "
+        for param_name, (passed_param, set_param) in non_matching_params.items():
+            msg += f"\n\t{param_name} (existing lock has {set_param} but {passed_param} was passed)"
+        raise ValueError(msg)
+
+    def _create_instance(  # noqa: PLR0913
+        cls: type[_T],
+        lock_file: str | os.PathLike[str],
+        timeout: float,
+        mode: int,
+        thread_local: bool,  # noqa: FBT001
+        *,
+        blocking: bool,
+        is_singleton: bool,
+        poll_interval: float,
+        lifetime: float | None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> _T:
         # Workaround to make `__init__`'s params optional in subclasses
         # E.g. virtualenv changes the signature of the `__init__` method in the `BaseFileLock` class descendant
         # (https://github.com/tox-dev/filelock/pull/340)
@@ -171,12 +218,7 @@ class FileLockMeta(ABCMeta):
         present_params = inspect.signature(cls.__init__).parameters
         init_params = {key: value for key, value in all_params.items() if key in present_params}
 
-        instance = super().__call__(lock_file, **init_params)
-
-        if is_singleton:
-            cls._instances[str(lock_file)] = instance
-
-        return instance
+        return super().__call__(lock_file, **init_params)
 
 
 class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
@@ -190,11 +232,13 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     """
 
     _instances: WeakValueDictionary[str, BaseFileLock]
+    _instances_lock: Lock
 
     def __init_subclass__(cls, **kwargs: dict[str, Any]) -> None:
         """Setup unique state for lock subclasses."""
         super().__init_subclass__(**kwargs)
         cls._instances = WeakValueDictionary()
+        cls._instances_lock = Lock()
 
     def __init__(  # noqa: PLR0913
         self,

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -127,39 +127,27 @@ class FileLockMeta(ABCMeta):
         lifetime: float | None = None,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
+        params = {
+            "timeout": timeout,
+            "mode": mode,
+            "thread_local": thread_local,
+            "blocking": blocking,
+            "is_singleton": is_singleton,
+            "poll_interval": poll_interval,
+            "lifetime": lifetime,
+            **kwargs,
+        }
         if not is_singleton:
-            return cls._create_instance(
-                lock_file,
-                timeout,
-                mode,
-                thread_local,
-                blocking=blocking,
-                is_singleton=is_singleton,
-                poll_interval=poll_interval,
-                lifetime=lifetime,
-                **kwargs,
-            )
+            return cls._create_instance(lock_file, params)
 
-        # The lookup, construction and store have to happen under one lock. Without it two threads racing the
-        # first construction for a path each miss the cache and build their own instance, so callers that pass
-        # is_singleton to get reentrant locking across instances end up holding two different "singletons" and
-        # the deadlock check in acquire() then rejects a legitimate reentrant acquire. The unguarded writes to
-        # the shared WeakValueDictionary are a data race in their own right. ReadWriteLock and SoftReadWriteLock
-        # already serialise their singleton caches this way.
+        # Look up, build and store under one lock. Without it two threads racing the first construction for a
+        # path both miss the cache and each build their own instance, so callers relying on is_singleton for
+        # reentrant locking across instances end up with two "singletons" and acquire()'s deadlock check then
+        # rejects a legitimate reentrant acquire; the unguarded writes to the WeakValueDictionary are a data
+        # race besides. ReadWriteLock and SoftReadWriteLock already guard their singleton caches this way.
         with cls._instances_lock:
-            instance = cls._instances.get(str(lock_file))
-            if instance is None:
-                instance = cls._create_instance(
-                    lock_file,
-                    timeout,
-                    mode,
-                    thread_local,
-                    blocking=blocking,
-                    is_singleton=is_singleton,
-                    poll_interval=poll_interval,
-                    lifetime=lifetime,
-                    **kwargs,
-                )
+            if (instance := cls._instances.get(str(lock_file))) is None:
+                instance = cls._create_instance(lock_file, params)
                 cls._instances[str(lock_file)] = instance
                 return instance
 
@@ -187,37 +175,11 @@ class FileLockMeta(ABCMeta):
             msg += f"\n\t{param_name} (existing lock has {set_param} but {passed_param} was passed)"
         raise ValueError(msg)
 
-    def _create_instance(  # noqa: PLR0913
-        cls: type[_T],
-        lock_file: str | os.PathLike[str],
-        timeout: float,
-        mode: int,
-        thread_local: bool,  # noqa: FBT001
-        *,
-        blocking: bool,
-        is_singleton: bool,
-        poll_interval: float,
-        lifetime: float | None,
-        **kwargs: Any,  # noqa: ANN401
-    ) -> _T:
-        # Workaround to make `__init__`'s params optional in subclasses
-        # E.g. virtualenv changes the signature of the `__init__` method in the `BaseFileLock` class descendant
-        # (https://github.com/tox-dev/filelock/pull/340)
-
-        all_params = {
-            "timeout": timeout,
-            "mode": mode,
-            "thread_local": thread_local,
-            "blocking": blocking,
-            "is_singleton": is_singleton,
-            "poll_interval": poll_interval,
-            "lifetime": lifetime,
-            **kwargs,
-        }
-
+    def _create_instance(cls: type[_T], lock_file: str | os.PathLike[str], params: dict[str, Any]) -> _T:
+        # Keep only the params this subclass's __init__ accepts: virtualenv narrows the signature of its
+        # BaseFileLock descendant, so passing the full set would break it (https://github.com/tox-dev/filelock/pull/340).
         present_params = inspect.signature(cls.__init__).parameters
-        init_params = {key: value for key, value in all_params.items() if key in present_params}
-
+        init_params = {key: value for key, value in params.items() if key in present_params}
         return super().__call__(lock_file, **init_params)
 
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from errno import EAGAIN, ENOSYS, EWOULDBLOCK
@@ -833,6 +834,32 @@ def test_singleton_locks_are_the_same(lock_type: type[BaseFileLock], tmp_path: P
 
     lock_2 = lock_type(str(lock_path), is_singleton=True)
     assert lock_2 is lock_1
+
+
+def test_singleton_locks_survive_concurrent_first_construction(tmp_path: Path) -> None:
+    # Two threads constructing the same is_singleton=True lock at once must still share one instance. A slow
+    # __init__ widens the window between the cache miss and the store so the race is hit deterministically.
+    lock_path = tmp_path / "a"
+
+    class _SlowLock(SoftFileLock):
+        def __init__(self, lock_file: str, *, is_singleton: bool = True) -> None:
+            time.sleep(0.05)
+            super().__init__(lock_file, is_singleton=is_singleton)
+
+    results: list[BaseFileLock] = []
+    barrier = threading.Barrier(2)
+
+    def build() -> None:
+        barrier.wait()
+        results.append(_SlowLock(str(lock_path), is_singleton=True))
+
+    threads = [threading.Thread(target=build) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results[0] is results[1]
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])


### PR DESCRIPTION
FileLockMeta.__call__ reads and writes its singleton cache without a lock, so two threads constructing the same is_singleton=True lock for a fresh path both miss the cache and each build their own instance. That quietly breaks the singleton guarantee callers lean on for reentrant locking across instances, so a later reentrant acquire on what should be the same lock can hit the deadlock check in acquire(), and the concurrent writes to the shared WeakValueDictionary are a race in their own right. ReadWriteLock and SoftReadWriteLock already take their _instances_lock around the get-or-create, so this brings the base metaclass in line.