### PR TITLE
_util: drop the dead st_mtime=0 short-circuit in raise_on_not_writable_file

### DIFF
--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -12,37 +12,32 @@ def raise_on_not_writable_file(filename: str) -> None:
     """
     Raise an exception if attempting to open the file for writing would fail.
 
-    This is done so files that will never be writable can be separated from files that are writable but currently
-    locked.
+    Separates files that can never be written from files that are writable but currently locked.
 
     :param filename: file to check
 
     :raises OSError: as if the file was opened for writing.
 
     """
-    try:  # use lstat to do exists + can write to check without race condition
-        # lstat, not stat: a hostile symlink planted at the lock path would otherwise make this check inspect the
-        # link target, so an attacker could turn a contended acquire into a misleading PermissionError /
-        # IsADirectoryError and probe the target's attributes. The actual open uses O_NOFOLLOW and refuses the
-        # symlink anyway, so reading the link itself here keeps the handling consistent with the rest of the module.
+    try:
+        # lstat, not stat: it settles exists-and-writable in one syscall, and a hostile symlink planted at the lock
+        # path would otherwise make this inspect the link target, letting an attacker turn a contended acquire into a
+        # misleading PermissionError / IsADirectoryError and probe that target's attributes. The real open passes
+        # O_NOFOLLOW and refuses the symlink anyway.
         file_stat = os.lstat(filename)
     except OSError:
-        return  # swallow does not exist or other errors
+        return  # does not exist, or an error the caller cannot act on
 
-    # No mtime guard: the old `if st_mtime != 0` skip existed for very old NFS/Linux quirks where os.lstat could
-    # return an all-zero struct, which it never does today for a file that exists. Skipping the checks when mtime
-    # happened to be 0 let a read-only file or a directory in the lock path pass as missing, so acquire() then
-    # blocked forever waiting on an open that cannot succeed (or locked a file nothing else can write).
+    # No mtime guard: the old `if st_mtime != 0` skip existed for NFS/Linux quirks where os.lstat could return an
+    # all-zero struct, which it no longer does. Skipping on mtime 0 let a read-only file or a directory at the lock
+    # path pass as missing, so acquire() blocked forever on an open that cannot succeed.
     if not (file_stat.st_mode & stat.S_IWUSR):
         raise PermissionError(EACCES, "Permission denied", filename)
 
     if stat.S_ISDIR(file_stat.st_mode):
         if sys.platform == "win32":  # pragma: win32 cover
-            # On Windows, this is PermissionError
             raise PermissionError(EACCES, "Permission denied", filename)
-        else:  # pragma: win32 no cover # noqa: RET506
-            # On linux / macOS, this is IsADirectoryError
-            raise IsADirectoryError(EISDIR, "Is a directory", filename)
+        raise IsADirectoryError(EISDIR, "Is a directory", filename)  # pragma: win32 no cover
 
 
 def ensure_directory_exists(filename: Path | str) -> None:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -954,8 +954,7 @@ def test_file_lock_positional_argument(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform != "win32" and os.geteuid() == 0, reason="root can open a 0o444 file for writing")
 @pytest.mark.parametrize("lock_type", [SoftFileLock, FileLock])
 def test_readonly_lock_file_with_mtime_zero_raises(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # A read-only lock file whose mtime is 0 must still be rejected: acquire() no longer short-circuits the
-    # writability check on mtime == 0, so it reports the file can never be opened for writing.
+    # acquire() no longer short-circuits the writability check on mtime 0, so a read-only lock file is still rejected.
     lock_path = tmp_path / "z.lock"
     lock_path.touch()
     lock_path.chmod(0o444)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -142,11 +142,9 @@ def test_raise_on_not_writable_file_still_rejects_readonly_file(tmp_path: Path) 
         path.chmod(0o644)
 
 
-# raise_on_not_writable_file no longer short-circuits on mtime == 0 (the old `if st_mtime != 0` guard existed for
-# very old NFS/Linux quirks where os.lstat could return an all-zero struct; it can't today). Writability is
-# independent of mtime, so both an mtime of 0 and a far-future mtime must still reject a read-only file — the
-# latter case pins that a later patch can't narrow the check to one mtime range. The verdict is mode-based, not
-# access-based, so it holds regardless of euid (no root skip, unlike the acquire-level test in test_filelock.py).
+# Writability follows the mode bits, so a read-only file is rejected whatever its mtime. The far-future row pins that
+# a later patch cannot narrow the check back to a single mtime range. The check reads the mode rather than probing
+# real access, so it holds for root too and needs no euid skip.
 @pytest.mark.parametrize("mtime", [0, 2_000_000_000], ids=["mtime-zero", "mtime-future"])
 def test_raise_on_not_writable_file_rejects_readonly_file_any_mtime(tmp_path: Path, mtime: int) -> None:
     path = tmp_path / "ro.lock"


### PR DESCRIPTION
The guard predated the lstat-symlink hardening (PR #567) and was meant to defend against old platforms where os.stat could return an all-zero struct for a file that exists.