### PR TITLE
🐛 fix(api): ignore lifetime on native OS locks

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -40,6 +40,26 @@ _LOGGER: Final[logging.Logger] = logging.getLogger("filelock")
 _canonical: Final[Callable[[str], str]] = os.path.abspath if sys.platform == "win32" else os.path.realpath
 
 
+def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str) -> float | None:
+    """
+    Drop a ``lifetime`` a lock cannot honor.
+
+    ``lifetime`` is a deliberate age-based lease: a lock file older than ``lifetime`` is broken even while its holder is
+    still alive. That is only safe for existence locks (:class:`SoftFileLock`), where breaking means unlinking a
+    pathname the protocol already treats as reclaimable. A native OS lock lives on the inode, so unlinking the pathname
+    by age cannot revoke the kernel lock; a contender would lock a fresh inode and overlap the live holder (#590).
+    Ignore the request with a warning rather than accept a setting that breaks mutual exclusion.
+    """
+    if lifetime is not None and not supported:
+        warnings.warn(
+            f"lifetime is ignored for {cls_name}: a native OS lock cannot be broken safely by file age; "
+            f"only SoftFileLock supports lifetime-based expiry",
+            stacklevel=3,
+        )
+        return None
+    return lifetime
+
+
 class _ThreadLocalRegistry(local):
     def __init__(self) -> None:
         super().__init__()
@@ -69,6 +89,7 @@ class FileLockMeta(ABCMeta):
         lifetime: float | None = None,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
+        lifetime = _resolve_lifetime(lifetime, supported=cls._lifetime_supported, cls_name=cls.__name__)
         params = {
             "timeout": timeout,
             "mode": mode,
@@ -138,6 +159,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     #: How the cross-instance deadlock message names the conflicting holder; the async subclass says "task".
     _deadlock_holder_desc: str = "FileLock instance in this thread"
 
+    #: Whether an age-based :attr:`lifetime` lease may break this lock. Only existence locks set it (they reclaim by
+    #: unlinking a pathname); native OS locks leave it ``False`` since a kernel lock cannot be revoked by file age.
+    _lifetime_supported: bool = False
+
     def __init_subclass__(cls, **kwargs: dict[str, Any]) -> None:
         """Give each lock subclass its own singleton registry and lock."""
         super().__init_subclass__(**kwargs)
@@ -178,9 +203,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             same object around.
         :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback value
             in the acquire method, if no poll_interval value (``None``) is given.
-        :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set, a waiting
-            process will break a lock whose file modification time is older than ``lifetime`` seconds. ``None`` (the
-            default) means locks never expire.
+        :param lifetime: for :class:`SoftFileLock`, the maximum time in seconds a lock may be held before it expires: a
+            waiting process breaks a lock file whose modification time is older than ``lifetime`` seconds, even if the
+            holder is still alive. ``None`` (the default) means locks never expire. Native OS locks (:class:`FileLock`)
+            cannot be revoked by file age and ignore a non-``None`` ``lifetime`` with a warning.
 
         """
         self._is_thread_local = thread_local
@@ -304,7 +330,9 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             if value < 0:
                 msg = f"lifetime must be non-negative, not {value!r}"
                 raise ValueError(msg)
-        self._context.lifetime = value
+        self._context.lifetime = _resolve_lifetime(
+            value, supported=self._lifetime_supported, cls_name=type(self).__name__
+        )
 
     @property
     def mode(self) -> int:

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -33,6 +33,9 @@ class SoftFileLock(BaseFileLock):
 
     """
 
+    #: Existence locks reclaim by unlinking a pathname, so an age-based lease may break one; a native inode lock cannot.
+    _lifetime_supported: bool = True
+
     def _acquire(self) -> None:
         raise_on_not_writable_file(self.lock_file)
         ensure_directory_exists(self.lock_file)

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -116,9 +116,11 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             same object around.
         :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback value
             in the acquire method, if no poll_interval value (``None``) is given.
-        :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set, a waiting
-            process will break a lock whose file modification time is older than ``lifetime`` seconds. ``None`` (the
-            default) means locks never expire.
+        :param lifetime: for :class:`AsyncSoftFileLock`, the maximum time in seconds a lock may be held before it
+            expires: a waiting process breaks a lock file whose modification time is older than ``lifetime`` seconds,
+            even if the holder is still alive. ``None`` (the default) means locks never expire. Native OS locks
+            (:class:`AsyncFileLock`) cannot be revoked by file age and ignore a non-``None`` ``lifetime``, with a
+            warning.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -3,27 +3,52 @@ from __future__ import annotations
 import os
 import socket
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
-from filelock import AsyncFileLock, AsyncSoftFileLock, FileLock, SoftFileLock
+from filelock import AsyncFileLock, AsyncSoftFileLock, FileLock, SoftFileLock, Timeout
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from pytest_mock import MockerFixture
 
+_NATIVE_IGNORES: Final[str] = "lifetime is ignored"
 
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_expired_lock_is_broken(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
+
+def test_expired_soft_lock_is_broken(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
     os.utime(lock_path, (0, 0))
 
-    lock = lock_type(lock_path, lifetime=0.1, timeout=1)
+    lock = SoftFileLock(lock_path, lifetime=0.1, timeout=1)
     with lock:
         assert lock.is_locked
+
+
+@pytest.mark.parametrize("lock_type", [FileLock, AsyncFileLock])
+def test_native_lifetime_warns_and_is_ignored(lock_type: type[FileLock | AsyncFileLock], tmp_path: Path) -> None:
+    with pytest.warns(UserWarning, match=_NATIVE_IGNORES):
+        lock = lock_type(tmp_path / "test.lock", lifetime=10.0)
+    assert lock.lifetime is None
+
+
+def test_native_lifetime_setter_warns_and_is_ignored(tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "test.lock")
+    with pytest.warns(UserWarning, match=_NATIVE_IGNORES):
+        lock.lifetime = 10.0
+    assert lock.lifetime is None
+
+
+def test_native_lifetime_does_not_break_live_holder(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    with FileLock(lock_path, timeout=0):
+        os.utime(lock_path, (0, 0))  # a broken age-based break would evict this live holder
+        with pytest.warns(UserWarning, match=_NATIVE_IGNORES):
+            contender = FileLock(lock_path, lifetime=0.1, timeout=0.3)
+        with pytest.raises(Timeout):
+            contender.acquire()
 
 
 def test_soft_non_expired_lock_not_broken(tmp_path: Path) -> None:
@@ -55,7 +80,7 @@ def test_expired_lock_race_rename_fails(tmp_path: Path, mocker: MockerFixture) -
 
 
 def test_lifetime_property_getter_setter(tmp_path: Path) -> None:
-    lock = FileLock(tmp_path / "test.lock", lifetime=10.0)
+    lock = SoftFileLock(tmp_path / "test.lock", lifetime=10.0)
     assert lock.lifetime == pytest.approx(10.0)
 
     lock.lifetime = 20.0
@@ -92,41 +117,39 @@ def test_lifetime_setter_rejects_bool(bad_value: bool, tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("value", [0, 0.0])
 def test_lifetime_setter_accepts_zero(value: float, tmp_path: Path) -> None:
-    lock = FileLock(tmp_path / "test.lock")
+    lock = SoftFileLock(tmp_path / "test.lock")
     lock.lifetime = value
     assert lock.lifetime == 0
 
 
 def test_lifetime_singleton_mismatch(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
-    lock1 = FileLock(lock_path, is_singleton=True, lifetime=10.0)
+    lock1 = SoftFileLock(lock_path, is_singleton=True, lifetime=10.0)
     assert lock1.lifetime == pytest.approx(10.0)
 
     with pytest.raises(ValueError, match="lifetime"):
-        FileLock(lock_path, is_singleton=True, lifetime=20.0)
+        SoftFileLock(lock_path, is_singleton=True, lifetime=20.0)
 
 
 def test_lifetime_singleton_match(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
-    lock1 = FileLock(lock_path, is_singleton=True, lifetime=10.0)
-    lock2 = FileLock(lock_path, is_singleton=True, lifetime=10.0)
+    lock1 = SoftFileLock(lock_path, is_singleton=True, lifetime=10.0)
+    lock2 = SoftFileLock(lock_path, is_singleton=True, lifetime=10.0)
     assert lock1 is lock2
 
 
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_lock_file_missing_during_expiry_check(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
-    lock = lock_type(tmp_path / "test.lock", lifetime=0.1, timeout=1)
+def test_lock_file_missing_during_expiry_check(tmp_path: Path) -> None:
+    lock = SoftFileLock(tmp_path / "test.lock", lifetime=0.1, timeout=1)
     with lock:
         assert lock.is_locked
 
 
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_expired_lock_becomes_acquirable(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
+def test_expired_lock_becomes_acquirable(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
     os.utime(lock_path, (0, 0))
 
-    lock = lock_type(lock_path, lifetime=0.5, timeout=1)
+    lock = SoftFileLock(lock_path, lifetime=0.5, timeout=1)
     with lock:
         assert lock.is_locked
     assert not lock.is_locked
@@ -138,7 +161,7 @@ async def test_async_expired_lock_is_broken(tmp_path: Path) -> None:
     lock_path.touch()
     os.utime(lock_path, (0, 0))
 
-    lock = AsyncFileLock(lock_path, lifetime=0.1, timeout=1)
+    lock = AsyncSoftFileLock(lock_path, lifetime=0.1, timeout=1)
     async with lock:
         assert lock.is_locked
 
@@ -152,11 +175,9 @@ async def test_async_soft_non_expired_lock_not_broken(tmp_path: Path) -> None:
         await AsyncSoftFileLock(lock_path, lifetime=9999, timeout=0.2).acquire()
 
 
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_lock_mtime_updated_on_acquire(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
+def test_lock_mtime_updated_on_acquire(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     before = time.time()
-    lock = lock_type(lock_path, lifetime=60)
-    with lock:
+    with SoftFileLock(lock_path, lifetime=60):
         if lock_path.exists():
             assert lock_path.stat().st_mtime >= before - 1


### PR DESCRIPTION
Setting a non-`None` `lifetime` on a native `FileLock` could break mutual exclusion, as reported in #590. When the lock file's modification time aged past the configured lifetime, a waiter would rename and unlink the path and then create and lock a fresh inode, while the original process still held its `flock`/`msvcrt` lock on the old inode. Two processes then believed they held the same lock. The inode recheck in `break_lock_file` guards against replacing a different file mid-break, but it cannot prove the inode is not currently locked by a live holder.

`lifetime` is a deliberate age-based lease: a lock file older than `lifetime` is broken even while its holder is alive. That is safe only for existence locks, where breaking means unlinking a pathname the protocol already treats as reclaimable; a native kernel lock cannot be revoked through the pathname at all. This adds a `_lifetime_supported` capability flag that only `SoftFileLock` sets, and routes every `lifetime` through a resolver that drops it for locks which cannot honor it. A native lock now warns and ignores a non-`None` `lifetime`, both at construction and through the property setter, so the setting can no longer defeat the lock's core guarantee.

`SoftFileLock` and `AsyncSoftFileLock` keep their existing lease behavior. Callers who relied on `lifetime` with `FileLock` or `AsyncFileLock` will see it ignored with a warning rather than applied unsafely; a stale-holder lease for native locks would need holder cooperation and fencing, not pathname age alone.

Fixes #590.
