### PR TITLE
✨ feat(api): add optional lock-file opener hook

### DIFF
--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -12,7 +12,7 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Final
 
-from ._api import AcquireReturnProxy, BaseFileLock
+from ._api import AcquireReturnProxy, BaseFileLock, FileOpener
 from ._error import Timeout
 
 if TYPE_CHECKING:
@@ -82,6 +82,7 @@ __all__ = [
     "BaseAsyncFileLock",
     "BaseFileLock",
     "FileLock",
+    "FileOpener",
     "ReadWriteLock",
     "SoftFileLock",
     "SoftReadWriteLock",

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -10,7 +10,7 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import Lock, local
-from typing import TYPE_CHECKING, Any, Final, TypeVar
+from typing import TYPE_CHECKING, Any, Final, Protocol, TypeVar
 from weakref import WeakValueDictionary
 
 from ._error import Timeout
@@ -19,6 +19,22 @@ from ._util import break_lock_file
 #: No explicit file permission mode was passed. Lock files then open with 0o666 so umask and default ACLs pick
 #: the final permissions, and fchmod is skipped to preserve POSIX default ACL inheritance.
 _UNSET_FILE_MODE: Final[int] = -1
+
+
+class FileOpener(Protocol):
+    """Opener for the lock-file descriptor, standing in for the ``os.open`` call a backend would otherwise make."""
+
+    def __call__(self, path: str, flags: int, mode: int, /) -> int:
+        """:returns: an open file descriptor for *path*, opened with *flags* and *mode*."""
+
+
+class _OpenerFailed(Exception):  # noqa: N818
+    """Carries an opener's own exception past backend contention handling so acquire can re-raise it unchanged."""
+
+    def __init__(self, cause: BaseException) -> None:
+        super().__init__()
+        self.cause = cause
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -67,6 +83,7 @@ class FileLockMeta(ABCMeta):
         is_singleton: bool = False,
         poll_interval: float = 0.05,
         lifetime: float | None = None,
+        opener: FileOpener | None = None,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
         params = {
@@ -77,6 +94,7 @@ class FileLockMeta(ABCMeta):
             "is_singleton": is_singleton,
             "poll_interval": poll_interval,
             "lifetime": lifetime,
+            "opener": opener,
             **kwargs,
         }
         if not is_singleton:
@@ -101,11 +119,15 @@ class FileLockMeta(ABCMeta):
             "poll_interval": (poll_interval, instance.poll_interval),
             "lifetime": (lifetime, instance.lifetime),
         }
-        non_matching_params = {
+        non_matching_params: dict[str, tuple[Any, Any]] = {
             name: (passed_param, set_param)
             for name, (passed_param, set_param) in params_to_check.items()
             if passed_param != set_param
         }
+        # An opener is a callback: two equal-but-distinct callables would still open differently, so require the
+        # same object rather than value equality (a stateful callable could even compare equal to another).
+        if opener is not instance._context.opener:  # noqa: SLF001
+            non_matching_params["opener"] = (opener, instance._context.opener)  # noqa: SLF001
         if not non_matching_params:
             return instance  # ty: ignore[invalid-return-type]  # https://github.com/astral-sh/ty/issues/3231
 
@@ -155,6 +177,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         is_singleton: bool = False,
         poll_interval: float = 0.05,
         lifetime: float | None = None,
+        opener: FileOpener | None = None,
     ) -> None:
         """
         Create a new lock object.
@@ -181,6 +204,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set, a waiting
             process will break a lock whose file modification time is older than ``lifetime`` seconds. ``None`` (the
             default) means locks never expire.
+        :param opener: optional callback ``(path, flags, mode) -> fd`` used to open the lock-file descriptor in place of
+            :func:`os.open`. ``None`` (the default) keeps the backend's own open. The library still owns polling,
+            locking, release, and contention handling; the callback only creates the descriptor, letting callers apply
+            stricter platform-specific open semantics without subclassing.
 
         """
         self._is_thread_local = thread_local
@@ -194,6 +221,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             "blocking": blocking,
             "poll_interval": poll_interval,
             "lifetime": lifetime,
+            "opener": opener,
         }
         self._context: FileLockContext = (ThreadLocalFileContext if thread_local else FileLockContext)(**kwargs)
 
@@ -320,6 +348,28 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         """Mode for ``os.open``: 0o666 when unset so umask and ACLs decide, otherwise the explicit mode."""
         return 0o666 if self._context.mode == _UNSET_FILE_MODE else self._context.mode
 
+    def _open(self, path: str, flags: int, mode: int) -> int:
+        """
+        Open the lock-file descriptor, routing through a caller-supplied :attr:`opener` when one is set.
+
+        :returns: an open file descriptor for *path*.
+
+        :raises ValueError: if the opener does not return a non-negative integer descriptor.
+
+        """
+        if (opener := self._context.opener) is None:
+            return os.open(path, flags, mode)
+        try:
+            fd = opener(path, flags, mode)
+        except Exception as exc:
+            # A backend classifies its own os.open errors as contention (EEXIST/EACCES); an opener's failure is the
+            # caller's, so wrap it in a non-OSError the backend won't swallow and surface it verbatim from acquire.
+            raise _OpenerFailed(exc) from exc
+        if not isinstance(fd, int) or isinstance(fd, bool) or fd < 0:
+            msg = f"opener must return a non-negative file descriptor, got {fd!r}"
+            raise ValueError(msg)
+        return fd
+
     @property
     def is_locked(self) -> bool:
         """
@@ -433,6 +483,9 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
                 poll_interval=poll_interval,
                 start_time=start_time,
             )
+        except _OpenerFailed as failure:
+            self._undo_acquire(canonical)
+            raise failure.cause from None
         except BaseException:
             self._undo_acquire(canonical)
             raise
@@ -603,6 +656,9 @@ class FileLockContext:
     #: The lock lifetime in seconds; ``None`` means the lock never expires.
     lifetime: float | None = None
 
+    #: Optional caller-supplied opener for the lock-file descriptor; ``None`` uses the backend's own ``os.open``.
+    opener: FileOpener | None = None
+
     #: File descriptor from os.open for the lock file; not None while the lock is held.
     lock_file_fd: int | None = None
 
@@ -618,4 +674,5 @@ __all__ = [
     "_UNSET_FILE_MODE",
     "AcquireReturnProxy",
     "BaseFileLock",
+    "FileOpener",
 ]

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -42,7 +42,7 @@ class SoftFileLock(BaseFileLock):
         if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:
             flags |= o_nofollow
         try:
-            file_handler = os.open(self.lock_file, flags, self._open_mode())
+            file_handler = self._open(self.lock_file, flags, self._open_mode())
         except OSError as exception:
             if not (
                 exception.errno == EEXIST or (exception.errno == EACCES and sys.platform == "win32")

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -50,7 +50,7 @@ else:  # pragma: win32 no cover
             open_flags |= os.O_CREAT
             open_mode = self._open_mode()
             try:
-                fd = os.open(self.lock_file, open_flags, open_mode)
+                fd = self._open(self.lock_file, open_flags, open_mode)
             except FileNotFoundError:
                 # On FUSE/NFS, os.open(O_CREAT) is not atomic; a split LOOKUP + CREATE lets a concurrent unlink()
                 # delete the file between them. For a valid path, treat ENOENT as transient contention. For an
@@ -64,7 +64,7 @@ else:  # pragma: win32 no cover
                 if not Path(self.lock_file).exists():
                     raise
                 try:
-                    fd = os.open(self.lock_file, open_flags & ~os.O_CREAT, open_mode)
+                    fd = self._open(self.lock_file, open_flags & ~os.O_CREAT, open_mode)
                 except FileNotFoundError:
                     return
             if self.has_explicit_mode:

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -40,7 +40,7 @@ if sys.platform == "win32":  # pragma: win32 cover
                 raise OSError(msg)
 
             try:
-                fd = os.open(self.lock_file, os.O_RDWR | os.O_CREAT, self._open_mode())
+                fd = self._open(self.lock_file, os.O_RDWR | os.O_CREAT, self._open_mode())
             except OSError as exception:
                 if exception.errno != EACCES:
                     raise

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -12,7 +12,7 @@ from inspect import iscoroutinefunction
 from threading import local
 from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar
 
-from ._api import _UNSET_FILE_MODE, BaseFileLock, FileLockContext, FileLockMeta, _canonical
+from ._api import _UNSET_FILE_MODE, BaseFileLock, FileLockContext, FileLockMeta, _canonical, _OpenerFailed
 from ._error import Timeout
 from ._soft import SoftFileLock
 from ._unix import UnixFileLock
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from concurrent import futures
     from types import TracebackType
+
+    from ._api import FileOpener
 
     if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
         from typing import Self
@@ -47,6 +49,7 @@ class AsyncFileLockMeta(FileLockMeta):
         is_singleton: bool = False,
         poll_interval: float = 0.05,
         lifetime: float | None = None,
+        opener: FileOpener | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -63,6 +66,7 @@ class AsyncFileLockMeta(FileLockMeta):
             is_singleton=is_singleton,
             poll_interval=poll_interval,
             lifetime=lifetime,
+            opener=opener,
             loop=loop,
             run_in_executor=run_in_executor,
             executor=executor,
@@ -90,6 +94,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         is_singleton: bool = False,
         poll_interval: float = 0.05,
         lifetime: float | None = None,
+        opener: FileOpener | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -119,6 +124,8 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         :param lifetime: maximum time in seconds a lock can be held before it is considered expired. When set, a waiting
             process will break a lock whose file modification time is older than ``lifetime`` seconds. ``None`` (the
             default) means locks never expire.
+        :param opener: optional callback ``(path, flags, mode) -> fd`` used to open the lock-file descriptor in place of
+            :func:`os.open`. ``None`` (the default) keeps the backend's own open.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.
@@ -135,6 +142,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             "blocking": blocking,
             "poll_interval": poll_interval,
             "lifetime": lifetime,
+            "opener": opener,
             "loop": loop,
             "run_in_executor": run_in_executor,
             "executor": executor,
@@ -230,6 +238,9 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 poll_interval=poll_interval,
                 start_time=time.perf_counter(),
             )
+        except _OpenerFailed as failure:
+            self._undo_acquire(canonical)
+            raise failure.cause from None
         except BaseException:
             self._undo_acquire(canonical)
             raise

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import logging
+import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path, PurePath
@@ -475,3 +476,17 @@ async def test_force_release_clears_registry(tmp_path: Path, lock_type: type[Bas
     lock2 = lock_type(lock_path)
     async with lock2:
         assert lock2.is_locked
+
+
+@pytest.mark.asyncio
+async def test_async_opener_is_used(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def opener(path: str, flags: int, mode: int) -> int:
+        calls.append(path)
+        return os.open(path, flags, mode)
+
+    async with AsyncFileLock(tmp_path / "a.lock", opener=opener) as lock:
+        assert lock.is_locked
+
+    assert calls == [str(tmp_path / "a.lock")]

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import inspect
 import logging
 import os
@@ -8,7 +9,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from errno import EAGAIN, ENOSYS, EWOULDBLOCK
+from errno import EAGAIN, EEXIST, ENOSYS, EWOULDBLOCK
 from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
@@ -19,6 +20,7 @@ from weakref import WeakValueDictionary
 
 import pytest
 
+import filelock
 from filelock import BaseFileLock, FileLock, SoftFileLock, Timeout, UnixFileLock, WindowsFileLock
 
 if TYPE_CHECKING:
@@ -105,6 +107,9 @@ def test_ro_file(lock_type: type[BaseFileLock], tmp_file_ro: Path) -> None:
 
 
 _WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+_UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    sys.platform == "win32", reason="native flock contention is Unix-only"
+)
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
@@ -1312,3 +1317,106 @@ def test_force_release_cleans_registry(tmp_path: Path, lock_type: type[BaseFileL
     lock2 = lock_type(lock_path)
     with lock2:
         assert lock2.is_locked
+
+
+def test_file_opener_is_exported() -> None:
+    assert "FileOpener" in filelock.__all__
+
+
+def test_opener_receives_path_flags_mode_once(tmp_path: Path) -> None:
+    calls: list[tuple[str, int, int]] = []
+
+    def opener(path: str, flags: int, mode: int) -> int:
+        calls.append((path, flags, mode))
+        return os.open(path, flags, mode)
+
+    with FileLock(tmp_path / "a.lock", opener=opener) as lock:
+        assert lock.is_locked
+
+    assert len(calls) == 1
+    path, flags, mode = calls[0]
+    assert path == str(tmp_path / "a.lock")
+    assert isinstance(flags, int)
+    assert isinstance(mode, int)
+
+
+def test_opener_default_uses_os_open(tmp_path: Path, mocker: MockerFixture) -> None:
+    os_open_spy = mocker.spy(os, "open")
+    with FileLock(tmp_path / "a.lock") as lock:
+        assert lock.is_locked
+    assert os_open_spy.called
+
+
+@pytest.mark.parametrize("bad", [-1, "5", True, None, 1.0])
+def test_opener_invalid_descriptor_raises(bad: object, tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "a.lock", opener=lambda *_: bad)  # ty: ignore[invalid-argument-type]
+    with pytest.raises(ValueError, match="file descriptor"):
+        lock.acquire()
+
+
+def test_opener_exception_propagates(tmp_path: Path) -> None:
+    def boom(_path: str, _flags: int, _mode: int) -> int:
+        msg = "opener failed"
+        raise RuntimeError(msg)
+
+    lock = FileLock(tmp_path / "a.lock", opener=boom, timeout=0)
+    with pytest.raises(RuntimeError, match="opener failed"):
+        lock.acquire()
+
+
+def test_opener_oserror_propagates_not_timeout(tmp_path: Path) -> None:
+    def opener(_path: str, _flags: int, _mode: int) -> int:
+        raise FileExistsError(EEXIST, "already exists")
+
+    lock = SoftFileLock(tmp_path / "a.lock", opener=opener, timeout=0)
+    with pytest.raises(FileExistsError):
+        lock.acquire()
+
+
+def test_singleton_opener_match(tmp_path: Path) -> None:
+    lock1 = FileLock(tmp_path / "a.lock", is_singleton=True, opener=os.open)
+    lock2 = FileLock(tmp_path / "a.lock", is_singleton=True, opener=os.open)
+    assert lock1 is lock2
+
+
+def test_singleton_opener_mismatch(tmp_path: Path) -> None:
+    lock = FileLock(tmp_path / "a.lock", is_singleton=True, opener=os.open)
+    with pytest.raises(ValueError, match="opener"):
+        FileLock(tmp_path / "a.lock", is_singleton=True, opener=functools.partial(os.open))
+    del lock
+
+
+def test_singleton_opener_compared_by_identity(tmp_path: Path) -> None:
+    class EqualEverything:
+        def __call__(self, path: str, flags: int, mode: int) -> int:
+            return os.open(path, flags, mode)
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, EqualEverything)
+
+        def __hash__(self) -> int:
+            return 0
+
+    lock = FileLock(tmp_path / "a.lock", is_singleton=True, opener=EqualEverything())
+    with pytest.raises(ValueError, match="opener"):
+        FileLock(tmp_path / "a.lock", is_singleton=True, opener=EqualEverything())
+    del lock
+
+
+@_UNIX_FLOCK_ONLY
+def test_opener_descriptor_closed_on_contention(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "a.lock"
+    opened: list[int] = []
+
+    def opener(path: str, flags: int, mode: int) -> int:
+        fd = os.open(path, flags, mode)
+        opened.append(fd)
+        return fd
+
+    with FileLock(lock_path, timeout=0):
+        close_spy = mocker.spy(os, "close")
+        with pytest.raises(Timeout):
+            FileLock(lock_path, timeout=0, opener=opener).acquire()
+
+        assert opened
+        assert any(call.args and call.args[0] == opened[-1] for call in close_spy.call_args_list)


### PR DESCRIPTION
Callers with stronger local-filesystem requirements must subclass a private platform `_acquire` just to change how the lock-file descriptor opens, which couples them to internals like contention classification and fallback behavior, as raised in #592. Examples include applying stricter no-follow semantics, a private-descriptor policy, native Windows handle flags, or instrumenting opens for fault injection.

This adds a keyword-only `opener` callback with the narrow contract `(path, flags, mode) -> fd`. The callback threads through the constructor, the lock context, and the singleton compatibility check, and every backend calls it in place of its direct `os.open`. When `opener` is `None`, which is the default, each backend opens as before. When a caller provides one, the library still owns polling, locking, release, and error classification; the callback only creates the descriptor. The package exports `FileOpener` for callers to type their hooks.

An opener that returns anything other than a non-negative integer descriptor raises `ValueError`, and an exception from inside the callback propagates instead of surfacing as a timeout. Singleton construction treats a differing opener identity as an incompatible argument, and the sync and async wrappers share the same configured opener.

Closes #592.
