### PR TITLE
🐛 fix(windows): bind reparse-point check to the locked handle

### DIFF
--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -15,44 +15,77 @@ if sys.platform == "win32":  # pragma: win32 cover
     import msvcrt
     from ctypes import wintypes
 
+    _GENERIC_READ: Final[int] = 0x80000000
+    _GENERIC_WRITE: Final[int] = 0x40000000
+    _FILE_SHARE_READ_WRITE: Final[int] = (
+        0x00000001 | 0x00000002
+    )  # read | write; matches os.open (_SH_DENYNO), no delete
+    _OPEN_ALWAYS: Final[int] = 4  # open the file if it exists, create it otherwise
+    _FILE_ATTRIBUTE_READONLY: Final[int] = 0x00000001
     _FILE_ATTRIBUTE_REPARSE_POINT: Final[int] = 0x00000400
-    _INVALID_FILE_ATTRIBUTES: Final[int] = 0xFFFFFFFF
+    _FILE_FLAG_OPEN_REPARSE_POINT: Final[int] = 0x00200000  # open the reparse point itself instead of following it
+    _INVALID_HANDLE_VALUE: Final[int] = cast("int", wintypes.HANDLE(-1).value)  # non-null handle, never None
+    _ERROR_ACCESS_DENIED: Final[int] = 5
+    _ERROR_SHARING_VIOLATION: Final[int] = 32
+    _OWNER_WRITE: Final[int] = 0o200
 
     _kernel32: Final[ctypes.WinDLL] = ctypes.WinDLL("kernel32", use_last_error=True)
-    _kernel32.GetFileAttributesW.argtypes = [wintypes.LPCWSTR]
-    _kernel32.GetFileAttributesW.restype = wintypes.DWORD
+    _kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    _kernel32.CreateFileW.restype = wintypes.HANDLE
+    _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+
+    class _BY_HANDLE_FILE_INFORMATION(ctypes.Structure):  # noqa: N801  # mirrors the Win32 struct name
+        _fields_ = (
+            ("dwFileAttributes", wintypes.DWORD),
+            ("ftCreationTime", wintypes.FILETIME),
+            ("ftLastAccessTime", wintypes.FILETIME),
+            ("ftLastWriteTime", wintypes.FILETIME),
+            ("dwVolumeSerialNumber", wintypes.DWORD),
+            ("nFileSizeHigh", wintypes.DWORD),
+            ("nFileSizeLow", wintypes.DWORD),
+            ("nNumberOfLinks", wintypes.DWORD),
+            ("nFileIndexHigh", wintypes.DWORD),
+            ("nFileIndexLow", wintypes.DWORD),
+        )
+
+    _kernel32.GetFileInformationByHandle.argtypes = [wintypes.HANDLE, ctypes.POINTER(_BY_HANDLE_FILE_INFORMATION)]
+    _kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
 
     class WindowsFileLock(BaseFileLock):
         """
         Uses the :func:`msvcrt.locking` function to hard lock the lock file on Windows systems.
 
-        ``_release`` unlinks the lock file, but the unlink can fail while another thread still holds an
-        open handle. A surviving lock file on disk does not affect lock correctness.
+        Lock file cleanup: Windows attempts to delete the lock file after release, but deletion is
+        not guaranteed in multi-threaded scenarios where another thread holds an open handle. The lock
+        file may persist on disk, which does not affect lock correctness.
         """
 
         def _acquire(self) -> None:
             raise_on_not_writable_file(self.lock_file)
             ensure_directory_exists(self.lock_file)
 
-            # Refuse a reparse point (symlink/junction) at the lock path to blunt a symlink-swap attack.
-            if _is_reparse_point(self.lock_file):
-                msg = f"Lock file is a reparse point (symlink/junction): {self.lock_file}"
-                raise OSError(msg)
-
+            # The reparse test is bound to the opened handle, so a symlink or junction swapped in cannot defeat it
+            # through a check-then-open TOCTOU race.
+            fd = _open_non_reparse_fd(self.lock_file, self._open_mode())
+            if fd is None:
+                return  # access/sharing contention on open; let the retry loop try again
             try:
-                fd = os.open(self.lock_file, os.O_RDWR | os.O_CREAT, self._open_mode())
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
             except OSError as exception:
-                if exception.errno != EACCES:
+                os.close(fd)
+                if exception.errno != EACCES:  # EACCES means another holder owns the byte-range lock
                     raise
             else:
-                try:
-                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-                except OSError as exception:
-                    os.close(fd)
-                    if exception.errno != EACCES:  # EACCES means another holder owns the byte-range lock
-                        raise
-                else:
-                    self._context.lock_file_fd = fd
+                self._context.lock_file_fd = fd
 
         def _release(self) -> None:
             fd = cast("int", self._context.lock_file_fd)
@@ -63,12 +96,75 @@ if sys.platform == "win32":  # pragma: win32 cover
             with suppress(OSError):
                 Path(self.lock_file).unlink()
 
-    def _is_reparse_point(path: str) -> bool:
-        # A missing path reports INVALID_FILE_ATTRIBUTES; the caller creates it, so treat that as
-        # not-a-reparse-point and reject only an existing reparse-point attribute.
-        if (attrs := _kernel32.GetFileAttributesW(path)) == _INVALID_FILE_ATTRIBUTES:
-            return False
-        return bool(attrs & _FILE_ATTRIBUTE_REPARSE_POINT)
+    def _open_non_reparse_fd(path: str, mode: int) -> int | None:
+        """
+        Open *path* for locking while refusing reparse points, bound to the handle actually locked.
+
+        The file is opened with ``FILE_FLAG_OPEN_REPARSE_POINT`` so a symlink or junction planted at the path is not
+        followed, and the reparse decision is read from *that* handle via ``GetFileInformationByHandle`` rather than
+        from a prior pathname query. Reading the held handle closes the check-then-open race: an attacker cannot swap
+        the path between validation and use because both now act on the same handle. Share mode omits delete so a peer
+        cannot unlink or rename the file out from under a live holder, matching ``os.open``'s ``_SH_DENYNO``.
+
+        The flag only guards the final path component; Windows still follows reparse points in intermediate
+        directories. This assumes the lock file sits in a lock directory untrusted users cannot modify — a path with
+        attacker-controlled parent directories would need component-by-component handle validation.
+
+        :param path: the lock file path.
+        :param mode: the permission mode; as ``os.open`` does on Windows, a cleared owner-write bit creates the file
+            read-only. The attribute only takes effect when the file is created, not when an existing one is opened.
+
+        :returns: a file descriptor owning the opened handle, or ``None`` on a sharing violation or a delete-pending
+            access denial the caller should treat as contention and retry.
+
+        :raises OSError: if the path resolves to a reparse point, or the open fails for any other reason, raised with
+            its real Windows error code rather than masked as contention.
+
+        """
+        # Emit the audit event os.open would, so consumers watching "open" still see the path-level open and can veto.
+        sys.audit("open", path, None, os.O_RDWR | os.O_CREAT)
+        flags_and_attributes = _FILE_FLAG_OPEN_REPARSE_POINT
+        if not mode & _OWNER_WRITE:
+            flags_and_attributes |= _FILE_ATTRIBUTE_READONLY
+        handle = _kernel32.CreateFileW(
+            path,
+            _GENERIC_READ | _GENERIC_WRITE,
+            _FILE_SHARE_READ_WRITE,
+            None,
+            _OPEN_ALWAYS,
+            flags_and_attributes,
+            None,
+        )
+        if handle == _INVALID_HANDLE_VALUE:
+            err = ctypes.get_last_error()
+            if err in {_ERROR_SHARING_VIOLATION, _ERROR_ACCESS_DENIED}:
+                # Both are contention, not permanent failure. A conflicting share mode reports a sharing violation. A
+                # lock file another holder just unlinked lingers in Windows' delete-pending state, where CreateFileW
+                # returns access-denied until the last handle closes; os.open reports the same case as EACCES and the
+                # backend has always retried it. Permanent denials (a read-only file, a directory at the path) are
+                # already rejected up front by raise_on_not_writable_file.
+                return None
+            # Raise the real Windows failure with the pathname. A second os.open() to reshape the exception could
+            # observe a swapped path (a fresh TOCTOU) and would mask the true error, so map the captured code directly:
+            # winerror selects the right OSError subclass (FileNotFoundError for a missing path, and so on).
+            raise OSError(None, ctypes.FormatError(err).strip(), path, err)
+
+        info = _BY_HANDLE_FILE_INFORMATION()
+        if not _kernel32.GetFileInformationByHandle(handle, ctypes.byref(info)):
+            err = ctypes.get_last_error()
+            _kernel32.CloseHandle(handle)
+            raise ctypes.WinError(err)
+        if info.dwFileAttributes & _FILE_ATTRIBUTE_REPARSE_POINT:
+            _kernel32.CloseHandle(handle)
+            msg = f"Lock file is a reparse point (symlink/junction): {path}"
+            raise OSError(msg)
+
+        try:
+            # O_NOINHERIT mirrors os.open on Windows: the lock fd must not leak into child processes.
+            return msvcrt.open_osfhandle(handle, os.O_RDWR | os.O_NOINHERIT)
+        except BaseException:  # open_osfhandle audits too; a hook raising anything must not leak the handle
+            _kernel32.CloseHandle(handle)
+            raise
 
 else:  # pragma: win32 no cover
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -114,7 +114,10 @@ _UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
 @pytest.mark.parametrize(
     ("expected_error", "match", "bad_lock_file"),
     [
-        pytest.param(FileNotFoundError, "No such file or directory:", "", id="blank_filename"),
+        # WindowsFileLock raises the real Win32 error now, so accept its wording alongside os.open's.
+        pytest.param(
+            FileNotFoundError, "No such file or directory:|cannot find the (path|file)", "", id="blank_filename"
+        ),
         pytest.param(ValueError, "embedded null (byte|character)", "\0", id="null_byte"),
         # Should be PermissionError on Windows
         (
@@ -129,7 +132,10 @@ _UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
             )
         ),
     ]
-    + [pytest.param(OSError, "Invalid argument", i, id=f"invalid_{i}", marks=_WINDOWS_ONLY) for i in '<>:"|?*\a']
+    + [
+        pytest.param(OSError, "Invalid argument|syntax is incorrect", i, id=f"invalid_{i}", marks=_WINDOWS_ONLY)
+        for i in '<>:"|?*\a'
+    ]
     + [
         pytest.param(PermissionError, "Permission denied:", i, id=f"permission_{i}", marks=_WINDOWS_ONLY) for i in "/\\"
     ],
@@ -1373,3 +1379,19 @@ def test_post_lock_truncate_failure_closes_fd(tmp_path: Path, mocker: MockerFixt
         FileLock(tmp_path / "resource.lock", timeout=0).acquire()
 
     assert any(call.args and call.args[0] == open_spy.spy_return for call in close_spy.call_args_list)
+
+
+@_WINDOWS_ONLY
+def test_windows_reparse_point_lock_file_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("sensitive", encoding="utf-8")
+    link = tmp_path / "resource.lock"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("cannot create symlinks (needs Developer Mode or administrator)")
+
+    with pytest.raises(OSError, match="reparse point"):
+        FileLock(link).acquire()
+
+    assert target.read_text(encoding="utf-8") == "sensitive"


### PR DESCRIPTION
The Windows acquisition path validated the lock pathname with `GetFileAttributesW` to reject reparse points, then opened the same pathname in a separate `os.open` that follows reparse points. Nothing bound the check and the open to one handle, so an attacker able to write the lock directory could replace the path with a symlink or junction in the window between them and redirect the lock to another file. A comment claimed the check prevented a symlink TOCTOU, but nothing tied the decision to the descriptor the lock used.

This opens the path with `CreateFileW` and `FILE_FLAG_OPEN_REPARSE_POINT` so a symlink is not followed, reads the reparse attribute from that same handle through `GetFileInformationByHandle`, rejects a reparse point, and only then wraps the handle into a descriptor for `msvcrt.locking`. The security decision now comes from the handle the lock takes rather than a prior pathname query, so a path swapped after the check no longer changes what gets locked. The backend still creates a missing lock file, and the open still treats access or sharing errors as contention.

The change stays inside the Windows backend and preserves the existing acquire, release, and contention semantics. Placing lock files in a directory untrusted users cannot modify remains the strongest mitigation, since it removes the attacker-controlled path-replacement precondition.
