### PR TITLE
test: silence fork DeprecationWarning on 3.15

### DIFF
--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -1042,6 +1042,10 @@ def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:
 
 @requires_fork
 @pytest.mark.timeout(15)
+# Holding the write lock keeps the heartbeat thread alive, so this fork is necessarily from a multi-threaded
+# process and Python 3.15 warns that it may deadlock. That is the scenario under test, and it is already safe:
+# register_at_fork resets inherited state in the child (any child use raises "invalidated by fork()"). Expected.
+@pytest.mark.filterwarnings("ignore:.*multi-threaded, use of fork.*:DeprecationWarning")
 def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:
     path = str(tmp_path / "foo.lock")
     lock = SoftReadWriteLock(path, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)


### PR DESCRIPTION
## What

Python 3.15 emits a `DeprecationWarning` when `os.fork()` is called from a multi-threaded process (reported in #584). `test_parent_retains_lock_across_fork` holds the write lock — which keeps the heartbeat thread alive — so its fork is necessarily multi-threaded. That is the exact scenario the test exercises ("does the parent keep its write lock across a fork"), and it is already safe: `os.register_at_fork(after_in_child=_reset_all_after_fork)` resets inherited state in the child, and any child use of the inherited lock raises `"invalidated by fork()"`.

So the warning is expected, already-handled behaviour, not a filelock defect — there is nothing in production code to fix. `filterwarnings = ["error"]` would otherwise promote it to a test failure, so it is scoped-ignored on that one test. The sibling fork tests fork inside `spawn`-launched subprocesses, so their warnings never reach pytest's filters.

Fixes #584