### PR TITLE
🎨 style: readability cleanup across the library

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -72,7 +72,7 @@ same thread:
         with lock_b:  # RuntimeError: Deadlock detected!
             pass
 
-This would normally deadlock forever because ``lock_b`` waits for a lock that ``lock_a`` holds in the same thread.
+This would deadlock forever because ``lock_b`` waits for a lock that ``lock_a`` holds in the same thread.
 filelock detects this and raises ``RuntimeError`` with a message suggesting ``is_singleton=True`` as the fix.
 
 This detection only applies to blocking acquires (``timeout < 0``) within the same thread. Non-blocking or timed
@@ -94,8 +94,8 @@ file handle can lock it. When a process dies, the OS automatically releases its 
 
     - - Pros
       - Cons
-    - - ✓ Enforced by the kernel—foolproof.
-      - ✗ Exclusive only—no reader/writer distinction (use ReadWriteLock for that).
+    - - ✓ Enforced by the kernel, so it is foolproof.
+      - ✗ Exclusive only, with no reader/writer distinction (use ReadWriteLock for that).
     - - ✓ Works even if your process crashes.
       - ✗ Unreliable on some network filesystems.
     - - ✓ No network filesystem issues.
@@ -122,8 +122,8 @@ the lock file additionally stores the process creation time to guard against PID
     - - Pros
       - Cons
     - - ✓ Works on any filesystem, including network mounts.
-      - ✗ Not enforced—requires cooperation (a buggy process can ignore it).
-    - - ✓ Portable—same code works everywhere.
+      - ✗ Not enforced; it requires cooperation (a buggy process can ignore it).
+    - - ✓ Portable; the same code works everywhere.
       - ✗ Higher overhead than OS-level locks.
     - - ✓ Can detect stale locks (all platforms).
       - ✗ Cross-host detection doesn't work (stale locks from other hosts require manual cleanup).
@@ -134,7 +134,7 @@ the lock file additionally stores the process creation time to guard against PID
 
 **Windows**
     Uses the :class:`WindowsFileLock <filelock.WindowsFileLock>` class, backed by ``msvcrt.locking``. This is enforced
-    by Windows, so all code running on the system respects it—whether it uses filelock or not.
+    by Windows, so all code running on the system respects it, whether it uses filelock or not.
 
     The lock is exclusive and works reliably on local filesystems. Network filesystem (SMB) support is available but
     considered less reliable.
@@ -148,7 +148,7 @@ the lock file additionally stores the process creation time to guard against PID
     Uses the :class:`UnixFileLock <filelock.UnixFileLock>` class, backed by ``fcntl.flock``. This is the POSIX standard
     for file locking and enforced by the kernel.
 
-    Works best on local filesystems. Network filesystems (NFS) may have issues—locking isn't always reliable on NFS even
+    Works best on local filesystems. Network filesystems (NFS) may have issues; locking isn't always reliable on NFS even
     in POSIX-compliant systems.
 
     Lock file cleanup: Unix and macOS delete the lock file reliably after release, even in multi-threaded scenarios.
@@ -163,7 +163,7 @@ the lock file additionally stores the process creation time to guard against PID
  Which lock type should I use?
 *******************************
 
-**Start with FileLock** — the platform-aware alias that automatically chooses the best backend:
+**Start with FileLock**, the platform-aware alias that automatically chooses the best backend:
 
 .. code-block:: python
 
@@ -336,7 +336,7 @@ On older platforms without ``O_NOFOLLOW``, prefer :class:`UnixFileLock <filelock
 
 **Locks on network filesystems**
     OS-level locks (FileLock on Windows/Unix) are unreliable on network filesystems (NFS, SMB). This is a fundamental
-    limitation of how network filesystems work—they don't reliably support locking semantics.
+    limitation of how network filesystems work; they don't reliably support locking semantics.
 
     For **exclusive locking** on NFS, use :class:`SoftFileLock <filelock.SoftFileLock>`. For **reader/writer
     locking** (shared readers + exclusive writers) on NFS, use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>`,
@@ -345,11 +345,11 @@ On older platforms without ``O_NOFOLLOW``, prefer :class:`UnixFileLock <filelock
 
 **Locks across different machines**
     A lock on one machine doesn't stop another machine from accessing the resource unless they use a centralized locking
-    service — or a shared filesystem plus filelock's soft locks. On a multi-node slurm/HPC cluster,
+    service, or a shared filesystem plus filelock's soft locks. On a multi-node slurm/HPC cluster,
     :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` is correct across compute nodes sharing an NFS mount.
 
 **Read-write semantics**
-    FileLock is exclusive only—readers block writers and vice versa. If you need multiple readers with occasional
+    FileLock is exclusive only; readers block writers and vice versa. If you need multiple readers with occasional
     writers, use ReadWriteLock instead.
 
 **Atomicity without locks**
@@ -363,7 +363,7 @@ On older platforms without ``O_NOFOLLOW``, prefer :class:`UnixFileLock <filelock
             # if Process B doesn't use the lock
             open("data.txt").write("A")
 
-    Locks require cooperation—all code accessing a resource must use the same lock.
+    Locks require cooperation; all code accessing a resource must use the same lock.
 
 *******************
  Design trade-offs
@@ -412,9 +412,9 @@ How does SoftReadWriteLock work on NFS?
 :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` fills the gap left by ``ReadWriteLock`` on network filesystems.
 It stores state as a small directory tree next to the lock file:
 
-- ``<path>.state`` — a short-held :class:`SoftFileLock <filelock.SoftFileLock>` used as the state mutex during transitions.
-- ``<path>.write`` — the writer marker; its presence blocks readers and other writers.
-- ``<path>.readers/<host>.<pid>.<uuid>`` — one marker file per active reader.
+- ``<path>.state`` is a short-held :class:`SoftFileLock <filelock.SoftFileLock>` used as the state mutex during transitions.
+- ``<path>.write`` is the writer marker; its presence blocks readers and other writers.
+- ``<path>.readers/<host>.<pid>.<uuid>`` is one marker file per active reader.
 
 Each marker stores a random 128-bit token, the holder's pid, and the holder's hostname. Every acquire uses
 ``O_CREAT | O_EXCL | O_NOFOLLOW`` with mode ``0o600``; the readers directory uses mode ``0o700`` and a ``lstat``
@@ -429,7 +429,7 @@ Cross-host stale detection
 ==========================
 
 On a multi-node cluster, a process on ``node-42`` that crashes while holding a lock cannot be detected via
-``kill(pid, 0)`` from ``node-17`` — the pid means nothing to a different kernel. ``SoftReadWriteLock`` therefore
+``kill(pid, 0)`` from ``node-17``; the pid means nothing to a different kernel. ``SoftReadWriteLock`` therefore
 uses a **TTL with a heartbeat** rather than ``SoftFileLock``'s PID-alive check:
 
 - Each lock instance starts a daemon thread on acquire. The thread refreshes the marker's ``mtime`` every
@@ -443,7 +443,7 @@ uses a **TTL with a heartbeat** rather than ``SoftFileLock``'s PID-alive check:
   never gets accidentally refreshed.
 
 The trade-off: ``stale_threshold`` must be larger than any realistic pause a holder might hit (GC, syscall delay,
-NFS hiccup). Pick it generously. Clock synchronization across compute nodes is assumed — every HPC cluster runs
+NFS hiccup). Pick it generously. We assume clock synchronization across compute nodes; every HPC cluster runs
 NTP or chrony, so this is not an additional constraint in the target environment.
 
 Fork semantics

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -42,7 +42,7 @@ You can also pass ``timeout`` directly to ``acquire()``:
  Use non-blocking locks
 ************************
 
-Sometimes you want to attempt the lock exactly once—either you get it immediately or you don't.
+Sometimes you want to try the lock once. Either you get it immediately or you don't.
 
 Set ``blocking=False``:
 
@@ -60,7 +60,7 @@ Set ``blocking=False``:
 
 When ``blocking=False``, the lock makes only one attempt and raises ``Timeout`` if it can't acquire immediately.
 
-The ``blocking`` parameter takes precedence over ``timeout``\ —if you set both, ``blocking`` wins:
+The ``blocking`` parameter takes precedence over ``timeout``. If you set both, ``blocking`` wins:
 
 .. code-block:: python
 
@@ -121,7 +121,7 @@ For async code, use the async variants with ``async with``:
 
 .. warning::
 
-   ``with`` does not work on async locks — ``acquire`` and ``release`` are coroutines and must be awaited.
+   ``with`` does not work on async locks. ``acquire`` and ``release`` are coroutines; await them.
    Use ``async with`` as shown above.
 
 By default, async locks run blocking I/O in a thread pool. You can customize this:
@@ -146,12 +146,12 @@ You can also pass a specific event loop:
     loop = asyncio.new_event_loop()
     lock = AsyncFileLock("work.lock", loop=loop)
 
-Note that async locks default to ``thread_local=False`` (unlike sync locks which default to ``True``) because the
+Async locks default to ``thread_local=False`` (unlike sync locks which default to ``True``) because the
 acquiring and releasing threads may differ when using an executor.
 
 Available async lock classes:
 
-- :class:`AsyncFileLock <filelock.AsyncFileLock>` — platform-aware (recommended).
+- :class:`AsyncFileLock <filelock.AsyncFileLock>`, platform-aware (recommended).
 - :class:`AsyncSoftFileLock <filelock.AsyncSoftFileLock>`.
 - :class:`AsyncUnixFileLock <filelock.AsyncUnixFileLock>`.
 - :class:`AsyncWindowsFileLock <filelock.AsyncWindowsFileLock>`.
@@ -348,12 +348,12 @@ preemption). ``heartbeat_interval`` should be roughly ``stale_threshold / 3``; t
 its ``LeaseKeepAlive``. Lower ``poll_interval`` reduces acquire latency under contention at the cost of more
 NFS ``stat`` calls per waiting client.
 
-Writer acquisition is two-phase and writer-preferring: phase one claims the writer marker (which immediately
-blocks any new reader), phase two waits for existing readers to drain. This rules out writer starvation even
-under a read-heavy workload like the 99/1 reader-to-writer mix typical of slurm job queues.
+Writer acquisition is two-phase and writer-preferring: phase one claims the writer marker (which blocks any
+new reader), phase two waits for existing readers to drain. This rules out writer starvation even under a
+read-heavy workload like the 99/1 reader-to-writer mix typical of slurm job queues.
 
-**Fork caveat.** A process that forks while holding a ``SoftReadWriteLock`` loses the lock in the child. The
-inherited instance is marked fork-invalidated; ``release()`` on it becomes a no-op, and the child must call
+**Fork caveat.** A process that forks while holding a ``SoftReadWriteLock`` loses the lock in the child. filelock marks the
+inherited instance fork-invalidated; ``release()`` on it becomes a no-op, and the child must call
 ``SoftReadWriteLock(path)`` again to get a fresh instance before acquiring. Matches the semantics of
 :class:`threading.Lock` and PyMongo's connection pools.
 
@@ -402,7 +402,7 @@ Low-level ``acquire_read``/``acquire_write``/``release`` methods are also availa
         await rw.release()
 
 The same reentrancy and upgrade/downgrade rules as the synchronous :class:`ReadWriteLock <filelock.ReadWriteLock>`
-apply — see :ref:`how-to:Use shared read / exclusive write locks` for details.
+apply. See :ref:`how-to:Use shared read / exclusive write locks` for details.
 
 For network filesystems, use :class:`AsyncSoftReadWriteLock <filelock.AsyncSoftReadWriteLock>`, which wraps
 :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` the same way:
@@ -421,9 +421,9 @@ For network filesystems, use :class:`AsyncSoftReadWriteLock <filelock.AsyncSoftR
 **************************************
 
 :class:`SoftFileLock <filelock.SoftFileLock>` stores the PID and hostname of the lock holder. It can detect when the
-holding process has died and automatically break stale locks on all platforms.
+holding process has died and break stale locks on all platforms.
 
-This happens automatically—you don't need to do anything special:
+This happens automatically. You don't need to do anything special:
 
 .. code-block:: python
 
@@ -438,8 +438,8 @@ This happens automatically—you don't need to do anything special:
 
 Stale lock detection only detects locks from the same host. Cross-host stale locks still require manual removal.
 
-On Windows, the lock file additionally stores the process creation time to guard against PID recycling. Malformed lock
-files (empty or corrupted) are evicted automatically after a brief safety window.
+On Windows, the lock file additionally stores the process creation time to guard against PID recycling. filelock evicts
+malformed lock files (empty or corrupted) after a brief safety window.
 
 *****************************************
  Inspect and manage PID locks
@@ -505,7 +505,7 @@ library:
  Set lock lifetime
 *******************
 
-You can create locks that automatically expire after a certain time:
+You can create locks that expire after a set time:
 
 .. code-block:: python
 
@@ -519,7 +519,7 @@ You can create locks that automatically expire after a certain time:
         pass
 
 This is useful for distributed systems where a process might crash and leave a lock behind. After the lifetime expires,
-other processes can acquire it automatically.
+other processes can acquire it.
 
 **************************
  Cancel lock acquisition

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -2,8 +2,8 @@
  Tutorials
 ###########
 
-This section guides you through the fundamentals of file locking. We'll learn by doing, starting with the basics and
-building up to more advanced patterns.
+This section guides you through the fundamentals of file locking, starting with the basics and building up to advanced
+patterns.
 
 *****************
  Your first lock
@@ -11,7 +11,7 @@ building up to more advanced patterns.
 
 Let's create our first lock and use it to coordinate between processes.
 
-First, we'll import what we need and create a lock object:
+We import what we need and create a lock object:
 
 .. code-block:: python
 
@@ -30,14 +30,14 @@ statement):
         print("I have the lock!")
     # Outside this block, the lock is released
 
-Run this code multiple times in different terminal windows at the same time. You'll see that only one process prints the
-message at a time—the others wait for their turn. The lock is working correctly!
+Run this code in several terminal windows at the same time. Only one process prints the message at a time; the others
+wait for their turn.
 
 ************************
  Protecting shared data
 ************************
 
-File locks are most useful when protecting data that multiple processes access. Let's see how:
+File locks are most useful when protecting data that multiple processes access:
 
 .. code-block:: python
 
@@ -57,9 +57,9 @@ File locks are most useful when protecting data that multiple processes access. 
         with data_file.open("a") as f:
             f.write("Hello from Process B\n")
 
-The key pattern here: **Before making changes, check what's already done.** Process A checks if the file exists before
-writing. Process B doesn't need to check because it's just appending. But both use the lock to ensure only one process
-modifies the file at a time.
+The key pattern: **before making changes, check what's already done.** Process A checks whether the file exists before
+writing. Process B appends, so it skips the check. Both use the lock so that only one process modifies the file at a
+time.
 
 Run this code from two different processes. The file will contain messages from both in a consistent order.
 
@@ -86,8 +86,8 @@ Sometimes you need to acquire the same lock multiple times from the same process
         helper_function()  # Can acquire the same lock again
         print("Still have the lock")
 
-No deadlock occurs—the lock counts how many times it's been acquired and releases only when the count reaches zero. You
-can inspect this counter and the lock state at any time:
+No deadlock occurs. The lock counts how many times you acquire it and releases only when the count reaches zero. You can
+inspect this counter and the lock state at any time:
 
 .. code-block:: python
 
@@ -111,7 +111,7 @@ can inspect this counter and the lock state at any time:
     print(lock.lock_counter)  # 0 — fully released
     print(lock.is_locked)     # False
 
-Key lesson: You can safely call functions that acquire a lock, even if you already hold the lock.
+You can call functions that acquire a lock even while you already hold it.
 
 *****************************
  Multiple ways to use a lock
@@ -142,7 +142,7 @@ Always use a ``try/finally`` block to guarantee the lock is released, even if an
 
     protected_operation()  # Lock is acquired, function runs, lock is released
 
-Choose whichever feels most natural for your code. The ``with`` statement is usually clearest.
+Choose whichever feels most natural for your code. The ``with`` statement reads clearest.
 
 Important: Always use the context manager
 =========================================
@@ -171,8 +171,8 @@ Instead, always keep a reference to the lock object:
  Thread-local by default
 **************************
 
-By default, each lock uses thread-local state (``thread_local=True``). This means each thread tracks its own lock
-counter independently. Two threads holding the same ``FileLock`` object each get their own reentrant state.
+By default, each lock uses thread-local state (``thread_local=True``): each thread tracks its own lock counter. Two
+threads holding the same ``FileLock`` object each get their own reentrant state.
 
 Async locks default to ``thread_local=False`` because they run in a thread pool where the acquiring thread may differ
 from the releasing thread.
@@ -218,8 +218,8 @@ Key differences from ``PIDLockFile``:
  Reader/writer locks on a shared NFS
 *************************************
 
-If your lock file lives on a network filesystem — a slurm-mounted home directory, a Lustre cluster scratch
-space, or any NFS share — use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` rather than
+If your lock file lives on a network filesystem (a slurm-mounted home directory, a Lustre cluster scratch space, or any
+NFS share), use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` rather than
 :class:`ReadWriteLock <filelock.ReadWriteLock>`. ``ReadWriteLock`` is SQLite-backed and unsafe on NFS.
 ``SoftReadWriteLock`` is built on :class:`SoftFileLock <filelock.SoftFileLock>` primitives and handles cross-host stale detection via a
 background heartbeat thread.

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import sys
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from ._api import AcquireReturnProxy, BaseFileLock
 from ._error import Timeout
@@ -44,7 +44,7 @@ from .asyncio import (
 from .version import version
 
 #: version of the project as a string
-__version__: str = version
+__version__: Final[str] = version
 
 
 if sys.platform == "win32":  # pragma: win32 cover
@@ -57,8 +57,7 @@ else:  # pragma: win32 no cover # noqa: PLR5501
     else:
         _FileLock = SoftFileLock
         _AsyncFileLock = AsyncSoftFileLock
-        if warnings is not None:
-            warnings.warn("only soft file lock is available", stacklevel=2)
+        warnings.warn("only soft file lock is available", stacklevel=2)
 
 if TYPE_CHECKING:
     FileLock = SoftFileLock

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -10,16 +10,15 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import Lock, local
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Final, TypeVar
 from weakref import WeakValueDictionary
 
 from ._error import Timeout
 from ._util import break_lock_file
 
-#: Sentinel indicating that no explicit file permission mode was passed.
-#: When used, lock files are created with 0o666 (letting umask and default ACLs control the final permissions)
-#: and fchmod is skipped so that POSIX default ACL inheritance is preserved.
-_UNSET_FILE_MODE: int = -1
+#: No explicit file permission mode was passed. Lock files then open with 0o666 so umask and default ACLs pick
+#: the final permissions, and fchmod is skipped to preserve POSIX default ACL inheritance.
+_UNSET_FILE_MODE: Final[int] = -1
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -34,11 +33,11 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 
-_LOGGER = logging.getLogger("filelock")
+_LOGGER: Final[logging.Logger] = logging.getLogger("filelock")
 
 # On Windows os.path.realpath calls CreateFileW with share_mode=0, which blocks concurrent DeleteFileW and causes
 # livelocks under threaded contention with SoftFileLock. os.path.abspath is purely string-based and avoids this.
-_canonical = os.path.abspath if sys.platform == "win32" else os.path.realpath
+_canonical: Final[Callable[[str], str]] = os.path.abspath if sys.platform == "win32" else os.path.realpath
 
 
 class _ThreadLocalRegistry(local):
@@ -47,64 +46,7 @@ class _ThreadLocalRegistry(local):
         self.held: dict[str, int] = {}
 
 
-_registry = _ThreadLocalRegistry()
-
-
-# This is a helper class which is returned by :meth:`BaseFileLock.acquire` and wraps the lock to make sure __enter__
-# is not called twice when entering the with statement. If we would simply return *self*, the lock would be acquired
-# again in the *__enter__* method of the BaseFileLock, but not released again automatically. issue #37 (memory leak)
-class AcquireReturnProxy:
-    """A context-aware object that will release the lock file when exiting."""
-
-    def __init__(self, lock: BaseFileLock | ReadWriteLock | SoftReadWriteLock) -> None:
-        self.lock: BaseFileLock | ReadWriteLock | SoftReadWriteLock = lock
-
-    def __enter__(self) -> BaseFileLock | ReadWriteLock | SoftReadWriteLock:
-        return self.lock
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        self.lock.release()
-
-
-@dataclass
-class FileLockContext:
-    """A dataclass which holds the context for a ``BaseFileLock`` object."""
-
-    # The context is held in a separate class to allow optional use of thread local storage via the
-    # ThreadLocalFileContext class.
-
-    #: The path to the lock file.
-    lock_file: str
-
-    #: The default timeout value.
-    timeout: float
-
-    #: The mode for the lock files
-    mode: int
-
-    #: Whether the lock should be blocking or not
-    blocking: bool
-
-    #: The default polling interval value.
-    poll_interval: float
-
-    #: The lock lifetime in seconds; ``None`` means the lock never expires.
-    lifetime: float | None = None
-
-    #: The file descriptor for the *_lock_file* as it is returned by the os.open() function, not None when lock held
-    lock_file_fd: int | None = None
-
-    #: The lock counter is used for implementing the nested locking mechanism.
-    lock_counter: int = 0  # When the lock is acquired is increased and the lock is only released, when this value is 0
-
-
-class ThreadLocalFileContext(FileLockContext, local):
-    """A thread local version of the ``FileLockContext`` class."""
+_registry: Final[_ThreadLocalRegistry] = _ThreadLocalRegistry()
 
 
 _T = TypeVar("_T", bound="BaseFileLock")
@@ -159,7 +101,6 @@ class FileLockMeta(ABCMeta):
             "poll_interval": (poll_interval, instance.poll_interval),
             "lifetime": (lifetime, instance.lifetime),
         }
-
         non_matching_params = {
             name: (passed_param, set_param)
             for name, (passed_param, set_param) in params_to_check.items()
@@ -168,7 +109,6 @@ class FileLockMeta(ABCMeta):
         if not non_matching_params:
             return instance  # ty: ignore[invalid-return-type]  # https://github.com/astral-sh/ty/issues/3231
 
-        # parameters do not match; raise error
         msg = "Singleton lock instances cannot be initialized with differing arguments"
         msg += "\nNon-matching arguments: "
         for param_name, (passed_param, set_param) in non_matching_params.items():
@@ -176,11 +116,10 @@ class FileLockMeta(ABCMeta):
         raise ValueError(msg)
 
     def _create_instance(cls: type[_T], lock_file: str | os.PathLike[str], params: dict[str, Any]) -> _T:
-        # Keep only the params this subclass's __init__ accepts: virtualenv narrows the signature of its
-        # BaseFileLock descendant, so passing the full set would break it (https://github.com/tox-dev/filelock/pull/340).
+        # Keep only the params this subclass's __init__ accepts. virtualenv narrows its BaseFileLock
+        # descendant's signature, so passing the full set breaks it (tox-dev/filelock#340).
         present_params = inspect.signature(cls.__init__).parameters
-        init_params = {key: value for key, value in params.items() if key in present_params}
-        return super().__call__(lock_file, **init_params)
+        return super().__call__(lock_file, **{key: value for key, value in params.items() if key in present_params})
 
 
 class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
@@ -200,7 +139,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
     _deadlock_holder_desc: str = "FileLock instance in this thread"
 
     def __init_subclass__(cls, **kwargs: dict[str, Any]) -> None:
-        """Setup unique state for lock subclasses."""
+        """Give each lock subclass its own singleton registry and lock."""
         super().__init_subclass__(**kwargs)
         cls._instances = WeakValueDictionary()
         cls._instances_lock = Lock()
@@ -247,8 +186,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
 
-        # Create the context. Note that external code should not work with the context directly and should instead use
-        # properties of this class.
+        # External code reaches these values through the public properties, not through _context directly.
         kwargs: dict[str, Any] = {
             "lock_file": os.fspath(lock_file),
             "timeout": timeout,
@@ -379,32 +317,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         return self._context.mode != _UNSET_FILE_MODE
 
     def _open_mode(self) -> int:
-        """:returns: the mode for os.open() — 0o666 when unset (let umask/ACLs decide), else the explicit mode"""
+        """Mode for ``os.open``: 0o666 when unset so umask and ACLs decide, otherwise the explicit mode."""
         return 0o666 if self._context.mode == _UNSET_FILE_MODE else self._context.mode
-
-    def _try_break_expired_lock(self) -> None:
-        """Remove the lock file if its modification time exceeds the configured :attr:`lifetime`."""
-        if (lifetime := self._context.lifetime) is None:
-            return
-        with contextlib.suppress(OSError):
-            # lstat, not stat: an attacker with write access to the lock directory can replace a held
-            # lock file with a symlink pointing at an old file, making stat() report the target's stale
-            # mtime so a waiter breaks a live lock and two processes hold it at once. lstat reads the
-            # symlink's own mtime, matching the O_NOFOLLOW reads elsewhere.
-            st = os.lstat(self.lock_file)
-            if time.time() - st.st_mtime < lifetime:
-                return
-            break_lock_file(self.lock_file, st.st_mtime, st.st_ino)
-
-    @abstractmethod
-    def _acquire(self) -> None:
-        """If the file lock could be acquired, self._context.lock_file_fd holds the file descriptor of the lock file."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def _release(self) -> None:
-        """Releases the lock and sets self._context.lock_file_fd to None."""
-        raise NotImplementedError
 
     @property
     def is_locked(self) -> bool:
@@ -423,26 +337,28 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         """The number of times this lock has been acquired (but not yet released)."""
         return self._context.lock_counter
 
-    @staticmethod
-    def _check_give_up(  # noqa: PLR0913
-        lock_id: int,
-        lock_filename: str,
-        *,
-        blocking: bool,
-        cancel_check: Callable[[], bool] | None,
-        timeout: float,
-        start_time: float,
-    ) -> bool:
-        if blocking is False:
-            _LOGGER.debug("Failed to immediately acquire lock %s on %s", lock_id, lock_filename)
-            return True
-        if cancel_check is not None and cancel_check():
-            _LOGGER.debug("Cancellation requested for lock %s on %s", lock_id, lock_filename)
-            return True
-        if 0 <= timeout < time.perf_counter() - start_time:
-            _LOGGER.debug("Timeout on acquiring lock %s on %s", lock_id, lock_filename)
-            return True
-        return False
+    def __enter__(self) -> Self:
+        """
+        Acquire the lock.
+
+        :returns: the lock object
+
+        """
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Release the lock."""
+        self.release()
+
+    def __del__(self) -> None:
+        """Force-release so a dropped reference never leaks a held lock."""
+        self.release(force=True)
 
     def acquire(
         self,
@@ -489,7 +405,6 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             without side effects.
 
         """
-        # Use the default timeout, if no timeout is provided.
         if timeout is None:
             timeout = self._context.timeout
 
@@ -503,7 +418,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
 
         poll_interval = poll_interval if poll_interval is not None else self._context.poll_interval
 
-        # Increment the number right at the beginning. We can still undo it, if something fails.
+        # Bump the counter up front; _undo_acquire rolls it back if acquisition fails.
         self._context.lock_counter += 1
 
         canonical = _canonical(self.lock_file)
@@ -524,6 +439,26 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         self._commit_acquire(canonical)
         return AcquireReturnProxy(lock=self)
 
+    def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
+        """
+        Release the file lock. The lock is only completely released when the lock counter reaches 0. The lock file
+        itself may be deleted automatically, the behavior is platform-specific.
+
+        :param force: If true, the lock counter is ignored and the lock is released in every case.
+
+        """
+        if self.is_locked:
+            self._context.lock_counter -= 1
+
+            if self._context.lock_counter == 0 or force:
+                lock_id, lock_filename = id(self), self.lock_file
+
+                _LOGGER.debug("Attempting to release lock %s on %s", lock_id, lock_filename)
+                self._release()
+                self._context.lock_counter = 0
+                self._drop_registry_entry()
+                _LOGGER.debug("Lock %s released on %s", lock_id, lock_filename)
+
     def _raise_if_would_deadlock(self, canonical: str, *, timeout: float, blocking: bool) -> None:
         """
         Fail fast when a *different* live instance already holds this path on the current thread/task.
@@ -539,21 +474,6 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
                 f"Use is_singleton=True to enable reentrant locking across instances."
             )
             raise RuntimeError(msg)
-
-    def _undo_acquire(self, canonical: str) -> None:
-        """Roll back the counter after a failed acquire, dropping the registry entry once nothing holds the path."""
-        self._context.lock_counter = max(0, self._context.lock_counter - 1)
-        if self._context.lock_counter == 0:
-            _registry.held.pop(canonical, None)
-
-    def _commit_acquire(self, canonical: str) -> None:
-        """Record this instance as the holder once the first acquire succeeds, so peers can detect the deadlock."""
-        if self._context.lock_counter == 1:
-            _registry.held[canonical] = id(self)
-
-    def _drop_registry_entry(self) -> None:
-        """Forget this path's holder on release so a later cross-instance acquire is not misread as a deadlock."""
-        _registry.held.pop(_canonical(self.lock_file), None)
 
     def _poll_until_acquired(
         self,
@@ -587,35 +507,77 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             _LOGGER.debug(msg, lock_id, lock_filename, poll_interval)
             time.sleep(poll_interval)
 
-    def release(self, force: bool = False) -> None:  # noqa: FBT001, FBT002
-        """
-        Release the file lock. The lock is only completely released when the lock counter reaches 0. The lock file
-        itself may be deleted automatically, the behavior is platform-specific.
+    def _undo_acquire(self, canonical: str) -> None:
+        """Roll back the counter after a failed acquire, dropping the registry entry once nothing holds the path."""
+        self._context.lock_counter = max(0, self._context.lock_counter - 1)
+        if self._context.lock_counter == 0:
+            _registry.held.pop(canonical, None)
 
-        :param force: If true, the lock counter is ignored and the lock is released in every case.
+    def _commit_acquire(self, canonical: str) -> None:
+        """Record this instance as the holder once the first acquire succeeds, so peers can detect the deadlock."""
+        if self._context.lock_counter == 1:
+            _registry.held[canonical] = id(self)
 
-        """
-        if self.is_locked:
-            self._context.lock_counter -= 1
+    def _drop_registry_entry(self) -> None:
+        """Forget this path's holder on release so a later cross-instance acquire is not misread as a deadlock."""
+        _registry.held.pop(_canonical(self.lock_file), None)
 
-            if self._context.lock_counter == 0 or force:
-                lock_id, lock_filename = id(self), self.lock_file
+    def _try_break_expired_lock(self) -> None:
+        """Remove the lock file if its modification time exceeds the configured :attr:`lifetime`."""
+        if (lifetime := self._context.lifetime) is None:
+            return
+        with contextlib.suppress(OSError):
+            # lstat, not stat: an attacker with write access to the lock directory can replace a held
+            # lock file with a symlink pointing at an old file, making stat() report the target's stale
+            # mtime so a waiter breaks a live lock and two processes hold it at once. lstat reads the
+            # symlink's own mtime, matching the O_NOFOLLOW reads elsewhere.
+            st = os.lstat(self.lock_file)
+            if time.time() - st.st_mtime < lifetime:
+                return
+            break_lock_file(self.lock_file, st.st_mtime, st.st_ino)
 
-                _LOGGER.debug("Attempting to release lock %s on %s", lock_id, lock_filename)
-                self._release()
-                self._context.lock_counter = 0
-                self._drop_registry_entry()
-                _LOGGER.debug("Lock %s released on %s", lock_id, lock_filename)
+    @staticmethod
+    def _check_give_up(  # noqa: PLR0913
+        lock_id: int,
+        lock_filename: str,
+        *,
+        blocking: bool,
+        cancel_check: Callable[[], bool] | None,
+        timeout: float,
+        start_time: float,
+    ) -> bool:
+        if blocking is False:
+            _LOGGER.debug("Failed to immediately acquire lock %s on %s", lock_id, lock_filename)
+            return True
+        if cancel_check is not None and cancel_check():
+            _LOGGER.debug("Cancellation requested for lock %s on %s", lock_id, lock_filename)
+            return True
+        if 0 <= timeout < time.perf_counter() - start_time:
+            _LOGGER.debug("Timeout on acquiring lock %s on %s", lock_id, lock_filename)
+            return True
+        return False
 
-    def __enter__(self) -> Self:
-        """
-        Acquire the lock.
+    @abstractmethod
+    def _acquire(self) -> None:
+        """If the file lock could be acquired, self._context.lock_file_fd holds the file descriptor of the lock file."""
+        raise NotImplementedError
 
-        :returns: the lock object
+    @abstractmethod
+    def _release(self) -> None:
+        """Releases the lock and sets self._context.lock_file_fd to None."""
+        raise NotImplementedError
 
-        """
-        self.acquire()
-        return self
+
+# acquire() returns this wrapper instead of self so entering the with-statement does not call __enter__ a second
+# time; returning self would re-acquire the lock in BaseFileLock.__enter__ without a matching release (issue #37).
+class AcquireReturnProxy:
+    """A context-aware object that will release the lock file when exiting."""
+
+    def __init__(self, lock: BaseFileLock | ReadWriteLock | SoftReadWriteLock) -> None:
+        self.lock: BaseFileLock | ReadWriteLock | SoftReadWriteLock = lock
+
+    def __enter__(self) -> BaseFileLock | ReadWriteLock | SoftReadWriteLock:
+        return self.lock
 
     def __exit__(
         self,
@@ -623,19 +585,33 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """
-        Release the lock.
+        self.lock.release()
 
-        :param exc_type: the exception type if raised
-        :param exc_value: the exception value if raised
-        :param traceback: the exception traceback if raised
 
-        """
-        self.release()
+@dataclass
+class FileLockContext:
+    """Holds the context for a ``BaseFileLock`` object."""
 
-    def __del__(self) -> None:
-        """Called when the lock object is deleted."""
-        self.release(force=True)
+    # A separate class so ThreadLocalFileContext can make the whole context thread-local.
+
+    lock_file: str
+    timeout: float
+    mode: int
+    blocking: bool
+    poll_interval: float
+
+    #: The lock lifetime in seconds; ``None`` means the lock never expires.
+    lifetime: float | None = None
+
+    #: File descriptor from os.open for the lock file; not None while the lock is held.
+    lock_file_fd: int | None = None
+
+    #: Depth of nested acquisitions; the lock is released only when it returns to 0.
+    lock_counter: int = 0
+
+
+class ThreadLocalFileContext(FileLockContext, local):
+    """A thread local version of the ``FileLockContext`` class."""
 
 
 __all__ = [

--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -17,41 +17,23 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 
-class AsyncAcquireReadWriteReturnProxy:
-    """Context-aware object that releases the async read/write lock on exit."""
-
-    def __init__(self, lock: AsyncReadWriteLock) -> None:
-        self.lock = lock
-
-    async def __aenter__(self) -> AsyncReadWriteLock:
-        return self.lock
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        await self.lock.release()
-
-
 class AsyncReadWriteLock:
     """
     Async wrapper around :class:`ReadWriteLock` for use in ``asyncio`` applications.
 
-    Because Python's :mod:`sqlite3` module has no async API, all blocking SQLite operations are dispatched to a thread
-    pool via ``loop.run_in_executor()``. Reentrancy, upgrade/downgrade rules, and singleton behavior are delegated
-    to the underlying :class:`ReadWriteLock`.
+    This wrapper dispatches every blocking SQLite operation to a thread pool via ``loop.run_in_executor()`` because
+    Python's :mod:`sqlite3` module has no async API. It delegates reentrancy, upgrade/downgrade rules, and singleton
+    behavior to the underlying :class:`ReadWriteLock`.
 
     :param lock_file: path to the SQLite database file used as the lock
     :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
     :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable
     :param is_singleton: if ``True``, reuse existing :class:`ReadWriteLock` instances for the same resolved path
     :param loop: event loop for ``run_in_executor``; ``None`` uses the running loop
-    :param executor: executor for ``run_in_executor``. When ``None`` a dedicated single-thread executor is created
-        and owned by this lock, ensuring every operation runs on the same thread (required for SQLite affinity); it
-        is shut down by :meth:`close`. A caller-supplied executor is used as-is and never shut down here, so when no
-        executor is passed remember to call :meth:`close` to release the owned one.
+    :param executor: executor for ``run_in_executor``. When ``None`` this lock creates and owns a dedicated
+        single-thread executor so every operation runs on the same thread (SQLite affinity requires this) and shuts it
+        down in :meth:`close`. This lock uses a caller-supplied executor as-is and never shuts it down, so after passing
+        no executor call :meth:`close` to release the owned one.
 
     .. versionadded:: 3.21.0
 
@@ -97,9 +79,47 @@ class AsyncReadWriteLock:
         """The executor used for ``run_in_executor`` (a dedicated single-thread one if none was supplied)."""
         return self._executor
 
-    async def _run(self, func: Callable[..., object], *args: object, **kwargs: object) -> object:
-        loop = self._loop or asyncio.get_running_loop()
-        return await loop.run_in_executor(self._executor, functools.partial(func, *args, **kwargs))
+    @asynccontextmanager
+    async def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
+        """
+        Async context manager that acquires and releases a shared read lock.
+
+        Falls back to instance defaults for *timeout* and *blocking* when ``None``.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        """
+        if timeout is None:
+            timeout = self._lock.timeout
+        if blocking is None:
+            blocking = self._lock.blocking
+        await self.acquire_read(timeout, blocking=blocking)
+        try:
+            yield
+        finally:
+            await self.release()
+
+    @asynccontextmanager
+    async def write_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
+        """
+        Async context manager that acquires and releases an exclusive write lock.
+
+        Falls back to instance defaults for *timeout* and *blocking* when ``None``.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        """
+        if timeout is None:
+            timeout = self._lock.timeout
+        if blocking is None:
+            blocking = self._lock.blocking
+        await self.acquire_write(timeout, blocking=blocking)
+        try:
+            yield
+        finally:
+            await self.release()
 
     async def acquire_read(self, timeout: float = -1, *, blocking: bool = True) -> AsyncAcquireReadWriteReturnProxy:
         """
@@ -150,48 +170,6 @@ class AsyncReadWriteLock:
         """
         await self._run(self._lock.release, force=force)
 
-    @asynccontextmanager
-    async def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
-        """
-        Async context manager that acquires and releases a shared read lock.
-
-        Falls back to instance defaults for *timeout* and *blocking* when ``None``.
-
-        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
-        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
-
-        """
-        if timeout is None:
-            timeout = self._lock.timeout
-        if blocking is None:
-            blocking = self._lock.blocking
-        await self.acquire_read(timeout, blocking=blocking)
-        try:
-            yield
-        finally:
-            await self.release()
-
-    @asynccontextmanager
-    async def write_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
-        """
-        Async context manager that acquires and releases an exclusive write lock.
-
-        Falls back to instance defaults for *timeout* and *blocking* when ``None``.
-
-        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
-        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
-
-        """
-        if timeout is None:
-            timeout = self._lock.timeout
-        if blocking is None:
-            blocking = self._lock.blocking
-        await self.acquire_write(timeout, blocking=blocking)
-        try:
-            yield
-        finally:
-            await self.release()
-
     async def close(self) -> None:
         """
         Release the lock (if held) and close the underlying SQLite connection.
@@ -203,11 +181,33 @@ class AsyncReadWriteLock:
         if self._owns_executor:
             self._executor.shutdown(wait=False)
 
+    async def _run(self, func: Callable[..., object], *args: object, **kwargs: object) -> object:
+        loop = self._loop or asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, functools.partial(func, *args, **kwargs))
+
     def __del__(self) -> None:
-        # Safety net: if close() was never called, still shut down the executor we created so its worker thread does
-        # not outlive the lock. A caller-supplied executor is left untouched. shutdown(wait=False) never blocks.
+        # Safety net when close() was never called: shut down the executor we own so its worker thread does not
+        # outlive the lock. shutdown(wait=False) never blocks.
         if getattr(self, "_owns_executor", False):
             self._executor.shutdown(wait=False)
+
+
+class AsyncAcquireReadWriteReturnProxy:
+    """Context-aware object that releases the async read/write lock on exit."""
+
+    def __init__(self, lock: AsyncReadWriteLock) -> None:
+        self.lock = lock
+
+    async def __aenter__(self) -> AsyncReadWriteLock:
+        return self.lock
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.lock.release()
 
 
 __all__ = [

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -9,7 +9,8 @@ class Timeout(TimeoutError):  # noqa: N818
         self._lock_file = lock_file
 
     def __reduce__(self) -> tuple[type[Timeout], tuple[str]]:
-        return self.__class__, (self._lock_file,)  # Properly pickle the exception
+        # __init__ needs lock_file, so pickle must restore it as a constructor arg
+        return self.__class__, (self._lock_file,)
 
     def __str__(self) -> str:
         return f"The file lock '{self._lock_file}' could not be acquired."

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -8,7 +8,7 @@ import sqlite3
 import threading
 import time
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 from weakref import WeakValueDictionary
 
 from ._api import AcquireReturnProxy
@@ -17,10 +17,10 @@ from ._error import Timeout
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-_LOGGER = logging.getLogger("filelock")
+_LOGGER: Final[logging.Logger] = logging.getLogger("filelock")
 
-_all_connections: set[sqlite3.Connection] = set()
-_all_connections_lock = threading.Lock()
+_all_connections: Final[set[sqlite3.Connection]] = set()
+_all_connections_lock: Final[threading.Lock] = threading.Lock()
 
 
 def _cleanup_connections() -> None:
@@ -34,34 +34,15 @@ def _cleanup_connections() -> None:
 atexit.register(_cleanup_connections)
 
 # sqlite3_busy_timeout() accepts a C int, max 2_147_483_647 on 32-bit. Use a lower value to be safe (~23 days).
-_MAX_SQLITE_TIMEOUT_MS = 2_000_000_000 - 1
-
-
-def timeout_for_sqlite(timeout: float, *, blocking: bool, already_waited: float) -> int:
-    if blocking is False:
-        return 0
-
-    if timeout == -1:
-        return _MAX_SQLITE_TIMEOUT_MS
-
-    if timeout < 0:
-        msg = "timeout must be a non-negative number or -1"
-        raise ValueError(msg)
-
-    remaining = max(timeout - already_waited, 0) if timeout > 0 else timeout
-    timeout_ms = int(remaining * 1000)
-    if timeout_ms > _MAX_SQLITE_TIMEOUT_MS or timeout_ms < 0:
-        _LOGGER.warning("timeout %s is too large for SQLite, using %s ms instead", timeout, _MAX_SQLITE_TIMEOUT_MS)
-        return _MAX_SQLITE_TIMEOUT_MS
-    return timeout_ms
+_MAX_SQLITE_TIMEOUT_MS: Final[int] = 2_000_000_000 - 1
 
 
 class _ReadWriteLockMeta(type):
     """
-    Metaclass that handles singleton resolution when is_singleton=True.
+    Resolve singleton instances for ``is_singleton=True`` construction.
 
-    Singleton logic lives here rather than in ReadWriteLock.get_lock so that ``ReadWriteLock(path)`` transparently
-    returns cached instances without a 2-arg ``super()`` call that type checkers cannot verify.
+    This logic lives here rather than in ReadWriteLock.get_lock so ``ReadWriteLock(path)`` returns cached instances
+    without a 2-arg ``super()`` call that type checkers cannot verify.
 
     """
 
@@ -158,104 +139,6 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         with _all_connections_lock:
             _all_connections.add(self._con)
 
-    def _acquire_transaction_lock(self, *, blocking: bool, timeout: float) -> None:
-        if not blocking:
-            acquired = self._transaction_lock.acquire(blocking=False)
-        elif timeout == -1:
-            acquired = self._transaction_lock.acquire(blocking=True)
-        else:
-            acquired = self._transaction_lock.acquire(blocking=True, timeout=timeout)
-        if not acquired:
-            raise Timeout(self.lock_file) from None
-
-    def _validate_reentrant(self, mode: Literal["read", "write"]) -> AcquireReturnProxy:
-        opposite = "write" if mode == "read" else "read"
-        direction = "downgrade" if mode == "read" else "upgrade"
-        if self._current_mode != mode:
-            msg = (
-                f"Cannot acquire {mode} lock on {self.lock_file} (lock id: {id(self)}): "
-                f"already holding a {opposite} lock ({direction} not allowed)"
-            )
-            raise RuntimeError(msg)
-        if mode == "write" and (cur := threading.get_ident()) != self._write_thread_id:
-            msg = (
-                f"Cannot acquire write lock on {self.lock_file} (lock id: {id(self)}) "
-                f"from thread {cur} while it is held by thread {self._write_thread_id}"
-            )
-            raise RuntimeError(msg)
-        self._lock_level += 1
-        return AcquireReturnProxy(lock=self)
-
-    def _configure_and_begin(
-        self, mode: Literal["read", "write"], timeout: float, *, blocking: bool, start_time: float
-    ) -> None:
-        waited = time.perf_counter() - start_time
-        timeout_ms = timeout_for_sqlite(timeout, blocking=blocking, already_waited=waited)
-        self._con.execute(f"PRAGMA busy_timeout={timeout_ms};").close()
-        # Use legacy journal mode (not WAL) because WAL does not block readers when a concurrent EXCLUSIVE
-        # write transaction is active, making read-write locking impossible without modifying table data.
-        # MEMORY is safe here since no actual writes happen — crashes cannot corrupt the DB.
-        # See https://sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
-        #
-        # Set here (not in __init__) because this pragma itself may block on a locked database,
-        # so it must run after busy_timeout is configured above.
-        self._con.execute("PRAGMA journal_mode=MEMORY;").close()
-        # Recompute remaining timeout after the potentially blocking journal_mode pragma.
-        waited = time.perf_counter() - start_time
-        if (recomputed := timeout_for_sqlite(timeout, blocking=blocking, already_waited=waited)) != timeout_ms:
-            self._con.execute(f"PRAGMA busy_timeout={recomputed};").close()
-        stmt = "BEGIN EXCLUSIVE TRANSACTION;" if mode == "write" else "BEGIN TRANSACTION;"
-        self._con.execute(stmt).close()
-        if mode == "read":
-            # A SELECT is needed to force SQLite to actually acquire the SHARED lock on the database.
-            # https://www.sqlite.org/lockingv3.html#transaction_control
-            self._con.execute("SELECT name FROM sqlite_schema LIMIT 1;").close()
-
-    def _acquire(self, mode: Literal["read", "write"], timeout: float, *, blocking: bool) -> AcquireReturnProxy:
-        with self._internal_lock:
-            if self._lock_level > 0:
-                return self._validate_reentrant(mode)
-
-        start_time = time.perf_counter()
-        self._acquire_transaction_lock(blocking=blocking, timeout=timeout)
-        try:
-            return self._do_acquire_inner(mode, timeout, blocking=blocking, start_time=start_time)
-        except sqlite3.Error as exc:
-            # A read acquire runs BEGIN (a deferred transaction that takes no database lock) and only then the
-            # SELECT that actually takes the SHARED lock. If a writer grabs the EXCLUSIVE lock between the two,
-            # the SELECT fails but BEGIN's transaction is left open on the shared connection. Roll it back here,
-            # while we still hold _transaction_lock, otherwise the next acquire's BEGIN dies with "cannot start a
-            # transaction within a transaction" and the instance is wedged for good. Catch only sqlite3.Error: a
-            # reentrant-validation RuntimeError from _do_acquire_inner's double-check must not roll back, or it
-            # would drop a transaction another thread legitimately holds on the shared connection.
-            with suppress(sqlite3.Error):
-                self._con.rollback()
-            if isinstance(exc, sqlite3.OperationalError) and "database is locked" in str(exc):
-                raise Timeout(self.lock_file) from None
-            raise
-        finally:
-            self._transaction_lock.release()
-
-    def _do_acquire_inner(
-        self,
-        mode: Literal["read", "write"],
-        timeout: float,
-        *,
-        blocking: bool,
-        start_time: float,
-    ) -> AcquireReturnProxy:
-        # Double-check: another thread may have acquired the lock while we waited on _transaction_lock.
-        with self._internal_lock:
-            if self._lock_level > 0:
-                return self._validate_reentrant(mode)
-        self._configure_and_begin(mode, timeout, blocking=blocking, start_time=start_time)
-        with self._internal_lock:
-            self._current_mode = mode
-            self._lock_level = 1
-            if mode == "write":
-                self._write_thread_id = threading.get_ident()
-        return AcquireReturnProxy(lock=self)
-
     def acquire_read(self, timeout: float = -1, *, blocking: bool = True) -> AcquireReturnProxy:
         """
         Acquire a shared read lock.
@@ -293,42 +176,6 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
         """
         return self._acquire("write", timeout, blocking=blocking)
-
-    def release(self, *, force: bool = False) -> None:
-        """
-        Release one level of the current lock.
-
-        When the lock level reaches zero the underlying SQLite transaction is rolled back, releasing the database lock.
-
-        :param force: if ``True``, release the lock completely regardless of the current lock level
-
-        :raises RuntimeError: if no lock is currently held and *force* is ``False``
-
-        """
-        should_rollback = False
-        with self._internal_lock:
-            if self._lock_level == 0:
-                if force:
-                    return
-                msg = f"Cannot release a lock on {self.lock_file} (lock id: {id(self)}) that is not held"
-                raise RuntimeError(msg)
-            if force:
-                self._lock_level = 0
-            else:
-                self._lock_level -= 1
-            if self._lock_level == 0:
-                self._current_mode = None
-                self._write_thread_id = None
-                should_rollback = True
-        if should_rollback:
-            # The rollback ends the transaction on the shared connection, so it has to be serialized against
-            # acquire()'s BEGIN the same way acquire() already serializes itself with _transaction_lock. Without
-            # this, another thread that sees lock_level back at 0 can start its BEGIN while this rollback's
-            # transaction is still open (raising "cannot start a transaction within a transaction") or, in the
-            # other ordering, have its freshly started transaction rolled back here, dropping the database lock
-            # while it still believes it holds it.
-            with self._transaction_lock:
-                self._con.rollback()
 
     @contextmanager
     def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> Generator[None]:
@@ -372,6 +219,42 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         finally:
             self.release()
 
+    def release(self, *, force: bool = False) -> None:
+        """
+        Release one level of the current lock.
+
+        When the lock level reaches zero the underlying SQLite transaction is rolled back, releasing the database lock.
+
+        :param force: if ``True``, release the lock completely regardless of the current lock level
+
+        :raises RuntimeError: if no lock is currently held and *force* is ``False``
+
+        """
+        should_rollback = False
+        with self._internal_lock:
+            if self._lock_level == 0:
+                if force:
+                    return
+                msg = f"Cannot release a lock on {self.lock_file} (lock id: {id(self)}) that is not held"
+                raise RuntimeError(msg)
+            if force:
+                self._lock_level = 0
+            else:
+                self._lock_level -= 1
+            if self._lock_level == 0:
+                self._current_mode = None
+                self._write_thread_id = None
+                should_rollback = True
+        if should_rollback:
+            # The rollback ends the transaction on the shared connection, so it has to be serialized against
+            # acquire()'s BEGIN the same way acquire() already serializes itself with _transaction_lock. Without
+            # this, another thread that sees lock_level back at 0 can start its BEGIN while this rollback's
+            # transaction is still open (raising "cannot start a transaction within a transaction") or, in the
+            # other ordering, have its freshly started transaction rolled back here, dropping the database lock
+            # while it still believes it holds it.
+            with self._transaction_lock:
+                self._con.rollback()
+
     def close(self) -> None:
         """
         Release the lock (if held) and close the underlying SQLite connection.
@@ -383,3 +266,118 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         self._con.close()
         with _all_connections_lock:
             _all_connections.discard(self._con)
+
+    def _acquire(self, mode: Literal["read", "write"], timeout: float, *, blocking: bool) -> AcquireReturnProxy:
+        with self._internal_lock:
+            if self._lock_level > 0:
+                return self._validate_reentrant(mode)
+
+        start_time = time.perf_counter()
+        self._acquire_transaction_lock(blocking=blocking, timeout=timeout)
+        try:
+            return self._do_acquire_inner(mode, timeout, blocking=blocking, start_time=start_time)
+        except sqlite3.Error as exc:
+            # A read acquire runs BEGIN (a deferred transaction that takes no database lock) and only then the
+            # SELECT that takes the SHARED lock. If a writer grabs the EXCLUSIVE lock between the two, the SELECT
+            # fails but BEGIN's transaction is left open on the shared connection. Roll it back here, while we still
+            # hold _transaction_lock, otherwise the next acquire's BEGIN dies with "cannot start a transaction
+            # within a transaction" and the instance is wedged for good. Catch only sqlite3.Error: a
+            # reentrant-validation RuntimeError from _do_acquire_inner's double-check must not roll back, or it
+            # would drop a transaction another thread holds on the shared connection.
+            with suppress(sqlite3.Error):
+                self._con.rollback()
+            if isinstance(exc, sqlite3.OperationalError) and "database is locked" in str(exc):
+                raise Timeout(self.lock_file) from None
+            raise
+        finally:
+            self._transaction_lock.release()
+
+    def _do_acquire_inner(
+        self,
+        mode: Literal["read", "write"],
+        timeout: float,
+        *,
+        blocking: bool,
+        start_time: float,
+    ) -> AcquireReturnProxy:
+        # Double-check: another thread may have acquired the lock while we waited on _transaction_lock.
+        with self._internal_lock:
+            if self._lock_level > 0:
+                return self._validate_reentrant(mode)
+        self._configure_and_begin(mode, timeout, blocking=blocking, start_time=start_time)
+        with self._internal_lock:
+            self._current_mode = mode
+            self._lock_level = 1
+            if mode == "write":
+                self._write_thread_id = threading.get_ident()
+        return AcquireReturnProxy(lock=self)
+
+    def _configure_and_begin(
+        self, mode: Literal["read", "write"], timeout: float, *, blocking: bool, start_time: float
+    ) -> None:
+        waited = time.perf_counter() - start_time
+        timeout_ms = timeout_for_sqlite(timeout, blocking=blocking, already_waited=waited)
+        self._con.execute(f"PRAGMA busy_timeout={timeout_ms};").close()
+        # Use legacy journal mode (not WAL) because WAL does not block readers while a concurrent EXCLUSIVE
+        # write transaction is active, which makes read-write locking impossible without modifying table data.
+        # MEMORY is safe here since no writes happen, so a crash cannot corrupt the DB.
+        # See https://sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
+        #
+        # Set here (not in __init__) because this pragma may block on a locked database, so it must run after
+        # busy_timeout is configured above.
+        self._con.execute("PRAGMA journal_mode=MEMORY;").close()
+        # Recompute the remaining timeout after the blocking journal_mode pragma.
+        waited = time.perf_counter() - start_time
+        if (recomputed := timeout_for_sqlite(timeout, blocking=blocking, already_waited=waited)) != timeout_ms:
+            self._con.execute(f"PRAGMA busy_timeout={recomputed};").close()
+        self._con.execute("BEGIN EXCLUSIVE TRANSACTION;" if mode == "write" else "BEGIN TRANSACTION;").close()
+        if mode == "read":
+            # SQLite takes the SHARED lock only when a statement reads; BEGIN alone stays deferred.
+            # https://www.sqlite.org/lockingv3.html#transaction_control
+            self._con.execute("SELECT name FROM sqlite_schema LIMIT 1;").close()
+
+    def _validate_reentrant(self, mode: Literal["read", "write"]) -> AcquireReturnProxy:
+        if self._current_mode != mode:
+            opposite = "write" if mode == "read" else "read"
+            direction = "downgrade" if mode == "read" else "upgrade"
+            msg = (
+                f"Cannot acquire {mode} lock on {self.lock_file} (lock id: {id(self)}): "
+                f"already holding a {opposite} lock ({direction} not allowed)"
+            )
+            raise RuntimeError(msg)
+        if mode == "write" and (cur := threading.get_ident()) != self._write_thread_id:
+            msg = (
+                f"Cannot acquire write lock on {self.lock_file} (lock id: {id(self)}) "
+                f"from thread {cur} while it is held by thread {self._write_thread_id}"
+            )
+            raise RuntimeError(msg)
+        self._lock_level += 1
+        return AcquireReturnProxy(lock=self)
+
+    def _acquire_transaction_lock(self, *, blocking: bool, timeout: float) -> None:
+        if not blocking:
+            acquired = self._transaction_lock.acquire(blocking=False)
+        elif timeout == -1:
+            acquired = self._transaction_lock.acquire(blocking=True)
+        else:
+            acquired = self._transaction_lock.acquire(blocking=True, timeout=timeout)
+        if not acquired:
+            raise Timeout(self.lock_file) from None
+
+
+def timeout_for_sqlite(timeout: float, *, blocking: bool, already_waited: float) -> int:
+    if blocking is False:
+        return 0
+
+    if timeout == -1:
+        return _MAX_SQLITE_TIMEOUT_MS
+
+    if timeout < 0:
+        msg = "timeout must be a non-negative number or -1"
+        raise ValueError(msg)
+
+    timeout_ms = int((max(timeout - already_waited, 0) if timeout > 0 else timeout) * 1000)
+    if timeout_ms > _MAX_SQLITE_TIMEOUT_MS or timeout_ms < 0:
+        _LOGGER.warning("timeout %s is too large for SQLite, using %s ms instead", timeout, _MAX_SQLITE_TIMEOUT_MS)
+        return _MAX_SQLITE_TIMEOUT_MS
+    return timeout_ms

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -7,15 +7,16 @@ import time
 from contextlib import suppress
 from errno import EACCES, EEXIST, EPERM, ESRCH
 from pathlib import Path
+from typing import Final
 
 from ._api import BaseFileLock
 from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file
 
-_WIN_SYNCHRONIZE = 0x100000
-_WIN_ERROR_INVALID_PARAMETER = 87
-_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-_MALFORMED_LOCK_AGE_THRESHOLD = 2.0
-_MAX_LOCK_FILE_SIZE = 1024
+_WIN_SYNCHRONIZE: Final[int] = 0x100000
+_WIN_ERROR_INVALID_PARAMETER: Final[int] = 87
+_WIN_PROCESS_QUERY_LIMITED_INFORMATION: Final[int] = 0x1000
+_MALFORMED_LOCK_AGE_THRESHOLD: Final[float] = 2.0
+_MAX_LOCK_FILE_SIZE: Final[int] = 1024
 
 
 class SoftFileLock(BaseFileLock):
@@ -35,12 +36,9 @@ class SoftFileLock(BaseFileLock):
     def _acquire(self) -> None:
         raise_on_not_writable_file(self.lock_file)
         ensure_directory_exists(self.lock_file)
-        flags = (
-            os.O_WRONLY  # open for writing only
-            | os.O_CREAT
-            | os.O_EXCL  # together with above raise EEXIST if the file specified by filename exists
-            | os.O_TRUNC  # truncate the file to zero byte
-        )
+        # O_CREAT | O_EXCL makes the create fail with EEXIST when the file already exists, so a successful open
+        # means this process now holds the lock.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
         if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:
             flags |= o_nofollow
         try:
@@ -74,11 +72,11 @@ class SoftFileLock(BaseFileLock):
 
             if self._is_process_alive(pid):
                 if sys.platform != "win32" or creation_time is None:  # pragma: win32 no cover
-                    return  # same process, or no creation time to disambiguate a recycled PID — don't evict
+                    return  # same process, or no creation time to disambiguate a recycled PID, so don't evict
                 actual = self._get_process_creation_time(pid)  # pragma: win32 cover
                 if actual is None or actual == creation_time:  # pragma: win32 cover
-                    return  # same process or can't verify — don't evict
-                # else: PID alive but creation time differs — the PID was recycled, so the lock is stale.
+                    return  # same process or can't verify, so don't evict
+                # PID alive but creation time differs, so the PID was recycled and the lock is stale.
 
             break_lock_file(self.lock_file, mtime, ino)
 
@@ -220,7 +218,7 @@ def _read_lock_file(path: str) -> tuple[str | None, float, int]:
 
 def _parse_lock_holder(content: str | None) -> tuple[int, str, int | None] | None:
     # A well-formed lock file is "<pid>\n<hostname>\n" with an optional "<creation_time>\n" third line on Windows.
-    # Anything else — wrong line count, a non-integer PID or creation time, empty or unreadable content — is
+    # Anything else (wrong line count, a non-integer PID or creation time, empty or unreadable content) is
     # unparsable; returning None lets the caller treat it as a malformed lock to self-heal rather than a holder.
     if not content or len(lines := content.strip().splitlines()) not in {2, 3}:
         return None

--- a/src/filelock/_soft_rw/_async.py
+++ b/src/filelock/_soft_rw/_async.py
@@ -16,31 +16,13 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 
-class AsyncAcquireSoftReadWriteReturnProxy:
-    """Async context-aware object that releases an :class:`AsyncSoftReadWriteLock` on exit."""
-
-    def __init__(self, lock: AsyncSoftReadWriteLock) -> None:
-        self.lock = lock
-
-    async def __aenter__(self) -> AsyncSoftReadWriteLock:
-        return self.lock
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        await self.lock.release()
-
-
 class AsyncSoftReadWriteLock:
     """
     Async wrapper around :class:`SoftReadWriteLock` for ``asyncio`` applications.
 
-    The sync class's blocking filesystem operations run on a thread pool via ``loop.run_in_executor()``.
-    Reentrancy, upgrade/downgrade rules, fork handling, heartbeat and TTL stale detection, and singleton
-    behavior are delegated to the underlying :class:`SoftReadWriteLock`.
+    The sync class's blocking filesystem operations run on a thread pool via ``loop.run_in_executor()``. The
+    underlying :class:`SoftReadWriteLock` handles reentrancy, upgrade/downgrade rules, fork handling, heartbeat and
+    TTL stale detection, and singleton behavior.
 
     :param lock_file: path to the lock file; sidecar state/write/readers live next to it
     :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
@@ -106,62 +88,6 @@ class AsyncSoftReadWriteLock:
         """The executor used for ``run_in_executor``, or ``None`` for the default executor."""
         return self._executor
 
-    async def acquire_read(
-        self, timeout: float | None = None, *, blocking: bool | None = None
-    ) -> AsyncAcquireSoftReadWriteReturnProxy:
-        """
-        Acquire a shared read lock.
-
-        See :meth:`SoftReadWriteLock.acquire_read` for the full reentrancy / upgrade / fork semantics. The blocking
-        work runs inside ``run_in_executor`` so other coroutines on the same loop continue to progress while this
-        call waits.
-
-        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
-        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
-
-        :returns: a proxy usable as an async context manager to release the lock
-
-        :raises RuntimeError: if a write lock is already held, if this instance was invalidated by
-            :func:`os.fork`, or if :meth:`close` was called
-        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
-
-        """
-        await self._run(self._lock.acquire_read, timeout, blocking=blocking)
-        return AsyncAcquireSoftReadWriteReturnProxy(lock=self)
-
-    async def acquire_write(
-        self, timeout: float | None = None, *, blocking: bool | None = None
-    ) -> AsyncAcquireSoftReadWriteReturnProxy:
-        """
-        Acquire an exclusive write lock.
-
-        See :meth:`SoftReadWriteLock.acquire_write` for the two-phase writer-preferring semantics. The blocking
-        work runs inside ``run_in_executor``.
-
-        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
-        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
-
-        :returns: a proxy usable as an async context manager to release the lock
-
-        :raises RuntimeError: if a read lock is already held, if a write lock is held by a different thread, if
-            this instance was invalidated by :func:`os.fork`, or if :meth:`close` was called
-        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
-
-        """
-        await self._run(self._lock.acquire_write, timeout, blocking=blocking)
-        return AsyncAcquireSoftReadWriteReturnProxy(lock=self)
-
-    async def release(self, *, force: bool = False) -> None:
-        """
-        Release one level of the current lock.
-
-        :param force: if ``True``, release the lock completely regardless of the current lock level
-
-        :raises RuntimeError: if no lock is currently held and *force* is ``False``
-
-        """
-        await self._run(self._lock.release, force=force)
-
     @asynccontextmanager
     async def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> AsyncGenerator[None]:
         """
@@ -198,6 +124,61 @@ class AsyncSoftReadWriteLock:
         finally:
             await self.release()
 
+    async def acquire_read(
+        self, timeout: float | None = None, *, blocking: bool | None = None
+    ) -> AsyncAcquireSoftReadWriteReturnProxy:
+        """
+        Acquire a shared read lock.
+
+        See :meth:`SoftReadWriteLock.acquire_read` for reentrancy / upgrade / fork semantics. The blocking work runs
+        inside ``run_in_executor`` so other coroutines on the same loop keep progressing while this call waits.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        :returns: a proxy usable as an async context manager to release the lock
+
+        :raises RuntimeError: if a write lock is already held, if this instance was invalidated by
+            :func:`os.fork`, or if :meth:`close` was called
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        await self._run(self._lock.acquire_read, timeout, blocking=blocking)
+        return AsyncAcquireSoftReadWriteReturnProxy(lock=self)
+
+    async def acquire_write(
+        self, timeout: float | None = None, *, blocking: bool | None = None
+    ) -> AsyncAcquireSoftReadWriteReturnProxy:
+        """
+        Acquire an exclusive write lock.
+
+        See :meth:`SoftReadWriteLock.acquire_write` for the two-phase writer-preferring semantics. The blocking work
+        runs inside ``run_in_executor``.
+
+        :param timeout: maximum wait time in seconds, or ``None`` to use the instance default
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately; ``None`` uses the instance default
+
+        :returns: a proxy usable as an async context manager to release the lock
+
+        :raises RuntimeError: if a read lock is already held, if a write lock is held by a different thread, if
+            this instance was invalidated by :func:`os.fork`, or if :meth:`close` was called
+        :raises Timeout: if the lock cannot be acquired within *timeout* seconds
+
+        """
+        await self._run(self._lock.acquire_write, timeout, blocking=blocking)
+        return AsyncAcquireSoftReadWriteReturnProxy(lock=self)
+
+    async def release(self, *, force: bool = False) -> None:
+        """
+        Release one level of the current lock.
+
+        :param force: if ``True``, release the lock completely regardless of the current lock level
+
+        :raises RuntimeError: if no lock is currently held and *force* is ``False``
+
+        """
+        await self._run(self._lock.release, force=force)
+
     async def close(self) -> None:
         """Release any held lock and release the underlying filesystem resources. Idempotent."""
         await self._run(self._lock.close)
@@ -205,6 +186,24 @@ class AsyncSoftReadWriteLock:
     async def _run(self, func: Callable[..., object], *args: object, **kwargs: object) -> object:
         loop = self._loop or asyncio.get_running_loop()
         return await loop.run_in_executor(self._executor, functools.partial(func, *args, **kwargs))
+
+
+class AsyncAcquireSoftReadWriteReturnProxy:
+    """Async context-aware object that releases an :class:`AsyncSoftReadWriteLock` on exit."""
+
+    def __init__(self, lock: AsyncSoftReadWriteLock) -> None:
+        self.lock = lock
+
+    async def __aenter__(self) -> AsyncSoftReadWriteLock:
+        return self.lock
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.lock.release()
 
 
 __all__ = [

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -16,7 +16,7 @@ import uuid
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 from weakref import WeakValueDictionary
 
 from filelock._api import AcquireReturnProxy
@@ -29,58 +29,23 @@ if TYPE_CHECKING:
 
 
 _Mode = Literal["read", "write"]
-_BREAK_SUFFIX = ".break"
-_MAX_MARKER_SIZE = 1024
-_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
-_O_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
+_BREAK_SUFFIX: Final[str] = ".break"
+_MAX_MARKER_SIZE: Final[int] = 1024
+_O_NOFOLLOW: Final[int] = getattr(os, "O_NOFOLLOW", 0)
+_O_NONBLOCK: Final[int] = getattr(os, "O_NONBLOCK", 0)
 # Retargeting os.utime to an open fd lets the heartbeat refresh the exact inode it just verified instead of
 # re-resolving the path; Windows read-only handles cannot set times that way, so keep it Unix-only.
-_SUPPORTS_UTIME_FD = sys.platform != "win32" and os.utime in os.supports_fd
+_SUPPORTS_UTIME_FD: Final[bool] = sys.platform != "win32" and os.utime in os.supports_fd
 # os.utime follows symlinks unless told not to; not every platform can refuse the follow, so probe support.
-_SUPPORTS_UTIME_NOFOLLOW = os.utime in os.supports_follow_symlinks
+_SUPPORTS_UTIME_NOFOLLOW: Final[bool] = os.utime in os.supports_follow_symlinks
 # dirfd-relative I/O is a Unix-only optimization; Windows cannot ``os.open()`` a directory at all, and
 # its ``os`` module skips dir_fd support entirely. When disabled, callers fall back to full-path ops.
-_SUPPORTS_DIR_FD = sys.platform != "win32" and os.open in os.supports_dir_fd
+_SUPPORTS_DIR_FD: Final[bool] = sys.platform != "win32" and os.open in os.supports_dir_fd
 
-_all_instances: WeakValueDictionary[Path, SoftReadWriteLock] = WeakValueDictionary()
+_all_instances: Final[WeakValueDictionary[Path, SoftReadWriteLock]] = WeakValueDictionary()
 _all_instances_lock = threading.Lock()
 _atexit_registered = False
 _fork_registered = False
-
-
-@dataclass(frozen=True)
-class _Paths:
-    state: str
-    write: str
-    readers: str
-
-
-@dataclass
-class _Locks:
-    internal: threading.Lock
-    transaction: threading.Lock
-    state: SoftFileLock
-
-
-@dataclass(frozen=True)
-class _MarkerInfo:
-    token: str
-    pid: int
-    hostname: str
-
-
-@dataclass
-class _Hold:
-    """Everything that exists only while a lock is held; ``None`` when the instance has no lock."""
-
-    level: int
-    mode: _Mode
-    write_thread_id: int | None
-    marker_name: str
-    is_reader: bool
-    token: str
-    heartbeat_thread: _HeartbeatThread
-    heartbeat_stop: threading.Event
 
 
 class _SoftRWMeta(type):
@@ -322,6 +287,28 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         """
         return self._acquire("write", timeout, blocking=blocking)
 
+    @classmethod
+    def get_lock(
+        cls,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+    ) -> SoftReadWriteLock:
+        """
+        Return the singleton :class:`SoftReadWriteLock` for *lock_file*.
+
+        :param lock_file: path to the lock file; sidecar state/write/readers live next to it
+        :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
+        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable
+
+        :returns: the singleton lock instance
+
+        :raises ValueError: if an instance already exists for this path with different *timeout* or *blocking* values
+
+        """
+        return cls(lock_file, timeout, blocking=blocking)
+
     def close(self) -> None:
         """
         Release any held lock and release internal filesystem resources.
@@ -371,9 +358,8 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
                 return
             self._hold = None
 
-        # Order matters: signal → join → unlink. A late tick on a deleted marker is harmless, and the
-        # token check in the heartbeat callback would catch any re-acquisition race, but joining first
-        # removes even that theoretical race.
+        # Order matters: signal → join → unlink. A late tick on a deleted marker is harmless and the
+        # heartbeat's token check would catch a re-acquisition race, but joining first removes that race.
         hold.heartbeat_stop.set()
         hold.heartbeat_thread.join(timeout=self.heartbeat_interval + 1.0)
         if hold.is_reader:
@@ -389,69 +375,12 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         # serializes this against a concurrent break/claim, and the heartbeat is already stopped, so the
         # token we read is authoritative. Mirrors the token re-check the stale-break path already does.
         with self._locks.state:
-            read = _read_marker(self._paths.write)
-            if read is None:
+            if (read := _read_marker(self._paths.write)) is None:
                 return
             info, _ = read
             if info is None or not hmac.compare_digest(info.token, token):
                 return
             _unlink(self._paths.write)
-
-    def _claim_writer_marker(self, token: str) -> bool:
-        # Claim the writer slot for ``token``. Must be called holding ``self._locks.state``. Evicts a
-        # stale marker first, then refuses to claim while a live ``.write`` exists so a peer holding the
-        # slot is waited out instead of overwritten.
-        _break_stale_marker(self._paths.write, stale_threshold=self.stale_threshold, now=time.time())
-        if _file_exists(self._paths.write):
-            return False
-        try:
-            _atomic_create_marker(self._paths.write, token)
-        except FileExistsError:
-            return False
-        return True
-
-    def _touch_writer_marker_if_ours(self, token: str) -> bool:
-        # Refresh the writer marker through a single O_NOFOLLOW fd, but only while it still carries our
-        # token. Returns False when the marker is gone or now belongs to a peer that reclaimed the slot,
-        # so the caller can re-claim rather than keep a stranger's marker alive. Mirrors _refresh_marker.
-        fd = _open_marker(self._paths.write)
-        if fd is None:
-            return False
-        try:
-            try:
-                data = os.read(fd, _MAX_MARKER_SIZE + 1)
-            except OSError:  # pragma: no cover - e.g. EAGAIN from a hostile FIFO that has a writer attached
-                return False
-            info = _parse_marker_bytes(data)
-            if info is None or not hmac.compare_digest(info.token, token):
-                return False
-            with suppress(OSError):
-                _touch(self._paths.write, fd=fd)
-            return True
-        finally:
-            os.close(fd)
-
-    @classmethod
-    def get_lock(
-        cls,
-        lock_file: str | os.PathLike[str],
-        timeout: float = -1,
-        *,
-        blocking: bool = True,
-    ) -> SoftReadWriteLock:
-        """
-        Return the singleton :class:`SoftReadWriteLock` for *lock_file*.
-
-        :param lock_file: path to the lock file; sidecar state/write/readers live next to it
-        :param timeout: maximum wait time in seconds; ``-1`` means block indefinitely
-        :param blocking: if ``False``, raise :class:`~filelock.Timeout` immediately when the lock is unavailable
-
-        :returns: the singleton lock instance
-
-        :raises ValueError: if an instance already exists for this path with different *timeout* or *blocking* values
-
-        """
-        return cls(lock_file, timeout, blocking=blocking)
 
     def _acquire(
         self,
@@ -586,6 +515,40 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             raise
         return self._paths.write, False
 
+    def _claim_writer_marker(self, token: str) -> bool:
+        # Claim the writer slot for ``token``. Must be called holding ``self._locks.state``. Evicts a
+        # stale marker first, then refuses to claim while a live ``.write`` exists so a peer holding the
+        # slot is waited out instead of overwritten.
+        _break_stale_marker(self._paths.write, stale_threshold=self.stale_threshold, now=time.time())
+        if _file_exists(self._paths.write):
+            return False
+        try:
+            _atomic_create_marker(self._paths.write, token)
+        except FileExistsError:
+            return False
+        return True
+
+    def _touch_writer_marker_if_ours(self, token: str) -> bool:
+        # Refresh the writer marker through a single O_NOFOLLOW fd, but only while it still carries our
+        # token. Returns False when the marker is gone or now belongs to a peer that reclaimed the slot,
+        # so the caller can re-claim rather than keep a stranger's marker alive. Mirrors _refresh_marker.
+        fd = _open_marker(self._paths.write)
+        if fd is None:
+            return False
+        try:
+            try:
+                data = os.read(fd, _MAX_MARKER_SIZE + 1)
+            except OSError:  # pragma: no cover - e.g. EAGAIN from a hostile FIFO that has a writer attached
+                return False
+            info = _parse_marker_bytes(data)
+            if info is None or not hmac.compare_digest(info.token, token):
+                return False
+            with suppress(OSError):
+                _touch(self._paths.write, fd=fd)
+            return True
+        finally:
+            os.close(fd)
+
     def _acquire_reader_slot(
         self,
         token: str,
@@ -643,8 +606,9 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             msg = f"{self._paths.readers} exists but is not a directory or is a symlink; refusing to use it"
             raise RuntimeError(msg)
         if self._readers_dir_fd is None and _SUPPORTS_DIR_FD:
-            flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
-            self._readers_dir_fd = os.open(self._paths.readers, flags)
+            self._readers_dir_fd = os.open(
+                self._paths.readers, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
+            )
 
     def _any_readers(self) -> bool:
         for _ in self._iter_reader_entries():
@@ -689,11 +653,11 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             token = hold.token
             dir_fd = self._readers_dir_fd if hold.is_reader else None
 
-        # Open once with O_NOFOLLOW and touch that exact descriptor. Doing the refresh through the verified fd
+        # Open once with O_NOFOLLOW and touch that exact descriptor. Refreshing through the verified fd
         # (instead of re-opening by name) closes the window where a peer unlinks our marker and drops a symlink
         # or a different file at the path between the read and the touch: utime then lands on the inode we
-        # verified, or nowhere. A failed open means the marker is gone or was swapped out -- a peer evicted us
-        # -- so stop the heartbeat at once instead of waiting a tick.
+        # verified, or nowhere. A failed open means the marker is gone or was swapped out (a peer evicted us),
+        # so stop the heartbeat now instead of waiting a tick.
         fd = _open_marker(marker_name, dir_fd=dir_fd)
         if fd is None:
             return False
@@ -750,19 +714,24 @@ class _HeartbeatThread(threading.Thread):
                 return
 
 
-def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -> None:
-    # O_NOFOLLOW blocks the symlink-overwrite attack where an attacker pre-creates the marker path as a
-    # symlink pointing at a victim file. Mode 0o600 keeps the token unreadable to other users.
-    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _O_NOFOLLOW
-    if _SUPPORTS_DIR_FD and dir_fd is not None:
-        fd = os.open(name, flags, 0o600, dir_fd=dir_fd)
-    else:
-        fd = os.open(name, flags, 0o600)
+def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo | None, float] | None:
+    fd = _open_marker(name, dir_fd=dir_fd)
+    if fd is None:
+        return None
     try:
-        content = f"{token}\n{os.getpid()}\n{socket.gethostname()}\n".encode("ascii")
-        os.write(fd, content)
+        st = os.fstat(fd)
+        # A legitimate marker is a regular file, so anything else at the path (a FIFO, say) is reported as a
+        # malformed marker (its mtime still drives stale eviction) without being read. Reading is where
+        # platforms diverge: an empty non-blocking read yields 0 bytes on Linux/macOS but EAGAIN on FreeBSD,
+        # and the EAGAIN used to abort the stale-break and wedge the acquire until timeout (#587).
+        if not stat.S_ISREG(st.st_mode):
+            return None, st.st_mtime
+        data = os.read(fd, _MAX_MARKER_SIZE + 1)
+    except OSError:  # pragma: no cover - marker vanished or turned unreadable between open and read
+        return None
     finally:
         os.close(fd)
+    return _parse_marker_bytes(data), st.st_mtime
 
 
 def _open_marker(name: str, *, dir_fd: int | None = None) -> int | None:
@@ -774,26 +743,6 @@ def _open_marker(name: str, *, dir_fd: int | None = None) -> int | None:
         return os.open(name, flags, dir_fd=dir_fd) if _SUPPORTS_DIR_FD and dir_fd is not None else os.open(name, flags)
     except OSError:
         return None
-
-
-def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo | None, float] | None:
-    fd = _open_marker(name, dir_fd=dir_fd)
-    if fd is None:
-        return None
-    try:
-        st = os.fstat(fd)
-        # A legitimate marker is always a regular file, so anything else at the path -- above all a FIFO -- is
-        # reported as a malformed marker (its mtime still drives stale eviction) without being read. Reading is
-        # where platforms diverge: an empty non-blocking read yields 0 bytes on Linux/macOS but EAGAIN on
-        # FreeBSD, and the EAGAIN used to abort the stale-break and wedge the acquire until timeout (#587).
-        if not stat.S_ISREG(st.st_mode):
-            return None, st.st_mtime
-        data = os.read(fd, _MAX_MARKER_SIZE + 1)
-    except OSError:  # pragma: no cover - marker vanished or turned unreadable between open and read
-        return None
-    finally:
-        os.close(fd)
-    return _parse_marker_bytes(data), st.st_mtime
 
 
 def _parse_marker_bytes(data: bytes) -> _MarkerInfo | None:
@@ -826,6 +775,15 @@ def _parse_marker_bytes(data: bytes) -> _MarkerInfo | None:
     return _MarkerInfo(token=match["token"], pid=pid, hostname=match["hostname"])
 
 
+def _unlink(name: str, *, dir_fd: int | None = None) -> None:
+    with suppress(FileNotFoundError):
+        if _SUPPORTS_DIR_FD and dir_fd is not None:
+            # Path.unlink has no dir_fd support, so we stay on os.unlink for the dirfd path.
+            os.unlink(name, dir_fd=dir_fd)
+        else:
+            Path(name).unlink()
+
+
 def _break_stale_marker(  # noqa: PLR0911
     name: str,
     *,
@@ -837,8 +795,7 @@ def _break_stale_marker(  # noqa: PLR0911
     # private name nobody else can touch; if the re-verify sees a newer mtime or a different token, the
     # legitimate holder's heartbeat fired between read and rename and we must abort (leaving the .break.*
     # file behind rather than rollback-renaming, because rollback is itself racy).
-    read_result = _read_marker(name, dir_fd=dir_fd)
-    if read_result is None:
+    if (read_result := _read_marker(name, dir_fd=dir_fd)) is None:
         return False
     info_before, mtime_before = read_result
     if now - mtime_before <= stale_threshold:
@@ -871,20 +828,25 @@ def _break_stale_marker(  # noqa: PLR0911
     return True
 
 
-def _unlink(name: str, *, dir_fd: int | None = None) -> None:
-    with suppress(FileNotFoundError):
-        if _SUPPORTS_DIR_FD and dir_fd is not None:
-            # Path.unlink has no dir_fd support, so we stay on os.unlink for the dirfd path.
-            os.unlink(name, dir_fd=dir_fd)
-        else:
-            Path(name).unlink()
+def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -> None:
+    # O_NOFOLLOW blocks the symlink-overwrite attack where an attacker pre-creates the marker path as a
+    # symlink pointing at a victim file. Mode 0o600 keeps the token unreadable to other users.
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _O_NOFOLLOW
+    if _SUPPORTS_DIR_FD and dir_fd is not None:
+        fd = os.open(name, flags, 0o600, dir_fd=dir_fd)
+    else:
+        fd = os.open(name, flags, 0o600)
+    try:
+        os.write(fd, f"{token}\n{os.getpid()}\n{socket.gethostname()}\n".encode("ascii"))
+    finally:
+        os.close(fd)
 
 
 def _touch(name: str, *, fd: int | None = None) -> None:
     # Prefer the already-open, already-verified fd so a peer that swaps a symlink or a different file in at the
     # path after our O_NOFOLLOW read cannot redirect the touch: utime then targets the inode behind the fd.
     # Where the platform cannot utime an fd, fall back to a path-based touch that still refuses to follow a
-    # symlink where supported -- matching the O_NOFOLLOW reads used everywhere else here.
+    # symlink where supported, matching the O_NOFOLLOW reads used elsewhere here.
     if fd is not None and _SUPPORTS_UTIME_FD:
         os.utime(fd, None)
         return
@@ -903,20 +865,39 @@ def _is_housekeeping_name(name: str) -> bool:
     return name.startswith(".") or _BREAK_SUFFIX in name
 
 
-def _reset_all_after_fork() -> None:  # pragma: no cover - fork child, not tracked by coverage
-    global _all_instances_lock  # noqa: PLW0603
-    # User-created threading locks do not auto-reset across fork: any lock held by a parent thread stays
-    # locked in the child with no owner to release it. Replace the module-level lock and every instance's
-    # locks with fresh ones; the child is single-threaded at this point so no synchronization is needed.
-    _all_instances_lock = threading.Lock()
-    for instance in list(_all_instances.values()):
-        instance._reset_after_fork_in_child()  # noqa: SLF001
+@dataclass(frozen=True)
+class _Paths:
+    state: str
+    write: str
+    readers: str
 
 
-def _cleanup_all_instances() -> None:  # pragma: no cover - runs from atexit at interpreter shutdown
-    for instance in list(_all_instances.values()):
-        with suppress(Exception):
-            instance.release(force=True)
+@dataclass
+class _Locks:
+    internal: threading.Lock
+    transaction: threading.Lock
+    state: SoftFileLock
+
+
+@dataclass(frozen=True)
+class _MarkerInfo:
+    token: str
+    pid: int
+    hostname: str
+
+
+@dataclass
+class _Hold:
+    """Everything that exists only while a lock is held; ``None`` when the instance has no lock."""
+
+    level: int
+    mode: _Mode
+    write_thread_id: int | None
+    marker_name: str
+    is_reader: bool
+    token: str
+    heartbeat_thread: _HeartbeatThread
+    heartbeat_stop: threading.Event
 
 
 def _register_hooks() -> None:
@@ -928,6 +909,22 @@ def _register_hooks() -> None:
     if not _fork_registered and hasattr(os, "register_at_fork"):
         os.register_at_fork(after_in_child=_reset_all_after_fork)
         _fork_registered = True
+
+
+def _cleanup_all_instances() -> None:  # pragma: no cover - runs from atexit at interpreter shutdown
+    for instance in list(_all_instances.values()):
+        with suppress(Exception):
+            instance.release(force=True)
+
+
+def _reset_all_after_fork() -> None:  # pragma: no cover - fork child, not tracked by coverage
+    global _all_instances_lock  # noqa: PLW0603
+    # User-created threading locks do not auto-reset across fork: any lock held by a parent thread stays
+    # locked in the child with no owner to release it. Replace the module-level lock and every instance's
+    # locks with fresh ones; the child is single-threaded at this point so no synchronization is needed.
+    _all_instances_lock = threading.Lock()
+    for instance in list(_all_instances.values()):
+        instance._reset_after_fork_in_child()  # noqa: SLF001
 
 
 __all__ = [

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -11,7 +11,6 @@ from typing import cast
 from ._api import BaseFileLock
 from ._util import ensure_directory_exists
 
-#: a flag to indicate if the fcntl API is available
 has_fcntl = False
 if sys.platform == "win32":  # pragma: win32 cover
 
@@ -38,25 +37,24 @@ else:  # pragma: win32 no cover
         """
         Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems.
 
-        The lock file is intentionally left in place after release. Unlinking a locked file on Unix
-        can split waiters across different inodes and break mutual exclusion for processes that
-        coordinate via the same path.
+        We leave the lock file in place after release. Unlinking a locked file on Unix splits
+        waiters across inodes and breaks mutual exclusion for processes that coordinate via the
+        same path.
         """
 
         def _acquire(self) -> None:  # noqa: C901, PLR0912
             ensure_directory_exists(self.lock_file)
             open_flags = os.O_RDWR | os.O_TRUNC
-            o_nofollow = getattr(os, "O_NOFOLLOW", None)
-            if o_nofollow is not None:
+            if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:
                 open_flags |= o_nofollow
             open_flags |= os.O_CREAT
             open_mode = self._open_mode()
             try:
                 fd = os.open(self.lock_file, open_flags, open_mode)
             except FileNotFoundError:
-                # On FUSE/NFS, os.open(O_CREAT) is not atomic: LOOKUP + CREATE can be split, allowing a concurrent
-                # unlink() to delete the file between them. For valid paths, treat ENOENT as transient contention.
-                # For invalid paths (e.g., empty string), re-raise to avoid infinite retry loops.
+                # On FUSE/NFS, os.open(O_CREAT) is not atomic; a split LOOKUP + CREATE lets a concurrent unlink()
+                # delete the file between them. For a valid path, treat ENOENT as transient contention. For an
+                # invalid path (e.g. empty string), re-raise to avoid an infinite retry loop.
                 if self.lock_file and Path(self.lock_file).parent.exists():
                     return
                 raise
@@ -85,8 +83,8 @@ else:  # pragma: win32 no cover
                 if exception.errno not in {EAGAIN, EWOULDBLOCK}:
                     raise
             else:
-                # The file may have been unlinked by a concurrent _release() between our open() and flock().
-                # A lock on an unlinked inode is useless — discard and let the retry loop start fresh.
+                # A concurrent _release() may unlink the file between our open() and flock(). A lock on an
+                # unlinked inode is useless, so discard it and let the retry loop start fresh.
                 if os.fstat(fd).st_nlink == 0:
                     os.close(fd)
                 else:

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -20,17 +20,17 @@ def raise_on_not_writable_file(filename: str) -> None:
 
     """
     try:
-        # lstat, not stat: it settles exists-and-writable in one syscall, and a hostile symlink planted at the lock
-        # path would otherwise make this inspect the link target, letting an attacker turn a contended acquire into a
-        # misleading PermissionError / IsADirectoryError and probe that target's attributes. The real open passes
-        # O_NOFOLLOW and refuses the symlink anyway.
+        # lstat, not stat: settles exists-and-writable in one syscall, and a hostile symlink at the lock path would
+        # make stat inspect the link target, letting an attacker turn a contended acquire into a misleading
+        # PermissionError / IsADirectoryError and probe that target's attributes. The real open passes O_NOFOLLOW and
+        # refuses the symlink anyway.
         file_stat = os.lstat(filename)
     except OSError:
         return  # does not exist, or an error the caller cannot act on
 
-    # No mtime guard: the old `if st_mtime != 0` skip existed for NFS/Linux quirks where os.lstat could return an
-    # all-zero struct, which it no longer does. Skipping on mtime 0 let a read-only file or a directory at the lock
-    # path pass as missing, so acquire() blocked forever on an open that cannot succeed.
+    # No mtime guard: the old `if st_mtime != 0` skip covered NFS/Linux quirks where os.lstat returned an all-zero
+    # struct, which it no longer does. Skipping on mtime 0 let a read-only file or a directory at the lock path pass
+    # as missing, so acquire() blocked forever on an open that cannot succeed.
     if not (file_stat.st_mode & stat.S_IWUSR):
         raise PermissionError(EACCES, "Permission denied", filename)
 
@@ -52,23 +52,23 @@ def ensure_directory_exists(filename: Path | str) -> None:
 
 def break_lock_file(lock_file: str, mtime_before: float, ino_before: int) -> None:
     """
-    Atomically break a stale lock file that was judged stale at modification time *mtime_before*.
+    Atomically break a stale lock file judged stale at modification time *mtime_before*.
 
-    The file is renamed to a process-private name before being unlinked, so two processes breaking the same lock
-    cannot delete each other's work (only one rename of a given inode succeeds; the loser gets ``OSError``). After the
-    rename the file is re-checked: a newer modification time, or a different inode than *ino_before*, means a peer
-    recreated the lock between the stale decision and the rename, so we grabbed a live file and must abort, leaving the
-    renamed file in place rather than rolling back (a rollback rename is itself racy — same trade-off as the soft
-    read/write marker break). The inode check matters because filesystems with coarse modification-time granularity
-    (NFS, FAT) can give a same-second recreation the old mtime, so mtime alone would not catch it and a live lock would
-    be unlinked; the inode is the reliable identity, mirroring the token re-check in the soft read/write marker break.
-    ``lstat`` is used so a hostile symlink swapped in after the decision is not followed.
+    Rename the file to a process-private name before unlinking it, so two processes breaking the same lock cannot
+    delete each other's work: only one rename of a given inode wins, the loser gets ``OSError``. After the rename,
+    re-check the file. A newer modification time, or a different inode than *ino_before*, means a peer recreated the
+    lock between the stale decision and the rename, so we grabbed a live file and abort, leaving the renamed file in
+    place. A rollback rename is itself racy, the same trade-off as the soft read/write marker break. The inode check
+    matters because filesystems with coarse modification-time granularity (NFS, FAT) can give a same-second recreation
+    the old mtime, so mtime alone would miss it and unlink a live lock; the inode is the reliable identity, mirroring
+    the token re-check in the soft read/write marker break. ``lstat`` avoids following a hostile symlink swapped in
+    after the decision.
 
     The break name carries a random token so it is unguessable and unique per attempt. Without it two breakers in the
-    same process share ``<lock>.break.<pid>``, and a second break can rename a freshly recreated live lock onto that
-    path in the window between the re-verify ``lstat`` above and the ``unlink`` below, so we would delete a live lock
-    the inode check just approved. A private name means nobody else can target our break path, matching the soft
-    read/write marker break.
+    same process share ``<lock>.break.<pid>``, and a second break can rename a recreated live lock onto that path in
+    the window between the re-verify ``lstat`` above and the ``unlink`` below, deleting a live lock the inode check
+    just approved. A private name keeps anyone else from targeting our break path, matching the soft read/write marker
+    break.
 
     :param lock_file: path to the lock file to break.
     :param mtime_before: modification time observed when the lock was judged stale.

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -5,7 +5,7 @@ import sys
 from contextlib import suppress
 from errno import EACCES
 from pathlib import Path
-from typing import cast
+from typing import Final, cast
 
 from ._api import BaseFileLock
 from ._util import ensure_directory_exists, raise_on_not_writable_file
@@ -15,72 +15,41 @@ if sys.platform == "win32":  # pragma: win32 cover
     import msvcrt
     from ctypes import wintypes
 
-    # Windows API constants for reparse point detection
-    FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
-    INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF
+    _FILE_ATTRIBUTE_REPARSE_POINT: Final[int] = 0x00000400
+    _INVALID_FILE_ATTRIBUTES: Final[int] = 0xFFFFFFFF
 
-    # Load kernel32.dll
-    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _kernel32: Final[ctypes.WinDLL] = ctypes.WinDLL("kernel32", use_last_error=True)
     _kernel32.GetFileAttributesW.argtypes = [wintypes.LPCWSTR]
     _kernel32.GetFileAttributesW.restype = wintypes.DWORD
-
-    def _is_reparse_point(path: str) -> bool:
-        """
-        Check if a path is a reparse point (symlink, junction, etc.) on Windows.
-
-        :param path: Path to check
-
-        :returns: True if path is a reparse point, False otherwise
-
-        :raises OSError: If GetFileAttributesW fails for reasons other than file-not-found
-
-        """
-        attrs = _kernel32.GetFileAttributesW(path)
-        if attrs == INVALID_FILE_ATTRIBUTES:
-            # File doesn't exist yet - that's fine, we'll create it
-            err = ctypes.get_last_error()
-            if err == 2:  # noqa: PLR2004  # ERROR_FILE_NOT_FOUND
-                return False
-            if err == 3:  # noqa: PLR2004 # ERROR_PATH_NOT_FOUND
-                return False
-            # Some other error - let caller handle it
-            return False
-        return bool(attrs & FILE_ATTRIBUTE_REPARSE_POINT)
 
     class WindowsFileLock(BaseFileLock):
         """
         Uses the :func:`msvcrt.locking` function to hard lock the lock file on Windows systems.
 
-        Lock file cleanup: Windows attempts to delete the lock file after release, but deletion is
-        not guaranteed in multi-threaded scenarios where another thread holds an open handle. The lock
-        file may persist on disk, which does not affect lock correctness.
+        ``_release`` unlinks the lock file, but the unlink can fail while another thread still holds an
+        open handle. A surviving lock file on disk does not affect lock correctness.
         """
 
         def _acquire(self) -> None:
             raise_on_not_writable_file(self.lock_file)
             ensure_directory_exists(self.lock_file)
 
-            # Security check: Refuse to open reparse points (symlinks, junctions)
-            # This prevents TOCTOU symlink attacks (CVE-TBD)
+            # Refuse a reparse point (symlink/junction) at the lock path to blunt a symlink-swap attack.
             if _is_reparse_point(self.lock_file):
                 msg = f"Lock file is a reparse point (symlink/junction): {self.lock_file}"
                 raise OSError(msg)
 
-            flags = (
-                os.O_RDWR  # open for read and write
-                | os.O_CREAT  # create file if not exists
-            )
             try:
-                fd = os.open(self.lock_file, flags, self._open_mode())
+                fd = os.open(self.lock_file, os.O_RDWR | os.O_CREAT, self._open_mode())
             except OSError as exception:
-                if exception.errno != EACCES:  # has no access to this lock
+                if exception.errno != EACCES:
                     raise
             else:
                 try:
                     msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
                 except OSError as exception:
-                    os.close(fd)  # close file first
-                    if exception.errno != EACCES:  # file is already locked
+                    os.close(fd)
+                    if exception.errno != EACCES:  # EACCES means another holder owns the byte-range lock
                         raise
                 else:
                     self._context.lock_file_fd = fd
@@ -93,6 +62,13 @@ if sys.platform == "win32":  # pragma: win32 cover
 
             with suppress(OSError):
                 Path(self.lock_file).unlink()
+
+    def _is_reparse_point(path: str) -> bool:
+        # A missing path reports INVALID_FILE_ATTRIBUTES; the caller creates it, so treat that as
+        # not-a-reparse-point and reject only an existing reparse-point attribute.
+        if (attrs := _kernel32.GetFileAttributesW(path)) == _INVALID_FILE_ATTRIBUTES:
+            return False
+        return bool(attrs & _FILE_ATTRIBUTE_REPARSE_POINT)
 
 else:  # pragma: win32 no cover
 

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -10,7 +10,7 @@ import time
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
 from threading import local
-from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
+from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar
 
 from ._api import _UNSET_FILE_MODE, BaseFileLock, FileLockContext, FileLockMeta, _canonical
 from ._error import Timeout
@@ -30,44 +30,7 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 
-_LOGGER = logging.getLogger("filelock")
-
-
-@dataclass
-class AsyncFileLockContext(FileLockContext):
-    """A dataclass which holds the context for a ``BaseAsyncFileLock`` object."""
-
-    #: Whether run in executor
-    run_in_executor: bool = True
-
-    #: The executor
-    executor: futures.Executor | None = None
-
-    #: The loop
-    loop: asyncio.AbstractEventLoop | None = None
-
-
-class AsyncThreadLocalFileContext(AsyncFileLockContext, local):
-    """A thread local version of the ``FileLockContext`` class."""
-
-
-class AsyncAcquireReturnProxy:
-    """A context-aware object that will release the lock file when exiting."""
-
-    def __init__(self, lock: BaseAsyncFileLock) -> None:  # noqa: D107
-        self.lock = lock
-
-    async def __aenter__(self) -> BaseAsyncFileLock:  # noqa: D105
-        return self.lock
-
-    async def __aexit__(  # noqa: D105
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        await self.lock.release()
-
+_LOGGER: Final[logging.Logger] = logging.getLogger("filelock")
 
 _AT = TypeVar("_AT", bound="BaseAsyncFileLock")
 
@@ -164,8 +127,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
 
-        # Create the context. Note that external code should not work with the context directly and should instead use
-        # properties of this class.
+        # External code goes through this class's properties, not the context directly.
         kwargs: dict[str, Any] = {
             "lock_file": os.fspath(lock_file),
             "timeout": timeout,
@@ -245,7 +207,6 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 lock.release()
 
         """
-        # Use the default timeout, if no timeout is provided.
         if timeout is None:
             timeout = self._context.timeout
 
@@ -255,22 +216,21 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         if poll_interval is None:
             poll_interval = self._context.poll_interval
 
-        # Increment the number right at the beginning. We can still undo it, if something fails.
+        # Bump early; _undo_acquire rolls it back if acquisition fails.
         self._context.lock_counter += 1
 
         canonical = _canonical(self.lock_file)
         self._raise_if_would_deadlock(canonical, timeout=timeout, blocking=blocking)
 
-        start_time = time.perf_counter()
         try:
             await self._async_poll_until_acquired(
                 blocking=blocking,
                 cancel_check=cancel_check,
                 timeout=timeout,
                 poll_interval=poll_interval,
-                start_time=start_time,
+                start_time=time.perf_counter(),
             )
-        except BaseException:  # Something did go wrong, so decrement the counter.
+        except BaseException:
             self._undo_acquire(canonical)
             raise
         self._commit_acquire(canonical)
@@ -304,8 +264,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 start_time=start_time,
             ):
                 raise Timeout(lock_filename)
-            msg = "Lock %s not acquired on %s, waiting %s seconds ..."
-            _LOGGER.debug(msg, lock_id, lock_filename, poll_interval)
+            _LOGGER.debug("Lock %s not acquired on %s, waiting %s seconds ...", lock_id, lock_filename, poll_interval)
             await asyncio.sleep(poll_interval)
 
     async def release(self, force: bool = False) -> None:  # ty: ignore[invalid-method-override]  # noqa: FBT001, FBT002
@@ -383,7 +342,6 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
-                # No running loop — try stored loop or create one
                 loop = self._context.loop if self._context.loop and not self._context.loop.is_closed() else None
             if loop is None:
                 return
@@ -391,6 +349,42 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 loop.run_until_complete(self.release(force=True))
             else:
                 loop.create_task(self.release(force=True))
+
+
+@dataclass
+class AsyncFileLockContext(FileLockContext):
+    """A dataclass which holds the context for a ``BaseAsyncFileLock`` object."""
+
+    #: Whether run in executor
+    run_in_executor: bool = True
+
+    #: The executor
+    executor: futures.Executor | None = None
+
+    #: The loop
+    loop: asyncio.AbstractEventLoop | None = None
+
+
+class AsyncThreadLocalFileContext(AsyncFileLockContext, local):
+    """A thread local version of the ``FileLockContext`` class."""
+
+
+class AsyncAcquireReturnProxy:
+    """A context-aware object that will release the lock file when exiting."""
+
+    def __init__(self, lock: BaseAsyncFileLock) -> None:  # noqa: D107
+        self.lock = lock
+
+    async def __aenter__(self) -> BaseAsyncFileLock:  # noqa: D105
+        return self.lock
+
+    async def __aexit__(  # noqa: D105
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.lock.release()
 
 
 class AsyncSoftFileLock(SoftFileLock, BaseAsyncFileLock):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,14 @@ else:
 
 
 def pytest_sessionfinish() -> None:
-    if _cleanup_connections is not None:
-        if hasattr(sys, "pypy_version_info"):
-            gc.collect()
-            gc.collect()
-        _cleanup_connections()
-        if hasattr(sys, "pypy_version_info"):
-            gc.collect()
-            gc.collect()
+    if _cleanup_connections is None:
+        return
+    # PyPy runs finalizers during GC rather than on refcount drop, so force lock handles closed around cleanup.
+    on_pypy = hasattr(sys, "pypy_version_info")
+    if on_pypy:
+        gc.collect()
+        gc.collect()
+    _cleanup_connections()
+    if on_pypy:
+        gc.collect()
+        gc.collect()

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager, suppress
 from errno import EIO
 from multiprocessing import Event, Process
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
 
@@ -23,76 +23,13 @@ if TYPE_CHECKING:
     from multiprocessing.synchronize import Event as EventType
 
 
-requires_posix_signals = pytest.mark.skipif(sys.platform == "win32", reason="POSIX signals required")
-requires_posix_permissions = pytest.mark.skipif(
+_REQUIRES_POSIX_SIGNALS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX signals required"
+)
+_REQUIRES_POSIX_PERMISSIONS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     sys.platform == "win32", reason="POSIX file-mode bits not meaningful on Windows"
 )
-requires_fork = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
-
-
-def _worker(
-    lock_file: str,
-    mode: Literal["read", "write"],
-    acquired_event: EventType,
-    release_event: EventType | None = None,
-    timeout: float = -1,
-    blocking: bool = True,
-    heartbeat_interval: float = 0.1,
-    stale_threshold: float = 1.0,
-    poll_interval: float = 0.02,
-) -> None:
-    lock = SoftReadWriteLock(
-        lock_file,
-        timeout=timeout,
-        blocking=blocking,
-        is_singleton=False,
-        heartbeat_interval=heartbeat_interval,
-        stale_threshold=stale_threshold,
-        poll_interval=poll_interval,
-    )
-    ctx = lock.read_lock() if mode == "read" else lock.write_lock()
-    try:
-        with ctx:
-            acquired_event.set()
-            if release_event is not None:
-                release_event.wait(timeout=10)
-            else:
-                time.sleep(0.2)
-    finally:
-        lock.close()
-
-
-def _sigkill_worker(
-    lock_file: str,
-    mode: Literal["read", "write"],
-    acquired_event: EventType,
-    heartbeat_interval: float,
-    stale_threshold: float,
-) -> None:
-    lock = SoftReadWriteLock(
-        lock_file,
-        is_singleton=False,
-        heartbeat_interval=heartbeat_interval,
-        stale_threshold=stale_threshold,
-        poll_interval=0.05,
-    )
-    if mode == "read":
-        lock.acquire_read()
-    else:
-        lock.acquire_write()
-    acquired_event.set()
-    time.sleep(60)
-
-
-@contextmanager
-def _cleanup(processes: list[Process]) -> Generator[None]:
-    try:
-        yield
-    finally:
-        for proc in processes:
-            if proc.is_alive():
-                proc.terminate()
-                proc.join(timeout=2)
+_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
 
 
 @pytest.fixture(autouse=True)
@@ -108,23 +45,6 @@ def _clear_singletons() -> Generator[None]:
 @pytest.fixture
 def lock_file(tmp_path: Path) -> str:
     return str(tmp_path / "test.lock")
-
-
-def _make_lock(
-    path: str,
-    *,
-    heartbeat_interval: float = 0.1,
-    stale_threshold: float = 0.5,
-    poll_interval: float = 0.02,
-    is_singleton: bool = False,
-) -> SoftReadWriteLock:
-    return SoftReadWriteLock(
-        path,
-        heartbeat_interval=heartbeat_interval,
-        stale_threshold=stale_threshold,
-        poll_interval=poll_interval,
-        is_singleton=is_singleton,
-    )
 
 
 def test_rejects_non_positive_heartbeat_interval(lock_file: str) -> None:
@@ -213,7 +133,6 @@ def test_reentrant_read_holds_and_releases(lock_file: str) -> None:
     try:
         with lock.read_lock(timeout=2), lock.read_lock(timeout=2):
             pass
-        # After two releases the marker is gone.
         with lock.read_lock(timeout=2):
             pass
     finally:
@@ -403,9 +322,9 @@ def test_writer_preference_blocks_new_readers(lock_file: str) -> None:
 
 @pytest.mark.timeout(10)
 def test_transaction_lock_timeout_across_threads(lock_file: str) -> None:
-    # Two threads share one lock instance. Thread A grabs the transaction lock while spinning on a peer
-    # writer (phase 1 waits), thread B times out on the transaction lock, hitting the in-process Timeout
-    # path distinct from cross-process contention.
+    # Two threads share one lock instance. Thread A holds the transaction lock while spinning on a peer
+    # writer; thread B times out on the transaction lock, exercising the in-process Timeout path rather
+    # than cross-process contention.
     peer = SoftReadWriteLock(
         lock_file,
         is_singleton=False,
@@ -451,8 +370,8 @@ def test_transaction_lock_timeout_across_threads(lock_file: str) -> None:
 
 @pytest.mark.timeout(10)
 def test_two_readers_in_same_process_share_slot(lock_file: str) -> None:
-    # Multiple threads acquiring a read lock on the same instance; one of them inevitably takes the
-    # inner reentrant branch (lock level observed > 0 after waiting on the transaction lock).
+    # Many threads take a read lock on one instance; one hits the inner reentrant branch (lock level
+    # above 0 after waiting on the transaction lock).
     lock = SoftReadWriteLock(
         lock_file,
         is_singleton=False,
@@ -515,8 +434,8 @@ def test_non_blocking_writer_contended_raises(lock_file: str) -> None:
 
 @pytest.mark.timeout(10)
 def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
-    # A live reader with an always-fresh heartbeat makes phase-2 drain impossible; the writer must
-    # abandon its phase-1 claim so the next writer can try again.
+    # A live reader whose heartbeat stays fresh blocks the phase-2 drain; the writer must abandon its
+    # phase-1 claim so the next writer can retry.
     reader = _make_lock(lock_file)
     reader.acquire_read(timeout=2)
     try:
@@ -532,7 +451,7 @@ def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
         reader.close()
 
 
-@requires_posix_signals
+@_REQUIRES_POSIX_SIGNALS
 @pytest.mark.timeout(20)
 def test_dead_writer_evicted_by_reader(lock_file: str) -> None:
     import signal
@@ -556,7 +475,7 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:
         assert not Path(f"{lock_file}.write").exists()
 
 
-@requires_posix_signals
+@_REQUIRES_POSIX_SIGNALS
 @pytest.mark.timeout(20)
 def test_dead_reader_evicted_by_writer(lock_file: str) -> None:
     import signal
@@ -584,11 +503,11 @@ def test_heartbeat_self_stops_when_marker_vanishes(lock_file: str) -> None:
     lock.acquire_write(timeout=2)
     try:
         Path(f"{lock_file}.write").unlink()
-        time.sleep(0.15)  # give the heartbeat at least two ticks to observe and self-stop
+        time.sleep(0.15)  # two-plus heartbeat ticks to observe the vanished marker and self-stop
     finally:
         lock.release(force=True)
         lock.close()
-    # After the vanishing marker, a peer can acquire immediately because nothing is left to evict.
+    # The vanished marker leaves nothing to evict, so a peer can acquire.
     peer = _make_lock(lock_file, heartbeat_interval=0.05, stale_threshold=0.2)
     try:
         with peer.write_lock(timeout=1):
@@ -601,7 +520,7 @@ def test_heartbeat_self_stops_on_token_replacement(lock_file: str) -> None:
     lock = _make_lock(lock_file, heartbeat_interval=0.05, stale_threshold=0.2)
     lock.acquire_write(timeout=2)
     try:
-        # Replace the marker content with a well-formed marker holding a different token.
+        # A well-formed marker holding a different token.
         Path(f"{lock_file}.write").write_bytes(b"0" * 32 + b"\n1\nhost\n")
         time.sleep(0.15)
     finally:
@@ -610,9 +529,9 @@ def test_heartbeat_self_stops_on_token_replacement(lock_file: str) -> None:
 
 
 def test_release_keeps_a_peers_writer_marker(lock_file: str) -> None:
-    # A holder paused long enough (a stop-the-world GC pause, SIGSTOP, a suspended VM) for a peer to evict
-    # its stale marker and claim the writer slot must not unlink that peer's live marker on release: doing so
-    # would let a second writer through and break mutual exclusion.
+    # A holder paused past the stale threshold (GC pause, SIGSTOP, suspended VM) can have its marker evicted
+    # by a peer that then claims the writer slot. On release the holder must not unlink that peer's live
+    # marker; unlinking it would let a second writer through and break mutual exclusion.
     lock = _make_lock(lock_file, heartbeat_interval=10, stale_threshold=40)
     lock.acquire_write(timeout=2)
     try:
@@ -626,11 +545,11 @@ def test_release_keeps_a_peers_writer_marker(lock_file: str) -> None:
 
 
 def test_writer_phase2_does_not_complete_on_a_peers_marker(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    # If a writer is paused past stale_threshold during phase 2 (waiting for readers to drain) a peer can
-    # evict its stale marker and reclaim .write with its own token. Phase 2 must notice the foreign marker
-    # rather than keep touching it and completing the acquire as if we still held the slot, which would let
-    # two writers run at once. A live reader keeps phase 2 looping; on the first poll sleep we simulate the
-    # eviction by overwriting .write with a peer token and draining the reader.
+    # A writer paused past stale_threshold during phase 2 (waiting for readers to drain) can have its stale
+    # marker evicted by a peer that reclaims .write with its own token. Phase 2 must notice the foreign marker
+    # rather than keep touching it and completing the acquire as if we still held the slot, which would let two
+    # writers run at once. A live reader keeps phase 2 looping; on the first poll sleep we simulate the eviction
+    # by overwriting .write with a peer token and draining the reader.
     reader = _make_lock(lock_file, heartbeat_interval=10, stale_threshold=40)
     reader.acquire_read(timeout=2)
     writer = _make_lock(lock_file, heartbeat_interval=10, stale_threshold=40)
@@ -651,7 +570,7 @@ def test_writer_phase2_does_not_complete_on_a_peers_marker(lock_file: str, monke
         with pytest.raises(Timeout):
             writer.acquire_write(timeout=0.6)
         assert swapped.is_set()
-        # The peer's live marker was never overwritten or kept alive by us.
+        # We never overwrote or refreshed the peer's live marker.
         assert Path(write_marker).read_bytes() == peer_marker
     finally:
         monkeypatch.setattr(sync_mod.time, "sleep", real_sleep)
@@ -660,8 +579,8 @@ def test_writer_phase2_does_not_complete_on_a_peers_marker(lock_file: str, monke
 
 
 def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    # On the NFS-style filesystems this lock targets a transient ESTALE / EIO on the heartbeat touch is
-    # routine; it must not kill the heartbeat and silently drop the lease while we still believe we hold it.
+    # On the NFS-style filesystems this lock targets, a transient ESTALE/EIO on the heartbeat touch is
+    # routine; it must not kill the heartbeat and drop the lease while we still believe we hold it.
     def boom(name: str, *, fd: int | None = None) -> None:  # noqa: ARG001
         raise OSError(EIO, "Input/output error")
 
@@ -671,7 +590,7 @@ def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: p
         hold = lock._hold
         assert hold is not None
         monkeypatch.setattr(sync_mod, "_touch", boom)
-        time.sleep(0.2)  # ~10 ticks, all of which fail the touch
+        time.sleep(0.2)  # ~10 ticks, every one failing the touch
         assert hold.heartbeat_thread.is_alive()
         assert not hold.heartbeat_stop.is_set()
     finally:
@@ -680,8 +599,8 @@ def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: p
 
 
 def test_heartbeat_stops_when_marker_evicted(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    # A failed O_NOFOLLOW open means the marker we held was unlinked or swapped for a symlink -- a peer
-    # evicted us, not a transient hiccup -- so the heartbeat must stop at once rather than keep retrying.
+    # A failed O_NOFOLLOW open means the marker we held was unlinked or swapped for a symlink. A peer
+    # evicted us; this is not a transient hiccup, so the heartbeat must stop rather than keep retrying.
     def gone(name: str, *, dir_fd: int | None = None) -> int | None:  # noqa: ARG001
         return None
 
@@ -724,12 +643,6 @@ def test_live_heartbeat_keeps_lock_alive_past_stale_threshold(lock_file: str) ->
         holder.join(timeout=5)
 
 
-def _write_stale_marker(path: str, content: bytes) -> None:
-    Path(path).write_bytes(content)
-    past = time.time() - 1000
-    os.utime(path, (past, past))
-
-
 @pytest.mark.parametrize(
     "content",
     [
@@ -763,7 +676,7 @@ def test_fifo_write_marker_does_not_block(lock_file: str) -> None:
     os.mkfifo(marker)
     past = time.time() - 1000
     os.utime(marker, (past, past))
-    # Without O_NONBLOCK this open blocks forever; the FIFO instead reads as a stale marker and is evicted.
+    # Without O_NONBLOCK this open blocks forever; the lock instead reads the FIFO as a stale marker and evicts it.
     lock = _make_lock(lock_file)
     try:
         with lock.write_lock(timeout=2):
@@ -779,9 +692,9 @@ def test_fifo_write_marker_with_writer_is_evicted(lock_file: str) -> None:
     os.mkfifo(marker)
     past = time.time() - 1000
     os.utime(marker, (past, past))
-    # A writer attached to the FIFO makes the non-blocking read raise EAGAIN on every platform, matching how a
-    # writerless FIFO already behaves on FreeBSD (#587). The stale marker must still be evicted by mtime, not
-    # read, so the acquire completes instead of timing out.
+    # A writer attached to the FIFO makes the non-blocking read raise EAGAIN on all platforms, matching a
+    # writerless FIFO on FreeBSD (#587). The lock must evict the stale marker by mtime without reading it, so
+    # the acquire completes instead of timing out.
     reader_fd = os.open(marker, os.O_RDONLY | os.O_NONBLOCK)
     writer_fd = os.open(marker, os.O_WRONLY)
     lock = _make_lock(lock_file)
@@ -883,31 +796,29 @@ def test_readers_path_as_regular_file_is_refused(lock_file: str) -> None:
         lock.close()
 
 
-@requires_posix_permissions
+@_REQUIRES_POSIX_PERMISSIONS
 def test_write_marker_is_created_with_0600(lock_file: str) -> None:
     lock = _make_lock(lock_file)
     try:
         with lock.write_lock(timeout=2):
-            mode = stat.S_IMODE(Path(f"{lock_file}.write").lstat().st_mode)
-            assert mode == 0o600
+            assert stat.S_IMODE(Path(f"{lock_file}.write").lstat().st_mode) == 0o600
     finally:
         lock.close()
 
 
-@requires_posix_permissions
+@_REQUIRES_POSIX_PERMISSIONS
 def test_readers_directory_is_created_with_0700(lock_file: str) -> None:
     lock = _make_lock(lock_file)
     try:
         with lock.read_lock(timeout=2):
-            mode = stat.S_IMODE(Path(f"{lock_file}.readers").lstat().st_mode)
-            assert mode == 0o700
+            assert stat.S_IMODE(Path(f"{lock_file}.readers").lstat().st_mode) == 0o700
     finally:
         lock.close()
 
 
 def test_writer_ignores_housekeeping_files_in_readers_dir(lock_file: str) -> None:
-    # Dotfiles and leftover .break.* files from previous aborted evictions must not be mistaken for
-    # live readers by a writer doing its phase-2 drain scan.
+    # A writer's phase-2 drain scan must not mistake dotfiles or leftover .break.* files from aborted
+    # evictions for live readers.
     readers = Path(f"{lock_file}.readers")
     readers.mkdir(mode=0o700, exist_ok=True)
     (readers / ".hidden").write_bytes(b"ignored")
@@ -920,31 +831,175 @@ def test_writer_ignores_housekeeping_files_in_readers_dir(lock_file: str) -> Non
         lock.close()
 
 
-@requires_posix_permissions
+@_REQUIRES_POSIX_PERMISSIONS
 def test_reader_file_is_created_with_0600(lock_file: str) -> None:
     lock = _make_lock(lock_file)
     try:
         with lock.read_lock(timeout=2):
             entries = list(Path(f"{lock_file}.readers").iterdir())
             assert len(entries) == 1
-            mode = stat.S_IMODE(entries[0].lstat().st_mode)
-            assert mode == 0o600
+            assert stat.S_IMODE(entries[0].lstat().st_mode) == 0o600
     finally:
         lock.close()
 
 
-def _fork_process(target: Callable[..., object], args: tuple[object, ...] = ()) -> mp.process.BaseProcess:
-    if sys.platform == "win32":
-        msg = "fork context is POSIX only"
-        raise RuntimeError(msg)
-    return mp.get_context("fork").Process(target=target, args=args)
+@_REQUIRES_FORK
+@pytest.mark.timeout(15)
+def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:
+    ctx = mp.get_context("spawn")
+    result, failure = ctx.Event(), ctx.Event()
+    proc = ctx.Process(target=_reuse_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
+    proc.start()
+    proc.join(timeout=10)
+    assert not failure.is_set()
+    assert result.is_set()
 
 
-def _fork_event() -> EventType:
-    if sys.platform == "win32":
-        msg = "fork context is POSIX only"
-        raise RuntimeError(msg)
-    return mp.get_context("fork").Event()
+@_REQUIRES_FORK
+@pytest.mark.timeout(15)
+def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:
+    ctx = mp.get_context("spawn")
+    result, failure = ctx.Event(), ctx.Event()
+    proc = ctx.Process(target=_release_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
+    proc.start()
+    proc.join(timeout=10)
+    assert not failure.is_set()
+    assert result.is_set()
+
+
+@_REQUIRES_FORK
+@pytest.mark.timeout(15)
+def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:
+    ctx = mp.get_context("spawn")
+    result, failure = ctx.Event(), ctx.Event()
+    proc = ctx.Process(
+        target=_reacquire_fresh_lock_in_child,
+        args=(str(tmp_path / "parent.lock"), str(tmp_path / "child.lock"), result, failure),
+    )
+    proc.start()
+    proc.join(timeout=10)
+    assert not failure.is_set()
+    assert result.is_set()
+
+
+@_REQUIRES_FORK
+@pytest.mark.timeout(15)
+# Holding the write lock keeps the heartbeat thread alive, so this fork is necessarily from a multi-threaded
+# process and Python 3.15 warns that it may deadlock. That is the scenario under test, and it is already safe:
+# register_at_fork resets inherited state in the child (any child use raises "invalidated by fork()"). Expected.
+@pytest.mark.filterwarnings("ignore:.*multi-threaded, use of fork.*:DeprecationWarning")
+def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:
+    path = str(tmp_path / "foo.lock")
+    lock = SoftReadWriteLock(path, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
+    lock.acquire_write(timeout=5)
+    try:
+        child = _fork_process(target=time.sleep, args=(0.05,))
+        child.start()
+        child.join(timeout=5)
+        assert Path(f"{path}.write").exists()
+        peer = SoftReadWriteLock(
+            path,
+            heartbeat_interval=0.2,
+            stale_threshold=1.0,
+            poll_interval=0.02,
+            is_singleton=False,
+        )
+        try:
+            with pytest.raises(Timeout):
+                peer.acquire_write(timeout=0.3)
+        finally:
+            peer.close()
+    finally:
+        lock.release()
+        lock.close()
+    assert not Path(f"{path}.write").exists()
+
+
+def _make_lock(
+    path: str,
+    *,
+    heartbeat_interval: float = 0.1,
+    stale_threshold: float = 0.5,
+    poll_interval: float = 0.02,
+    is_singleton: bool = False,
+) -> SoftReadWriteLock:
+    return SoftReadWriteLock(
+        path,
+        heartbeat_interval=heartbeat_interval,
+        stale_threshold=stale_threshold,
+        poll_interval=poll_interval,
+        is_singleton=is_singleton,
+    )
+
+
+def _worker(
+    lock_file: str,
+    mode: Literal["read", "write"],
+    acquired_event: EventType,
+    release_event: EventType | None = None,
+    timeout: float = -1,
+    blocking: bool = True,
+    heartbeat_interval: float = 0.1,
+    stale_threshold: float = 1.0,
+    poll_interval: float = 0.02,
+) -> None:
+    lock = SoftReadWriteLock(
+        lock_file,
+        timeout=timeout,
+        blocking=blocking,
+        is_singleton=False,
+        heartbeat_interval=heartbeat_interval,
+        stale_threshold=stale_threshold,
+        poll_interval=poll_interval,
+    )
+    try:
+        with lock.read_lock() if mode == "read" else lock.write_lock():
+            acquired_event.set()
+            if release_event is not None:
+                release_event.wait(timeout=10)
+            else:
+                time.sleep(0.2)
+    finally:
+        lock.close()
+
+
+@contextmanager
+def _cleanup(processes: list[Process]) -> Generator[None]:
+    try:
+        yield
+    finally:
+        for proc in processes:
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=2)
+
+
+def _sigkill_worker(
+    lock_file: str,
+    mode: Literal["read", "write"],
+    acquired_event: EventType,
+    heartbeat_interval: float,
+    stale_threshold: float,
+) -> None:
+    lock = SoftReadWriteLock(
+        lock_file,
+        is_singleton=False,
+        heartbeat_interval=heartbeat_interval,
+        stale_threshold=stale_threshold,
+        poll_interval=0.05,
+    )
+    if mode == "read":
+        lock.acquire_read()
+    else:
+        lock.acquire_write()
+    acquired_event.set()
+    time.sleep(60)
+
+
+def _write_stale_marker(path: str, content: bytes) -> None:
+    Path(path).write_bytes(content)
+    past = time.time() - 1000
+    os.utime(path, (past, past))
 
 
 def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:
@@ -1023,73 +1078,15 @@ def _reacquire_fresh_lock_in_child(lock_file: str, child_path: str, result: Even
     parent_lock.close()
 
 
-@requires_fork
-@pytest.mark.timeout(15)
-def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:
-    ctx = mp.get_context("spawn")
-    result, failure = ctx.Event(), ctx.Event()
-    proc = ctx.Process(target=_reuse_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
-    proc.start()
-    proc.join(timeout=10)
-    assert not failure.is_set()
-    assert result.is_set()
+def _fork_process(target: Callable[..., object], args: tuple[object, ...] = ()) -> mp.process.BaseProcess:
+    if sys.platform == "win32":
+        msg = "fork context is POSIX only"
+        raise RuntimeError(msg)
+    return mp.get_context("fork").Process(target=target, args=args)
 
 
-@requires_fork
-@pytest.mark.timeout(15)
-def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:
-    ctx = mp.get_context("spawn")
-    result, failure = ctx.Event(), ctx.Event()
-    proc = ctx.Process(target=_release_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
-    proc.start()
-    proc.join(timeout=10)
-    assert not failure.is_set()
-    assert result.is_set()
-
-
-@requires_fork
-@pytest.mark.timeout(15)
-def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:
-    ctx = mp.get_context("spawn")
-    result, failure = ctx.Event(), ctx.Event()
-    proc = ctx.Process(
-        target=_reacquire_fresh_lock_in_child,
-        args=(str(tmp_path / "parent.lock"), str(tmp_path / "child.lock"), result, failure),
-    )
-    proc.start()
-    proc.join(timeout=10)
-    assert not failure.is_set()
-    assert result.is_set()
-
-
-@requires_fork
-@pytest.mark.timeout(15)
-# Holding the write lock keeps the heartbeat thread alive, so this fork is necessarily from a multi-threaded
-# process and Python 3.15 warns that it may deadlock. That is the scenario under test, and it is already safe:
-# register_at_fork resets inherited state in the child (any child use raises "invalidated by fork()"). Expected.
-@pytest.mark.filterwarnings("ignore:.*multi-threaded, use of fork.*:DeprecationWarning")
-def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:
-    path = str(tmp_path / "foo.lock")
-    lock = SoftReadWriteLock(path, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
-    lock.acquire_write(timeout=5)
-    try:
-        child = _fork_process(target=time.sleep, args=(0.05,))
-        child.start()
-        child.join(timeout=5)
-        assert Path(f"{path}.write").exists()
-        peer = SoftReadWriteLock(
-            path,
-            heartbeat_interval=0.2,
-            stale_threshold=1.0,
-            poll_interval=0.02,
-            is_singleton=False,
-        )
-        try:
-            with pytest.raises(Timeout):
-                peer.acquire_write(timeout=0.3)
-        finally:
-            peer.close()
-    finally:
-        lock.release()
-        lock.close()
-    assert not Path(f"{path}.write").exists()
+def _fork_event() -> EventType:
+    if sys.platform == "win32":
+        msg = "fork context is POSIX only"
+        raise RuntimeError(msg)
+    return mp.get_context("fork").Event()

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -25,7 +25,6 @@ async def test_simple(
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
-    # test lock creation by passing a `str`
     lock_path = tmp_path / filename
     lock = lock_type(path_type(lock_path))
     async with lock as locked:
@@ -57,7 +56,6 @@ async def test_acquire(
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
-    # test lock creation by passing a `str`
     lock_path = tmp_path / filename
     lock = lock_type(path_type(lock_path))
     async with await lock.acquire() as locked:
@@ -79,14 +77,12 @@ async def test_acquire(
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio
 async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
-    # raises Timeout error when the lock cannot be acquired
     lock_path = tmp_path / "a"
     lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
     lock_3 = lock_type(str(lock_path), blocking=False)
     lock_4 = lock_type(str(lock_path), timeout=0)
     lock_5 = lock_type(str(lock_path), blocking=False, timeout=-1)
 
-    # acquire lock 1
     await lock_1.acquire()
     assert lock_1.is_locked
     assert not lock_2.is_locked
@@ -94,32 +90,27 @@ async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) 
     assert not lock_4.is_locked
     assert not lock_5.is_locked
 
-    # try to acquire lock 2
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         await lock_2.acquire(blocking=False)
     assert not lock_2.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `blocking=False` lock 3 with `acquire`
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         await lock_3.acquire()
     assert not lock_3.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `blocking=False` lock 3 with context manager
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         async with lock_3:
             pass
     assert not lock_3.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `timeout=0` lock 4 with `acquire`
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         await lock_4.acquire()
     assert not lock_4.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `timeout=0` lock 4 with context manager
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         async with lock_4:
             pass
@@ -127,20 +118,17 @@ async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) 
     assert lock_1.is_locked
 
     # blocking precedence over timeout
-    # try to acquire pre-parametrized `timeout=-1,blocking=False` lock 5 with `acquire`
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         await lock_5.acquire()
     assert not lock_5.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `timeout=-1,blocking=False` lock 5 with context manager
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         async with lock_5:
             pass
     assert not lock_5.is_locked
     assert lock_1.is_locked
 
-    # release lock 1
     await lock_1.release()
     assert not lock_1.is_locked
     assert not lock_2.is_locked
@@ -153,8 +141,7 @@ async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) 
 @pytest.mark.parametrize("thread_local", [True, False])
 @pytest.mark.asyncio
 async def test_non_executor(lock_type: type[BaseAsyncFileLock], thread_local: bool, tmp_path: Path) -> None:
-    lock_path = tmp_path / "a"
-    lock = lock_type(str(lock_path), thread_local=thread_local, run_in_executor=False)
+    lock = lock_type(str(tmp_path / "a"), thread_local=thread_local, run_in_executor=False)
     async with lock as locked:
         assert lock.is_locked
         assert lock is locked
@@ -241,8 +228,8 @@ async def test_attempting_to_release(
     caplog.set_level(logging.DEBUG)
     lock = lock_type(str(tmp_path / "a.lock"), run_in_executor=False)
 
-    await lock.acquire(timeout=0.1)  # lock_counter = 1, is_locked = True
-    await lock.acquire(timeout=0.1)  # lock_counter = 2 (reentrant)
+    await lock.acquire(timeout=0.1)
+    await lock.acquire(timeout=0.1)  # reentrant acquire
     await lock.release(force=True)
 
     assert any("Attempting to release lock" in m for m in caplog.messages)
@@ -267,7 +254,7 @@ async def test_release_nonzero_counter_exit(
     lock = lock_type(str(tmp_path / "a.lock"), run_in_executor=False)
     await lock.acquire()
     await lock.acquire()
-    await lock.release()  # counter goes 2→1
+    await lock.release()
     assert lock.lock_counter == 1
     assert lock.is_locked
     assert not any("Attempting to release" in m for m in caplog.messages)
@@ -292,8 +279,7 @@ async def test_cancel_check_triggers(lock_type: type[BaseAsyncFileLock], tmp_pat
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio
 async def test_cancel_check_not_called_when_lock_available(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
-    lock_path = tmp_path / "a"
-    lock = lock_type(str(lock_path))
+    lock = lock_type(str(tmp_path / "a"))
 
     called = False
 
@@ -330,7 +316,7 @@ async def test_cancel_check_log_message(
     [pytest.param(AsyncFileLock, id="async"), pytest.param(AsyncSoftFileLock, id="soft")],
 )
 def test_sync_with_raises_not_implemented_error(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
-    # __exit__ must exist so Python can call it after __enter__ raises — without it AttributeError masks the real error
+    # __exit__ must exist so Python can call it after __enter__ raises; without it AttributeError hides the real error
     with pytest.raises(NotImplementedError, match=r"async with"), lock_type(str(tmp_path / "test.lock")):
         pass  # pragma: no cover
 
@@ -340,7 +326,7 @@ def test_sync_with_raises_not_implemented_error(lock_type: type[BaseAsyncFileLoc
     [pytest.param(AsyncFileLock, id="async"), pytest.param(AsyncSoftFileLock, id="soft")],
 )
 def test_del_after_loop_close_does_not_raise(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
-    # __del__ must not call get_running_loop() — it raises RuntimeError when no loop is running
+    # __del__ must not call get_running_loop(); it raises RuntimeError when no loop is running
     def _run() -> None:
         lock = lock_type(str(tmp_path / "test.lock"))
         loop = asyncio.new_event_loop()
@@ -427,8 +413,7 @@ async def test_singleton_avoids_deadlock(tmp_path: Path, lock_type: type[BaseAsy
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio
 async def test_different_tasks_no_false_positive(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
-    # The registry is per-thread; a second acquire from a different task (asyncio's counterpart to the sync
-    # test's separate thread) must not be mistaken for a reentrant deadlock.
+    # The registry is per-thread, so a second acquire from a different task must not look like a reentrant deadlock.
     lock_path = tmp_path / "test.lock"
     lock1 = lock_type(lock_path, timeout=0)
     await lock1.acquire()

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import gc
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pytest
 
@@ -33,113 +33,76 @@ def lock_file(tmp_path: Path) -> str:
     return str(tmp_path / "test_lock.db")
 
 
+@pytest.mark.parametrize("mode", ["read", "write"])
 @pytest.mark.asyncio
-async def test_acquire_release_read(lock_file: str) -> None:
+async def test_acquire_release(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    proxy = await lock.acquire_read()
+    proxy = await (lock.acquire_read() if mode == "read" else lock.acquire_write())
     assert lock._lock._lock_level == 1
-    assert lock._lock._current_mode == "read"
+    assert lock._lock._current_mode == mode
     await lock.release()
     assert lock._lock._lock_level == 0
     assert lock._lock._current_mode is None
     assert isinstance(proxy, object)
 
 
+@pytest.mark.parametrize("mode", ["read", "write"])
 @pytest.mark.asyncio
-async def test_acquire_release_write(lock_file: str) -> None:
+async def test_lock_context_manager(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    await lock.acquire_write()
-    assert lock._lock._lock_level == 1
-    assert lock._lock._current_mode == "write"
-    await lock.release()
-    assert lock._lock._lock_level == 0
-    assert lock._lock._current_mode is None
-
-
-@pytest.mark.asyncio
-async def test_read_lock_context_manager(lock_file: str) -> None:
-    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    async with lock.read_lock():
+    ctx = lock.read_lock() if mode == "read" else lock.write_lock()
+    async with ctx:
         assert lock._lock._lock_level == 1
-        assert lock._lock._current_mode == "read"
+        assert lock._lock._current_mode == mode
     assert lock._lock._lock_level == 0
     assert lock._lock._current_mode is None
 
 
+@pytest.mark.parametrize("mode", ["read", "write"])
 @pytest.mark.asyncio
-async def test_write_lock_context_manager(lock_file: str) -> None:
+async def test_reentrant(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    async with lock.write_lock():
-        assert lock._lock._lock_level == 1
-        assert lock._lock._current_mode == "write"
-    assert lock._lock._lock_level == 0
-    assert lock._lock._current_mode is None
-
-
-@pytest.mark.asyncio
-async def test_reentrant_read(lock_file: str) -> None:
-    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    await lock.acquire_read()
-    await lock.acquire_read()
+    acquire = lock.acquire_read if mode == "read" else lock.acquire_write
+    await acquire()
+    await acquire()
     assert lock._lock._lock_level == 2
     await lock.release()
     assert lock._lock._lock_level == 1
-    assert lock._lock._current_mode == "read"
+    assert lock._lock._current_mode == mode
     await lock.release()
     assert lock._lock._lock_level == 0
 
 
+@pytest.mark.parametrize(
+    ("held", "requested", "match"),
+    [
+        pytest.param("read", "write", r"already holding a read lock.*upgrade not allowed", id="upgrade"),
+        pytest.param("write", "read", r"already holding a write lock.*downgrade not allowed", id="downgrade"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_reentrant_write(lock_file: str) -> None:
+async def test_mode_change_prohibited(
+    lock_file: str,
+    held: Literal["read", "write"],
+    requested: Literal["read", "write"],
+    match: str,
+) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    await lock.acquire_write()
-    await lock.acquire_write()
-    assert lock._lock._lock_level == 2
+    await (lock.acquire_read() if held == "read" else lock.acquire_write())
+    with pytest.raises(RuntimeError, match=match):
+        await (lock.acquire_read() if requested == "read" else lock.acquire_write())
     await lock.release()
-    assert lock._lock._lock_level == 1
-    assert lock._lock._current_mode == "write"
-    await lock.release()
-    assert lock._lock._lock_level == 0
 
 
+@pytest.mark.parametrize("mode", ["read", "write"])
 @pytest.mark.asyncio
-async def test_upgrade_prohibited(lock_file: str) -> None:
-    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    await lock.acquire_read()
-    with pytest.raises(RuntimeError, match=r"already holding a read lock.*upgrade not allowed"):
-        await lock.acquire_write()
-    await lock.release()
-
-
-@pytest.mark.asyncio
-async def test_downgrade_prohibited(lock_file: str) -> None:
-    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    await lock.acquire_write()
-    with pytest.raises(RuntimeError, match=r"already holding a write lock.*downgrade not allowed"):
-        await lock.acquire_read()
-    await lock.release()
-
-
-@pytest.mark.asyncio
-async def test_non_blocking_read(lock_file: str) -> None:
+async def test_non_blocking_conflict(lock_file: str, mode: Literal["read", "write"]) -> None:
     holder = ReadWriteLock(lock_file, is_singleton=False)
-    holder.acquire_write()
+    (holder.acquire_write if mode == "read" else holder.acquire_read)()
     try:
         lock = AsyncReadWriteLock(lock_file, is_singleton=False)
         with pytest.raises(Timeout):
-            await lock.acquire_read(blocking=False)
-    finally:
-        holder.release()
-
-
-@pytest.mark.asyncio
-async def test_non_blocking_write(lock_file: str) -> None:
-    holder = ReadWriteLock(lock_file, is_singleton=False)
-    holder.acquire_read()
-    try:
-        lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-        with pytest.raises(Timeout):
-            await lock.acquire_write(blocking=False)
+            await (lock.acquire_read if mode == "read" else lock.acquire_write)(blocking=False)
     finally:
         holder.release()
 
@@ -226,7 +189,7 @@ async def test_close_shuts_down_owned_executor(lock_file: str) -> None:
     assert lock._owns_executor is True
     executor = lock.executor
     await lock.close()
-    with pytest.raises(RuntimeError):  # submitting after shutdown is rejected
+    with pytest.raises(RuntimeError):
         executor.submit(int)
 
 
@@ -236,14 +199,14 @@ async def test_close_keeps_provided_executor_open(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False, executor=executor)
     assert lock._owns_executor is False
     await lock.close()
-    assert executor.submit(int).result(timeout=5) == 0  # still usable
+    assert executor.submit(int).result(timeout=5) == 0
     executor.shutdown(wait=False)
 
 
 def test_del_shuts_down_owned_executor(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     executor = lock.executor
-    lock._lock.close()  # close the connection so only the executor lifecycle is under test
+    lock._lock.close()  # isolate the executor lifecycle from the sqlite connection
     del lock
     gc.collect()
     with pytest.raises(RuntimeError):
@@ -269,23 +232,14 @@ async def test_acquire_return_proxy_context_manager(lock_file: str) -> None:
     assert lock._lock._lock_level == 0
 
 
+@pytest.mark.parametrize("mode", ["read", "write"])
 @pytest.mark.asyncio
-async def test_nested_read_context_managers(lock_file: str) -> None:
+async def test_nested_context_managers(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    async with lock.read_lock():
+    make_ctx = lock.read_lock if mode == "read" else lock.write_lock
+    async with make_ctx():
         assert lock._lock._lock_level == 1
-        async with lock.read_lock():
-            assert lock._lock._lock_level == 2
-        assert lock._lock._lock_level == 1
-    assert lock._lock._lock_level == 0
-
-
-@pytest.mark.asyncio
-async def test_nested_write_context_managers(lock_file: str) -> None:
-    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    async with lock.write_lock():
-        assert lock._lock._lock_level == 1
-        async with lock.write_lock():
+        async with make_ctx():
             assert lock._lock._lock_level == 2
         assert lock._lock._lock_level == 1
     assert lock._lock._lock_level == 0

--- a/tests/test_default_mode.py
+++ b/tests/test_default_mode.py
@@ -16,39 +16,39 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_default_mode_property_returns_0o644(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    lock = lock_type(tmp_path / "a.lock")
-    assert lock.mode == 0o644
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        pytest.param(_UNSET_FILE_MODE, 0o644, id="default"),
+        pytest.param(0o600, 0o600, id="explicit"),
+    ],
+)
+def test_mode_property(lock_type: type[BaseFileLock], mode: int, expected: int, tmp_path: Path) -> None:
+    assert lock_type(tmp_path / "a.lock", mode=mode).mode == expected
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_explicit_mode_property_returns_value(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    lock = lock_type(tmp_path / "a.lock", mode=0o600)
-    assert lock.mode == 0o600
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        pytest.param(_UNSET_FILE_MODE, False, id="default"),
+        pytest.param(0o644, True, id="explicit"),
+    ],
+)
+def test_has_explicit_mode(lock_type: type[BaseFileLock], mode: int, expected: bool, tmp_path: Path) -> None:
+    assert lock_type(tmp_path / "a.lock", mode=mode).has_explicit_mode is expected
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_has_explicit_mode_false_by_default(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    lock = lock_type(tmp_path / "a.lock")
-    assert lock.has_explicit_mode is False
-
-
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_has_explicit_mode_true_when_set(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    lock = lock_type(tmp_path / "a.lock", mode=0o644)
-    assert lock.has_explicit_mode is True
-
-
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_open_mode_returns_0o666_when_unset(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    lock = lock_type(tmp_path / "a.lock")
-    assert lock._open_mode() == 0o666
-
-
-@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_open_mode_returns_explicit_value(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    lock = lock_type(tmp_path / "a.lock", mode=0o600)
-    assert lock._open_mode() == 0o600
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        pytest.param(_UNSET_FILE_MODE, 0o666, id="default"),
+        pytest.param(0o600, 0o600, id="explicit"),
+    ],
+)
+def test_open_mode(lock_type: type[BaseFileLock], mode: int, expected: int, tmp_path: Path) -> None:
+    assert lock_type(tmp_path / "a.lock", mode=mode)._open_mode() == expected
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not apply umask to file permissions")
@@ -61,9 +61,7 @@ def test_default_mode_respects_umask(lock_type: type[BaseFileLock], tmp_path: Pa
     try:
         lock.acquire()
         assert lock.is_locked
-
-        mode = filemode(lock_path.stat().st_mode)
-        assert mode == "-rw-r--r--"
+        assert filemode(lock_path.stat().st_mode) == "-rw-r--r--"
     finally:
         os.umask(initial_umask)
 
@@ -72,8 +70,7 @@ def test_default_mode_respects_umask(lock_type: type[BaseFileLock], tmp_path: Pa
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fchmod only on Unix")
 def test_default_mode_skips_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
-    lock_path = tmp_path / "a.lock"
-    lock = FileLock(str(lock_path))
+    lock = FileLock(str(tmp_path / "a.lock"))
 
     fchmod_spy = mocker.patch("os.fchmod")
     lock.acquire()
@@ -84,8 +81,7 @@ def test_default_mode_skips_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fchmod only on Unix")
 def test_explicit_mode_calls_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
-    lock_path = tmp_path / "a.lock"
-    lock = FileLock(str(lock_path), mode=0o644)
+    lock = FileLock(str(tmp_path / "a.lock"), mode=0o644)
 
     fchmod_spy = mocker.spy(os, "fchmod")
     lock.acquire()
@@ -104,34 +100,30 @@ def test_explicit_mode_overrides_umask(tmp_path: Path) -> None:
     try:
         lock.acquire()
         assert lock.is_locked
-
-        mode = filemode(lock_path.stat().st_mode)
-        assert mode == "-rw-rw-rw-"
+        assert filemode(lock_path.stat().st_mode) == "-rw-rw-rw-"
     finally:
         os.umask(initial_umask)
 
     lock.release()
 
 
-def test_singleton_default_mode_matches(tmp_path: Path) -> None:
-    lock_path = tmp_path / "a.lock"
-    lock_1 = FileLock(str(lock_path), is_singleton=True)
-    lock_2 = FileLock(str(lock_path), is_singleton=True)
-    assert lock_1 is lock_2
-
-
-def test_singleton_explicit_mode_matches(tmp_path: Path) -> None:
-    lock_path = tmp_path / "a.lock"
-    lock_1 = FileLock(str(lock_path), mode=0o600, is_singleton=True)
-    lock_2 = FileLock(str(lock_path), mode=0o600, is_singleton=True)
-    assert lock_1 is lock_2
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param(_UNSET_FILE_MODE, id="default"),
+        pytest.param(0o600, id="explicit"),
+    ],
+)
+def test_singleton_same_mode_matches(mode: int, tmp_path: Path) -> None:
+    lock_path = str(tmp_path / "a.lock")
+    assert FileLock(lock_path, mode=mode, is_singleton=True) is FileLock(lock_path, mode=mode, is_singleton=True)
 
 
 def test_singleton_default_vs_explicit_mode_differ(tmp_path: Path) -> None:
-    lock_path = tmp_path / "a.lock"
-    lock = FileLock(str(lock_path), is_singleton=True)
+    lock_path = str(tmp_path / "a.lock")
+    lock = FileLock(lock_path, is_singleton=True)
     with pytest.raises(ValueError, match="mode"):
-        FileLock(str(lock_path), mode=0o644, is_singleton=True)
+        FileLock(lock_path, mode=0o644, is_singleton=True)
     del lock
 
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,35 +1,39 @@
 from __future__ import annotations
 
 import pickle  # noqa: S403
+from typing import TYPE_CHECKING
+
+import pytest
 
 from filelock import Timeout
 
-
-def test_timeout_str() -> None:
-    timeout = Timeout("/path/to/lock")
-    assert str(timeout) == "The file lock '/path/to/lock' could not be acquired."
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
-def test_timeout_repr() -> None:
-    timeout = Timeout("/path/to/lock")
-    assert repr(timeout) == "Timeout('/path/to/lock')"
+@pytest.mark.parametrize(
+    ("extract", "expected"),
+    [
+        pytest.param(str, "The file lock '/path/to/lock' could not be acquired.", id="str"),
+        pytest.param(repr, "Timeout('/path/to/lock')", id="repr"),
+        pytest.param(lambda t: t.lock_file, "/path/to/lock", id="lock_file"),
+        pytest.param(lambda t: t.__reduce__(), (Timeout, ("/path/to/lock",)), id="reduce"),
+    ],
+)
+def test_timeout_attribute(timeout: Timeout, extract: Callable[[Timeout], object], expected: object) -> None:
+    assert extract(timeout) == expected
 
 
-def test_timeout_lock_file() -> None:
-    timeout = Timeout("/path/to/lock")
-    assert timeout.lock_file == "/path/to/lock"
+def test_timeout_pickle(timeout: Timeout) -> None:
+    reloaded = pickle.loads(pickle.dumps(timeout))  # noqa: S301
+    assert (type(reloaded), str(reloaded), repr(reloaded), reloaded.lock_file) == (
+        type(timeout),
+        str(timeout),
+        repr(timeout),
+        timeout.lock_file,
+    )
 
 
-def test_timeout_reduce() -> None:
-    timeout = Timeout("/path/to/lock")
-    assert timeout.__reduce__() == (Timeout, ("/path/to/lock",))
-
-
-def test_timeout_pickle() -> None:
-    timeout = Timeout("/path/to/lock")
-    timeout_loaded = pickle.loads(pickle.dumps(timeout))  # noqa: S301
-
-    assert timeout.__class__ == timeout_loaded.__class__
-    assert str(timeout) == str(timeout_loaded)
-    assert repr(timeout) == repr(timeout_loaded)
-    assert timeout.lock_file == timeout_loaded.lock_file
+@pytest.fixture
+def timeout() -> Timeout:
+    return Timeout("/path/to/lock")

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -13,7 +13,7 @@ from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IWGRP, S_IWOTH, S_IWUSR, filemode
 from types import TracebackType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 from uuid import uuid4
 from weakref import WeakValueDictionary
 
@@ -39,7 +39,6 @@ def test_simple(
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
-    # test lock creation by passing a `str`
     lock_path = tmp_path / filename
     lock = lock_type(path_type(lock_path))
     with lock as locked:
@@ -105,7 +104,7 @@ def test_ro_file(lock_type: type[BaseFileLock], tmp_file_ro: Path) -> None:
         lock.acquire()
 
 
-WindowsOnly = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+_WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
@@ -127,8 +126,10 @@ WindowsOnly = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
             )
         ),
     ]
-    + [pytest.param(OSError, "Invalid argument", i, id=f"invalid_{i}", marks=WindowsOnly) for i in '<>:"|?*\a']
-    + [pytest.param(PermissionError, "Permission denied:", i, id=f"permission_{i}", marks=WindowsOnly) for i in "/\\"],
+    + [pytest.param(OSError, "Invalid argument", i, id=f"invalid_{i}", marks=_WINDOWS_ONLY) for i in '<>:"|?*\a']
+    + [
+        pytest.param(PermissionError, "Permission denied:", i, id=f"permission_{i}", marks=_WINDOWS_ONLY) for i in "/\\"
+    ],
 )
 @pytest.mark.timeout(5)  # timeout in case of infinite loop
 def test_bad_lock_file(
@@ -145,7 +146,6 @@ def test_bad_lock_file(
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_nested_context_manager(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # lock is not released before the most outer with statement that locked the lock, is left
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path))
 
@@ -168,7 +168,6 @@ def test_nested_context_manager(lock_type: type[BaseFileLock], tmp_path: Path) -
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_nested_acquire(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # lock is not released before the most outer with statement that locked the lock, is left
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path))
 
@@ -191,7 +190,6 @@ def test_nested_acquire(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_nested_forced_release(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # acquires the lock using a with-statement and releases the lock before leaving the with-statement
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path))
 
@@ -208,7 +206,6 @@ def test_nested_forced_release(lock_type: type[BaseFileLock], tmp_path: Path) ->
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_nested_contruct(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # lock is re-entrant for a given file even if it is constructed multiple times
     lock_path = tmp_path / "a"
 
     with lock_type(str(lock_path), is_singleton=True, timeout=2) as lock_1:
@@ -251,8 +248,6 @@ def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path)
             "thread contention (EACCES from antivirus/indexer), orphaning the lock file with no recovery path"
         )
 
-    # Runs 100 threads, which need the filelock. The lock must be acquired if at least one thread required it and
-    # released, as soon as all threads stopped.
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path))
 
@@ -275,8 +270,6 @@ def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_pat
     if sys.platform == "win32" and (hasattr(sys, "pypy_version_info") or lock_type.__name__ == "SoftFileLock"):
         pytest.skip("SoftFileLock on Windows has race conditions under heavy threading")
 
-    # Runs multiple threads, which acquire the same lock file with a different FileLock object. When thread group 1
-    # acquired the lock, thread group 2 must not hold their lock.
     def t_1() -> None:
         for _ in range(1000):
             with lock_1:
@@ -306,22 +299,18 @@ def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_pat
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_timeout(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # raises Timeout error when the lock cannot be acquired
     lock_path = tmp_path / "a"
     lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
 
-    # acquire lock 1
     lock_1.acquire()
     assert lock_1.is_locked
     assert not lock_2.is_locked
 
-    # try to acquire lock 2
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         lock_2.acquire(timeout=0.1)
     assert not lock_2.is_locked
     assert lock_1.is_locked
 
-    # release lock 1
     lock_1.release()
     assert not lock_1.is_locked
     assert not lock_2.is_locked
@@ -329,14 +318,12 @@ def test_timeout(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_non_blocking(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # raises Timeout error when the lock cannot be acquired
     lock_path = tmp_path / "a"
     lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
     lock_3 = lock_type(str(lock_path), blocking=False)
     lock_4 = lock_type(str(lock_path), timeout=0)
     lock_5 = lock_type(str(lock_path), blocking=False, timeout=-1)
 
-    # acquire lock 1
     lock_1.acquire()
     assert lock_1.is_locked
     assert not lock_2.is_locked
@@ -344,50 +331,42 @@ def test_non_blocking(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     assert not lock_4.is_locked
     assert not lock_5.is_locked
 
-    # try to acquire lock 2
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         lock_2.acquire(blocking=False)
     assert not lock_2.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `blocking=False` lock 3 with `acquire`
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         lock_3.acquire()
     assert not lock_3.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `blocking=False` lock 3 with context manager
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."), lock_3:
         pass
     assert not lock_3.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `timeout=0` lock 4 with `acquire`
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         lock_4.acquire()
     assert not lock_4.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `timeout=0` lock 4 with context manager
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."), lock_4:
         pass
     assert not lock_4.is_locked
     assert lock_1.is_locked
 
     # blocking precedence over timeout
-    # try to acquire pre-parametrized `timeout=-1,blocking=False` lock 5 with `acquire`
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         lock_5.acquire()
     assert not lock_5.is_locked
     assert lock_1.is_locked
 
-    # try to acquire pre-parametrized `timeout=-1,blocking=False` lock 5 with context manager
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."), lock_5:
         pass
     assert not lock_5.is_locked
     assert lock_1.is_locked
 
-    # release lock 1
     lock_1.release()
     assert not lock_1.is_locked
     assert not lock_2.is_locked
@@ -398,17 +377,14 @@ def test_non_blocking(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_default_timeout(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # test if the default timeout parameter works
     lock_path = tmp_path / "a"
     lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path), timeout=0.1)
     assert lock_2.timeout == pytest.approx(0.1)
 
-    # acquire lock 1
     lock_1.acquire()
     assert lock_1.is_locked
     assert not lock_2.is_locked
 
-    # try to acquire lock 2
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         lock_2.acquire()
     assert not lock_2.is_locked
@@ -422,7 +398,6 @@ def test_default_timeout(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     assert not lock_2.is_locked
     assert lock_1.is_locked
 
-    # release lock 1
     lock_1.release()
     assert not lock_1.is_locked
     assert not lock_2.is_locked
@@ -430,7 +405,6 @@ def test_default_timeout(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_context_release_on_exc(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # lock is released when an exception is thrown in a with-statement
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path))
 
@@ -445,7 +419,6 @@ def test_context_release_on_exc(lock_type: type[BaseFileLock], tmp_path: Path) -
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_acquire_release_on_exc(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # lock is released when an exception is thrown in a acquire statement
     lock_path = tmp_path / "a"
     lock = lock_type(str(lock_path))
 
@@ -461,20 +434,16 @@ def test_acquire_release_on_exc(lock_type: type[BaseFileLock], tmp_path: Path) -
 @pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="del() does not trigger GC in PyPy")
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_del(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    # lock is released when the object is deleted
     lock_path = tmp_path / "a"
     lock_1, lock_2 = lock_type(str(lock_path)), lock_type(str(lock_path))
 
-    # acquire lock 1
     lock_1.acquire()
     assert lock_1.is_locked
     assert not lock_2.is_locked
 
-    # try to acquire lock 2
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         lock_2.acquire(timeout=0.1)
 
-    # delete lock 1 and try to acquire lock 2 again
     del lock_1
 
     lock_2.acquire()
@@ -484,7 +453,6 @@ def test_del(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
 
 
 def test_cleanup_soft_lock(tmp_path: Path) -> None:
-    # tests if the lock file is removed after use
     lock_path = tmp_path / "a"
 
     with SoftFileLock(lock_path):
@@ -498,8 +466,8 @@ def test_poll_intervall_deprecated(lock_type: type[BaseFileLock], tmp_path: Path
     lock = lock_type(str(lock_path))
 
     with pytest.deprecated_call(match="use poll_interval instead of poll_intervall") as checker:
-        lock.acquire(poll_intervall=0.05)  # the deprecation warning will be captured by the checker
-        frame_info = getframeinfo(stack()[0][0])  # get frame info of current file and lineno (+1 than the above lineno)
+        lock.acquire(poll_intervall=0.05)
+        frame_info = getframeinfo(stack()[0][0])  # lineno here is one past the acquire() call above
         for warning in checker:
             if warning.filename == frame_info.filename and warning.lineno + 1 == frame_info.lineno:  # pragma: no cover
                 break
@@ -571,18 +539,15 @@ def test_context_decorator(lock_type: type[BaseFileLock], tmp_path: Path) -> Non
 
 
 def test_lock_mode(tmp_path: Path) -> None:
-    # test file lock permissions are independent of umask
     lock_path = tmp_path / "a.lock"
     lock = FileLock(str(lock_path), mode=0o666)
 
-    # set umask so permissions can be anticipated
-    initial_umask = os.umask(0o022)
+    initial_umask = os.umask(0o022)  # pin umask so the resulting permissions are predictable
     try:
         lock.acquire()
         assert lock.is_locked
 
-        mode = filemode(lock_path.stat().st_mode)
-        assert mode == "-rw-rw-rw-"
+        assert filemode(lock_path.stat().st_mode) == "-rw-rw-rw-"
     finally:
         os.umask(initial_umask)
 
@@ -590,21 +555,15 @@ def test_lock_mode(tmp_path: Path) -> None:
 
 
 def test_lock_mode_soft(tmp_path: Path) -> None:
-    # test soft lock permissions are dependent of umask
     lock_path = tmp_path / "a.lock"
     lock = SoftFileLock(str(lock_path), mode=0o666)
 
-    # set umask so permissions can be anticipated
-    initial_umask = os.umask(0o022)
+    initial_umask = os.umask(0o022)  # pin umask so the resulting permissions are predictable
     try:
         lock.acquire()
         assert lock.is_locked
 
-        mode = filemode(lock_path.stat().st_mode)
-        if sys.platform == "win32":
-            assert mode == "-rw-rw-rw-"
-        else:
-            assert mode == "-rw-r--r--"
+        assert filemode(lock_path.stat().st_mode) == ("-rw-rw-rw-" if sys.platform == "win32" else "-rw-r--r--")
     finally:
         os.umask(initial_umask)
 
@@ -744,13 +703,10 @@ def test_lock_can_be_non_thread_local(
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_thread_local_setter_visibility(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    """Document that property setters are per-thread when thread_local=True.
+    """Property setters stay per-thread when thread_local=True.
 
-    Setting ``poll_interval`` on the constructing thread must not affect the
-    value observed from a different thread. The other thread sees the value
-    supplied to the constructor (``threading.local`` re-applies the original
-    constructor arguments the first time each new thread accesses the
-    context).
+    A ``poll_interval`` set on the constructing thread stays invisible to other threads: ``threading.local`` re-applies
+    the constructor arguments the first time each new thread touches the context, so the reader sees the default.
     """
     lock = lock_type(tmp_path / "x.lock", thread_local=True, poll_interval=0.05)
     lock.poll_interval = 0.5
@@ -764,7 +720,6 @@ def test_thread_local_setter_visibility(lock_type: type[BaseFileLock], tmp_path:
     t.start()
     t.join()
 
-    # setter is local to the writing thread; reader sees the constructor default
     assert observed == [pytest.approx(0.05)]
 
 
@@ -886,8 +841,8 @@ def test_singleton_locks_must_be_initialized_with_the_same_args(lock_type: type[
 
     lock = lock_type(str(lock_path), is_singleton=True, **args)
 
+    general_msg = "Singleton lock instances cannot be initialized with differing arguments"
     for arg_name in args:
-        general_msg = "Singleton lock instances cannot be initialized with differing arguments"
         altered_args = args.copy()
         altered_args[arg_name] = alternate_args[arg_name]
         with pytest.raises(ValueError, match=general_msg) as exc_info:
@@ -1214,7 +1169,7 @@ def test_cancel_check_log_message(
 
 @pytest.mark.skipif(sys.platform == "win32", reason="unix-only test")
 def test_filenotfound_on_fuse_nfs_retries(tmp_path: Path, mocker: MockerFixture) -> None:
-    """FileNotFoundError from FUSE/NFS os.open(O_CREAT) race is handled by retry."""
+    """Retry recovers from the FUSE/NFS os.open(O_CREAT) race that raises FileNotFoundError."""
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
 
@@ -1224,15 +1179,13 @@ def test_filenotfound_on_fuse_nfs_retries(tmp_path: Path, mocker: MockerFixture)
     def open_enoent_then_succeed(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
         nonlocal call_count
         call_count += 1
-        # Simulate FUSE/NFS race: first call to os.open(O_CREAT) fails with ENOENT
-        if call_count == 1 and flags & os.O_CREAT and "test.lock" in path:
+        if call_count == 1 and flags & os.O_CREAT and "test.lock" in path:  # first O_CREAT hits the FUSE/NFS ENOENT
             raise FileNotFoundError(2, "No such file or directory", path)
         return real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
 
     mocker.patch("os.open", side_effect=open_enoent_then_succeed)
     lock.acquire()
     assert lock.is_locked
-    # First call failed with ENOENT, retry succeeded
     assert call_count >= 2
     lock.release()
 

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from filelock import FileLock, SoftFileLock
+from filelock import AsyncFileLock, AsyncSoftFileLock, FileLock, SoftFileLock
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -30,9 +30,8 @@ def test_soft_non_expired_lock_not_broken(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
 
-    lock = SoftFileLock(lock_path, lifetime=9999, timeout=0.2)
     with pytest.raises(TimeoutError):
-        lock.acquire()
+        SoftFileLock(lock_path, lifetime=9999, timeout=0.2).acquire()
 
 
 def test_soft_lifetime_none_no_expiry(tmp_path: Path) -> None:
@@ -40,9 +39,8 @@ def test_soft_lifetime_none_no_expiry(tmp_path: Path) -> None:
     lock_path.write_text(f"{os.getpid()}\n{socket.gethostname()}\n", encoding="utf-8")
     os.utime(lock_path, (0, 0))
 
-    lock = SoftFileLock(lock_path, lifetime=None, timeout=0.2)
     with pytest.raises(TimeoutError):
-        lock.acquire()
+        SoftFileLock(lock_path, lifetime=None, timeout=0.2).acquire()
 
 
 def test_expired_lock_race_rename_fails(tmp_path: Path, mocker: MockerFixture) -> None:
@@ -52,9 +50,8 @@ def test_expired_lock_race_rename_fails(tmp_path: Path, mocker: MockerFixture) -
 
     mocker.patch("filelock._util.Path.rename", side_effect=FileNotFoundError)
 
-    lock = SoftFileLock(lock_path, lifetime=0.1, timeout=0.5)
     with pytest.raises(TimeoutError):
-        lock.acquire()
+        SoftFileLock(lock_path, lifetime=0.1, timeout=0.5).acquire()
 
 
 def test_lifetime_property_getter_setter(tmp_path: Path) -> None:
@@ -69,8 +66,7 @@ def test_lifetime_property_getter_setter(tmp_path: Path) -> None:
 
 
 def test_lifetime_default_none(tmp_path: Path) -> None:
-    lock = FileLock(tmp_path / "test.lock")
-    assert lock.lifetime is None
+    assert FileLock(tmp_path / "test.lock").lifetime is None
 
 
 @pytest.mark.parametrize("bad_value", [-1, -0.5, -1e9])
@@ -84,7 +80,7 @@ def test_lifetime_setter_rejects_negative_number(bad_value: float, tmp_path: Pat
 def test_lifetime_setter_rejects_non_numeric(bad_value: object, tmp_path: Path) -> None:
     lock = FileLock(tmp_path / "test.lock")
     with pytest.raises(TypeError, match="lifetime must be"):
-        lock.lifetime = bad_value  # ty: ignore[invalid-assignment]
+        lock.lifetime = bad_value  # ty: ignore[invalid-assignment]  # non-numeric input to hit the setter's TypeError
 
 
 @pytest.mark.parametrize("bad_value", [True, False])  # bool is an int subclass; reject it so it can't read as 1s/0s
@@ -119,9 +115,7 @@ def test_lifetime_singleton_match(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_lock_file_missing_during_expiry_check(lock_type: type[FileLock | SoftFileLock], tmp_path: Path) -> None:
-    lock_path = tmp_path / "test.lock"
-
-    lock = lock_type(lock_path, lifetime=0.1, timeout=1)
+    lock = lock_type(tmp_path / "test.lock", lifetime=0.1, timeout=1)
     with lock:
         assert lock.is_locked
 
@@ -140,8 +134,6 @@ def test_expired_lock_becomes_acquirable(lock_type: type[FileLock | SoftFileLock
 
 @pytest.mark.asyncio
 async def test_async_expired_lock_is_broken(tmp_path: Path) -> None:
-    from filelock import AsyncFileLock
-
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
     os.utime(lock_path, (0, 0))
@@ -153,14 +145,11 @@ async def test_async_expired_lock_is_broken(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_async_soft_non_expired_lock_not_broken(tmp_path: Path) -> None:
-    from filelock import AsyncSoftFileLock
-
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
 
-    lock = AsyncSoftFileLock(lock_path, lifetime=9999, timeout=0.2)
     with pytest.raises(TimeoutError):
-        await lock.acquire()
+        await AsyncSoftFileLock(lock_path, lifetime=9999, timeout=0.2).acquire()
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from contextlib import contextmanager
 from multiprocessing import Event, Process, Value
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
 
@@ -19,47 +19,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def acquire_lock(
-    lock_file: str,
-    mode: Literal["read", "write"],
-    acquired_event: EventType,
-    release_event: EventType | None = None,
-    timeout: float = -1,
-    blocking: bool = True,
-    ready_event: EventType | None = None,
-) -> None:
-    if ready_event:
-        ready_event.wait(timeout=10)
-
-    lock = ReadWriteLock(lock_file, timeout=timeout, blocking=blocking)
-    ctx = lock.read_lock() if mode == "read" else lock.write_lock()
-    with ctx:
-        acquired_event.set()
-        if release_event:
-            release_event.wait(timeout=10)
-        else:
-            time.sleep(0.5)  # hold lock briefly to simulate work
-
-
-@contextmanager
-def cleanup_processes(processes: list[Process]) -> Generator[None]:
-    try:
-        yield
-    finally:
-        for proc in processes:
-            proc.terminate()
-            proc.join(timeout=1)
-
-
-@pytest.fixture
-def lock_file(tmp_path: Path) -> str:
-    return str(tmp_path / "test_lock.db")
-
-
-@pytest.mark.timeout(20)
 @pytest.mark.timeout(20)
 def test_read_locks_are_shared(lock_file: str) -> None:
-    """Test that multiple processes can acquire read locks simultaneously."""
     read1_acquired = Event()
     read2_acquired = Event()
 
@@ -68,7 +29,7 @@ def test_read_locks_are_shared(lock_file: str) -> None:
 
     with cleanup_processes([reader1, reader2]):
         reader1.start()
-        time.sleep(0.5)  # give reader1 time to acquire lock before starting reader2
+        time.sleep(0.5)  # let reader1 acquire before reader2 starts
         reader2.start()
 
         assert read1_acquired.wait(timeout=10), f"First read lock not acquired on {lock_file}"
@@ -82,7 +43,6 @@ def test_read_locks_are_shared(lock_file: str) -> None:
 
 @pytest.mark.timeout(20)
 def test_write_lock_excludes_other_write_locks(lock_file: str) -> None:
-    """Test that a write lock prevents other processes from acquiring write locks."""
     write1_acquired = Event()
     release_write1 = Event()
     write2_acquired = Event()
@@ -112,107 +72,57 @@ def test_write_lock_excludes_other_write_locks(lock_file: str) -> None:
             assert not successor.is_alive(), "Successor did not exit cleanly"
 
 
+@pytest.mark.parametrize(
+    ("holder_mode", "contender_mode"),
+    [
+        pytest.param("write", "read", id="write-blocks-read"),
+        pytest.param("read", "write", id="read-blocks-write"),
+    ],
+)
 @pytest.mark.timeout(20)
-def test_write_lock_excludes_read_locks(lock_file: str) -> None:
-    """Test that a write lock prevents other processes from acquiring read locks."""
-    write_acquired = Event()
-    release_write = Event()
-    read_acquired = Event()
-    read_started = Event()
-
-    writer = Process(target=acquire_lock, args=(lock_file, "write", write_acquired, release_write))
-    reader = Process(target=acquire_lock, args=(lock_file, "read", read_acquired, None, -1, True, read_started))
-
-    with cleanup_processes([writer, reader]):
-        writer.start()
-        assert write_acquired.wait(timeout=2), "Write lock not acquired"
-
-        reader.start()
-        read_started.set()
-
-        time.sleep(2)  # wait to verify lock is NOT acquired
-        assert not read_acquired.is_set(), "Read lock should not be acquired while write lock held"
-
-        release_write.set()
-        writer.join(timeout=2)
-
-        assert read_acquired.wait(timeout=2), "Read lock not acquired after write released"
-
-        reader.join(timeout=2)
-        assert not reader.is_alive(), "Reader did not exit cleanly"
-
-
-@pytest.mark.timeout(20)
-def test_read_lock_excludes_write_locks(lock_file: str) -> None:
-    """Test that read locks prevent other processes from acquiring write locks."""
-    read_acquired = Event()
-    release_read = Event()
-    write_acquired = Event()
-    write_started = Event()
-
-    reader = Process(target=acquire_lock, args=(lock_file, "read", read_acquired, release_read))
-    writer = Process(target=acquire_lock, args=(lock_file, "write", write_acquired, None, -1, True, write_started))
-
-    with cleanup_processes([reader, writer]):
-        reader.start()
-        assert read_acquired.wait(timeout=2), "Read lock not acquired"
-
-        writer.start()
-        write_started.set()
-
-        time.sleep(2)  # wait to verify lock is NOT acquired
-        assert not write_acquired.is_set(), "Write lock should not be acquired while read lock held"
-
-        release_read.set()
-        reader.join(timeout=2)
-
-        assert write_acquired.wait(timeout=2), "Write lock not acquired after read released"
-
-        writer.join(timeout=2)
-        assert not writer.is_alive(), "Writer did not exit cleanly"
-
-
-def chain_reader(
-    reader_index: int,
+def test_lock_excludes_opposite_mode(
     lock_file: str,
-    release_count: Synchronized[int],
-    start_signal: EventType,
-    release_signal: EventType,
-    next_reader_signal: EventType | None,
-    writer_or_prev_signal: EventType,
+    holder_mode: Literal["read", "write"],
+    contender_mode: Literal["read", "write"],
 ) -> None:
-    start_signal.wait(timeout=10)
+    holder_acquired = Event()
+    release_holder = Event()
+    contender_acquired = Event()
+    contender_started = Event()
 
-    lock = ReadWriteLock(lock_file)
-    with lock.read_lock():
-        if reader_index > 0:
-            # delay so writer can attempt acquisition while readers overlap
-            time.sleep(2)
+    holder = Process(target=acquire_lock, args=(lock_file, holder_mode, holder_acquired, release_holder))
+    contender = Process(
+        target=acquire_lock,
+        args=(lock_file, contender_mode, contender_acquired, None, -1, True, contender_started),
+    )
 
-        if next_reader_signal is not None:
-            next_reader_signal.set()
+    with cleanup_processes([holder, contender]):
+        holder.start()
+        assert holder_acquired.wait(timeout=2), f"{holder_mode} lock not acquired"
 
-        if reader_index == 0:
-            # first reader holds lock briefly then signals writer
-            time.sleep(1)
+        contender.start()
+        contender_started.set()
 
-        writer_or_prev_signal.set()
+        time.sleep(2)  # confirm the contender stays blocked
+        assert not contender_acquired.is_set(), f"{contender_mode} lock should not be acquired while {holder_mode} held"
 
-        release_signal.wait(timeout=10)
+        release_holder.set()
+        holder.join(timeout=2)
 
-        with release_count.get_lock():
-            release_count.value += 1
+        assert contender_acquired.wait(timeout=2), f"{contender_mode} lock not acquired after {holder_mode} released"
+
+        contender.join(timeout=2)
+        assert not contender.is_alive(), "Contender did not exit cleanly"
 
 
 @pytest.mark.timeout(40)
 def test_write_non_starvation(lock_file: str) -> None:
-    """Test that write locks can eventually be acquired even with continuous read locks.
+    """A writer that joins after the first reader must acquire before the reader chain drains.
 
-    Creates a chain of reader processes where the writer starts after the first reader acquires a lock. The writer
-    should be able to acquire its lock before the entire reader chain has finished, demonstrating non-starvation.
-
+    Seven readers overlap in a chain and the writer contends mid-chain. It should win the lock while readers still
+    hold it, so it is not starved.
     """
-    NUM_READERS = 7
+    NUM_READERS: Final[int] = 7
 
     chain_forward = [Event() for _ in range(NUM_READERS)]
     chain_backward = [Event() for _ in range(NUM_READERS)]
@@ -261,57 +171,26 @@ def test_write_non_starvation(lock_file: str) -> None:
             assert not reader.is_alive(), f"Reader {idx} did not exit cleanly"
 
 
-def try_upgrade_lock(lock_file: str, upgrade_result: Synchronized[int]) -> None:
-    lock = ReadWriteLock(lock_file)
-    with lock.read_lock():
-        try:
-            lock.acquire_write()
-        except RuntimeError:
-            upgrade_result.value = 0
-
-
-def try_downgrade_lock(lock_file: str, downgrade_result: Synchronized[int]) -> None:
-    lock = ReadWriteLock(lock_file)
-    with lock.write_lock():
-        try:
-            lock.acquire_read()
-        except RuntimeError:
-            downgrade_result.value = 0
-
-
+@pytest.mark.parametrize(
+    "hold_mode",
+    [pytest.param("read", id="upgrade"), pytest.param("write", id="downgrade")],
+)
 @pytest.mark.timeout(10)
-def test_lock_upgrade_prohibited(lock_file: str) -> None:
-    """Test that a process cannot upgrade from a read lock to a write lock."""
-    upgrade_result = Value("i", -1)
+def test_lock_mode_transition_prohibited(lock_file: str, hold_mode: Literal["read", "write"]) -> None:
+    result = Value("i", -1)
 
-    upgrader = Process(target=try_upgrade_lock, args=(lock_file, upgrade_result))
+    worker = Process(target=try_illegal_transition, args=(lock_file, hold_mode, result))
 
-    with cleanup_processes([upgrader]):
-        upgrader.start()
-        upgrader.join(timeout=5)
-        assert not upgrader.is_alive(), "Process did not exit cleanly"
+    with cleanup_processes([worker]):
+        worker.start()
+        worker.join(timeout=5)
+        assert not worker.is_alive(), "Process did not exit cleanly"
 
-    assert upgrade_result.value == 0, "Read lock was incorrectly upgraded to write lock"
-
-
-@pytest.mark.timeout(10)
-def test_lock_downgrade_prohibited(lock_file: str) -> None:
-    """Test that a process cannot downgrade from a write lock to a read lock."""
-    downgrade_result = Value("i", -1)
-
-    downgrader = Process(target=try_downgrade_lock, args=(lock_file, downgrade_result))
-
-    with cleanup_processes([downgrader]):
-        downgrader.start()
-        downgrader.join(timeout=5)
-        assert not downgrader.is_alive(), "Process did not exit cleanly"
-
-    assert downgrade_result.value == 0, "Write lock was incorrectly downgraded to read lock"
+    assert result.value == 0, f"Illegal {hold_mode} transition was permitted"
 
 
 @pytest.mark.timeout(10)
 def test_timeout_behavior(lock_file: str) -> None:
-    """Test that timeout parameter works correctly in multi-process environment."""
     write_acquired = Event()
     release_write = Event()
     read_acquired = Event()
@@ -338,12 +217,6 @@ def test_timeout_behavior(lock_file: str) -> None:
 
 @pytest.mark.timeout(10)
 def test_non_blocking_behavior(lock_file: str) -> None:
-    """Test that non-blocking parameter works correctly.
-
-    This test directly attempts to acquire a read lock in non-blocking mode when a write lock is already held by another
-    process.
-
-    """
     write_acquired = Event()
     release_write = Event()
 
@@ -353,12 +226,10 @@ def test_non_blocking_behavior(lock_file: str) -> None:
         writer.start()
         assert write_acquired.wait(timeout=2), "Write lock not acquired"
 
-        lock = ReadWriteLock(lock_file)
-
         start_time = time.time()
 
         with pytest.raises(Timeout):
-            lock.acquire_read(blocking=False)
+            ReadWriteLock(lock_file).acquire_read(blocking=False)
 
         elapsed = time.time() - start_time
 
@@ -368,98 +239,31 @@ def test_non_blocking_behavior(lock_file: str) -> None:
         writer.join(timeout=2)
 
 
-def recursive_read_lock(lock_file: str, success_flag: Synchronized[int]) -> None:
-    lock = ReadWriteLock(lock_file)
-    with lock.read_lock():
-        assert lock._lock_level == 1
-        assert lock._current_mode == "read"
-
-        with lock.read_lock():
-            assert lock._lock_level == 2
-            assert lock._current_mode == "read"
-
-            with lock.read_lock():
-                assert lock._lock_level == 3
-                assert lock._current_mode == "read"
-
-            assert lock._lock_level == 2
-            assert lock._current_mode == "read"
-
-        assert lock._lock_level == 1
-        assert lock._current_mode == "read"
-
-    assert lock._lock_level == 0
-    assert lock._current_mode is None
-
-    success_flag.value = 1
-
-
+@pytest.mark.parametrize(
+    "mode",
+    [pytest.param("read", id="read"), pytest.param("write", id="write")],
+)
 @pytest.mark.timeout(10)
-def test_recursive_read_lock_acquisition(lock_file: str) -> None:
-    """Test that the same process can acquire the same read lock multiple times."""
+def test_recursive_lock_acquisition(lock_file: str, mode: Literal["read", "write"]) -> None:
     success = Value("i", 0)
-    worker = Process(target=recursive_read_lock, args=(lock_file, success))
+    worker = Process(target=recursive_lock, args=(lock_file, mode, success))
 
     with cleanup_processes([worker]):
         worker.start()
         worker.join(timeout=5)
 
-    assert success.value == 1, "Recursive read lock acquisition failed"
+    assert success.value == 1, "Recursive lock acquisition failed"
 
 
-def recursive_write_lock(lock_file: str, success_flag: Synchronized[int]) -> None:
-    lock = ReadWriteLock(lock_file)
-    with lock.write_lock():
-        assert lock._lock_level == 1
-        assert lock._current_mode == "write"
-
-        with lock.write_lock():
-            assert lock._lock_level == 2
-            assert lock._current_mode == "write"
-
-            with lock.write_lock():
-                assert lock._lock_level == 3
-                assert lock._current_mode == "write"
-
-            assert lock._lock_level == 2
-            assert lock._current_mode == "write"
-
-        assert lock._lock_level == 1
-        assert lock._current_mode == "write"
-
-    assert lock._lock_level == 0
-    assert lock._current_mode is None
-
-    success_flag.value = 1
-
-
-@pytest.mark.timeout(10)
-def test_recursive_write_lock_acquisition(lock_file: str) -> None:
-    """Test that the same process can acquire the same write lock multiple times."""
-    success = Value("i", 0)
-    worker = Process(target=recursive_write_lock, args=(lock_file, success))
-
-    with cleanup_processes([worker]):
-        worker.start()
-        worker.join(timeout=5)
-
-    assert success.value == 1, "Recursive write lock acquisition failed"
-
-
-def acquire_write_lock_and_crash(lock_file: str, acquired_event: EventType) -> None:
-    lock = ReadWriteLock(lock_file)
-    with lock.write_lock():
-        acquired_event.set()
-        while True:
-            time.sleep(0.1)
-
-
+@pytest.mark.parametrize(
+    "mode",
+    [pytest.param("read", id="read"), pytest.param("write", id="write")],
+)
 @pytest.mark.timeout(15)
-def test_write_lock_release_on_process_termination(lock_file: str) -> None:
-    """Test that write locks are properly released if a process terminates."""
+def test_lock_release_on_process_termination(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock_acquired = Event()
 
-    crashing = Process(target=acquire_write_lock_and_crash, args=(lock_file, lock_acquired))
+    crashing = Process(target=acquire_lock_and_crash, args=(lock_file, mode, lock_acquired))
     crashing.start()
 
     assert lock_acquired.wait(timeout=2), "Lock not acquired by first process"
@@ -468,7 +272,7 @@ def test_write_lock_release_on_process_termination(lock_file: str) -> None:
     successor = Process(target=acquire_lock, args=(lock_file, "write", write_acquired))
 
     with cleanup_processes([crashing, successor]):
-        time.sleep(0.5)  # ensure lock is fully acquired before terminating
+        time.sleep(0.5)  # let the lock settle before killing the holder
         crashing.terminate()
         crashing.join(timeout=2)
 
@@ -480,83 +284,150 @@ def test_write_lock_release_on_process_termination(lock_file: str) -> None:
         assert not successor.is_alive(), "Successor did not exit cleanly"
 
 
-def acquire_read_lock_and_crash(lock_file: str, acquired_event: EventType) -> None:
+@pytest.mark.parametrize(
+    "mode",
+    [pytest.param("read", id="read"), pytest.param("write", id="write")],
+)
+@pytest.mark.timeout(15)
+def test_single_lock_reentrant(lock_file: str, mode: Literal["read", "write"]) -> None:
+    lock = ReadWriteLock(lock_file)
+    acquire = lock.read_lock if mode == "read" else lock.write_lock
+
+    with acquire(), acquire():
+        pass
+
+    with acquire():
+        pass
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        pytest.param("read", "write", id="read-then-write"),
+        pytest.param("write", "read", id="write-then-read"),
+    ],
+)
+@pytest.mark.timeout(15)
+def test_sequential_lock_modes(
+    lock_file: str,
+    first: Literal["read", "write"],
+    second: Literal["read", "write"],
+) -> None:
+    lock = ReadWriteLock(lock_file)
+    for mode in (first, second):
+        acquire = lock.read_lock if mode == "read" else lock.write_lock
+        with acquire():
+            pass
+
+
+@pytest.fixture
+def lock_file(tmp_path: Path) -> str:
+    return str(tmp_path / "test_lock.db")
+
+
+def acquire_lock(
+    lock_file: str,
+    mode: Literal["read", "write"],
+    acquired_event: EventType,
+    release_event: EventType | None = None,
+    timeout: float = -1,
+    blocking: bool = True,
+    ready_event: EventType | None = None,
+) -> None:
+    if ready_event:
+        ready_event.wait(timeout=10)
+
+    lock = ReadWriteLock(lock_file, timeout=timeout, blocking=blocking)
+    with lock.read_lock() if mode == "read" else lock.write_lock():
+        acquired_event.set()
+        if release_event:
+            release_event.wait(timeout=10)
+        else:
+            time.sleep(0.5)  # hold briefly to simulate work
+
+
+@contextmanager
+def cleanup_processes(processes: list[Process]) -> Generator[None]:
+    try:
+        yield
+    finally:
+        for proc in processes:
+            proc.terminate()
+            proc.join(timeout=1)
+
+
+def chain_reader(
+    reader_index: int,
+    lock_file: str,
+    release_count: Synchronized[int],
+    start_signal: EventType,
+    release_signal: EventType,
+    next_reader_signal: EventType | None,
+    writer_or_prev_signal: EventType,
+) -> None:
+    start_signal.wait(timeout=10)
+
     lock = ReadWriteLock(lock_file)
     with lock.read_lock():
+        if reader_index > 0:
+            time.sleep(2)  # overlap with earlier readers so the writer contends mid-chain
+
+        if next_reader_signal is not None:
+            next_reader_signal.set()
+
+        if reader_index == 0:
+            time.sleep(1)  # hold briefly before releasing the writer
+
+        writer_or_prev_signal.set()
+
+        release_signal.wait(timeout=10)
+
+        with release_count.get_lock():
+            release_count.value += 1
+
+
+def try_illegal_transition(lock_file: str, hold_mode: Literal["read", "write"], result: Synchronized[int]) -> None:
+    lock = ReadWriteLock(lock_file)
+    with lock.read_lock() if hold_mode == "read" else lock.write_lock():
+        try:
+            if hold_mode == "read":
+                lock.acquire_write()
+            else:
+                lock.acquire_read()
+        except RuntimeError:
+            result.value = 0
+
+
+def recursive_lock(lock_file: str, mode: Literal["read", "write"], success_flag: Synchronized[int]) -> None:
+    lock = ReadWriteLock(lock_file)
+    acquire = lock.read_lock if mode == "read" else lock.write_lock
+    with acquire():
+        assert lock._lock_level == 1
+        assert lock._current_mode == mode
+
+        with acquire():
+            assert lock._lock_level == 2
+            assert lock._current_mode == mode
+
+            with acquire():
+                assert lock._lock_level == 3
+                assert lock._current_mode == mode
+
+            assert lock._lock_level == 2
+            assert lock._current_mode == mode
+
+        assert lock._lock_level == 1
+        assert lock._current_mode == mode
+
+    assert lock._lock_level == 0
+    assert lock._current_mode is None
+
+    success_flag.value = 1
+
+
+def acquire_lock_and_crash(lock_file: str, mode: Literal["read", "write"], acquired_event: EventType) -> None:
+    lock = ReadWriteLock(lock_file)
+    with lock.read_lock() if mode == "read" else lock.write_lock():
         acquired_event.set()
         while True:
             time.sleep(0.1)
-
-
-@pytest.mark.timeout(15)
-def test_read_lock_release_on_process_termination(lock_file: str) -> None:
-    """Test that readlocks are properly released if a process terminates."""
-    lock_acquired = Event()
-
-    crashing = Process(target=acquire_read_lock_and_crash, args=(lock_file, lock_acquired))
-    crashing.start()
-
-    assert lock_acquired.wait(timeout=2), "Lock not acquired by first process"
-
-    write_acquired = Event()
-    successor = Process(target=acquire_lock, args=(lock_file, "write", write_acquired))
-
-    with cleanup_processes([crashing, successor]):
-        time.sleep(0.5)  # ensure lock is fully acquired before terminating
-        crashing.terminate()
-        crashing.join(timeout=2)
-
-        successor.start()
-
-        assert write_acquired.wait(timeout=5), "Lock not acquired after process termination"
-
-        successor.join(timeout=2)
-        assert not successor.is_alive(), "Successor did not exit cleanly"
-
-
-@pytest.mark.timeout(15)
-def test_single_read_lock_acquire_release(lock_file: str) -> None:
-    """Test that a single read lock can be acquired and released."""
-    lock = ReadWriteLock(lock_file)
-
-    with lock.read_lock(), lock.read_lock():
-        pass
-
-    with lock.read_lock():
-        pass
-
-
-@pytest.mark.timeout(15)
-def test_single_write_lock_acquire_release(lock_file: str) -> None:
-    """Test that a single write lock can be acquired and released."""
-    lock = ReadWriteLock(lock_file)
-
-    with lock.write_lock(), lock.write_lock():
-        pass
-
-    with lock.write_lock():
-        pass
-
-
-@pytest.mark.timeout(15)
-def test_read_then_write_lock(lock_file: str) -> None:
-    """Test that we can acquire a read lock and then a write lock after releasing it."""
-    lock = ReadWriteLock(lock_file)
-
-    with lock.read_lock():
-        pass
-
-    with lock.write_lock():
-        pass
-
-
-@pytest.mark.timeout(15)
-def test_write_then_read_lock(lock_file: str) -> None:
-    """Test that we can acquire a write lock and then a read lock after releasing it."""
-    lock = ReadWriteLock(lock_file)
-
-    with lock.write_lock():
-        pass
-
-    with lock.read_lock():
-        pass

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -204,8 +204,7 @@ def test_release_force_resets_level(lock_file: str) -> None:
 )
 def test_lock_context_manager(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock = ReadWriteLock(lock_file, is_singleton=False)
-    ctx = lock.read_lock() if mode == "read" else lock.write_lock()
-    with ctx:
+    with lock.read_lock() if mode == "read" else lock.write_lock():
         assert lock._lock_level == 1
         assert lock._current_mode == mode
     assert lock._lock_level == 0
@@ -221,8 +220,7 @@ def test_lock_context_manager(lock_file: str, mode: Literal["read", "write"]) ->
 )
 def test_lock_uses_instance_defaults(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock = ReadWriteLock(lock_file, timeout=3.0, blocking=True, is_singleton=False)
-    ctx = lock.read_lock() if mode == "read" else lock.write_lock()
-    with ctx:
+    with lock.read_lock() if mode == "read" else lock.write_lock():
         assert lock._current_mode == mode
 
 
@@ -284,11 +282,9 @@ def test_write_lock_reentrant_from_different_thread_prohibited(lock_file: str) -
 )
 def test_sequential_mode_switch(lock_file: str, first: str, second: str) -> None:
     lock = ReadWriteLock(lock_file, is_singleton=False)
-    first_ctx = lock.read_lock() if first == "read" else lock.write_lock()
-    second_ctx = lock.read_lock() if second == "read" else lock.write_lock()
-    with first_ctx:
+    with lock.read_lock() if first == "read" else lock.write_lock():
         pass
-    with second_ctx:
+    with lock.read_lock() if second == "read" else lock.write_lock():
         pass
 
 
@@ -386,9 +382,8 @@ def test_non_blocking_transaction_lock_timeout(lock_file: str, mode: Literal["re
     lock = ReadWriteLock(lock_file, is_singleton=False)
     lock._transaction_lock.acquire()
     try:
-        acquire = lock.acquire_read if mode == "read" else lock.acquire_write
         with pytest.raises(Timeout):
-            acquire(blocking=False)
+            (lock.acquire_read if mode == "read" else lock.acquire_write)(blocking=False)
     finally:
         lock._transaction_lock.release()
 
@@ -404,9 +399,8 @@ def test_non_blocking_with_timeout_no_value_error(lock_file: str, mode: Literal[
     lock = ReadWriteLock(lock_file, is_singleton=False)
     lock._transaction_lock.acquire()
     try:
-        acquire = lock.acquire_read if mode == "read" else lock.acquire_write
         with pytest.raises(Timeout):
-            acquire(blocking=False, timeout=5.0)
+            (lock.acquire_read if mode == "read" else lock.acquire_write)(blocking=False, timeout=5.0)
     finally:
         lock._transaction_lock.release()
 
@@ -422,9 +416,8 @@ def test_finite_timeout_transaction_lock(lock_file: str, mode: Literal["read", "
     lock = ReadWriteLock(lock_file, is_singleton=False)
     lock._transaction_lock.acquire()
     try:
-        acquire = lock.acquire_read if mode == "read" else lock.acquire_write
         with pytest.raises(Timeout):
-            acquire(timeout=0.1)
+            (lock.acquire_read if mode == "read" else lock.acquire_write)(timeout=0.1)
     finally:
         lock._transaction_lock.release()
 
@@ -499,9 +492,8 @@ def test_double_check_wrong_mode_raises(
     mock_lock.acquire = fake_acquire
     mock_lock.release = real_lock.release
     lock._transaction_lock = mock_lock
-    acquire = lock.acquire_read if acquire_mode == "read" else lock.acquire_write
     with pytest.raises(RuntimeError, match=match):
-        acquire()
+        (lock.acquire_read if acquire_mode == "read" else lock.acquire_write)()
     lock._lock_level = 0
     lock._current_mode = None
 
@@ -531,9 +523,8 @@ def test_operational_error_handling(
     con_mock = mocker.MagicMock()
     con_mock.execute.side_effect = sqlite3.OperationalError(error_msg)
     lock._con = con_mock
-    acquire = lock.acquire_read if mode == "read" else lock.acquire_write
     with pytest.raises(expected_exception):
-        acquire()
+        (lock.acquire_read if mode == "read" else lock.acquire_write)()
 
 
 def test_write_lock_context_manager_overrides_defaults(lock_file: str) -> None:
@@ -555,8 +546,7 @@ def test_busy_timeout_recomputed_after_journal_mode(
     counter = iter([0.0, 0.0, 0.5])
     mocker.patch("filelock._read_write.time.perf_counter", side_effect=counter)
     lock = ReadWriteLock(lock_file, is_singleton=False)
-    acquire = lock.acquire_read if mode == "read" else lock.acquire_write
-    acquire(timeout=2.0)
+    (lock.acquire_read if mode == "read" else lock.acquire_write)(timeout=2.0)
     lock.release()
 
 
@@ -657,7 +647,7 @@ def test_read_acquire_rolls_back_begin_when_select_loses_lock_race(lock_file: st
 
 
 def test_failed_reentrant_double_check_keeps_a_concurrent_holders_lock(lock_file: str) -> None:
-    # The acquire-failure handler must not roll back on a reentrant-validation RuntimeError: a writer that reaches
+    # The acquire-failure handler must not roll back on a reentrant-validation RuntimeError. A writer that reaches
     # _do_acquire_inner's double-check after a reader took the lock would otherwise roll back the reader's still-open
     # transaction on the shared connection, dropping a lock the reader believes it holds. Force that interleaving.
     lock = ReadWriteLock(lock_file, is_singleton=False)
@@ -670,7 +660,7 @@ def test_failed_reentrant_double_check_keeps_a_concurrent_holders_lock(lock_file
     def gated(*, blocking: bool, timeout: float) -> None:
         if threading.get_ident() == writer_tid.get("id"):  # writer has passed its early check at lock_level == 0
             writer_at_gate.set()
-            reader_acquired.wait(5)  # let the reader fully acquire (and open its transaction) first
+            reader_acquired.wait(5)  # let the reader acquire (and open its transaction) first
         real_acquire_tx(blocking=blocking, timeout=timeout)
 
     def acquire_write_in_thread() -> None:
@@ -688,7 +678,7 @@ def test_failed_reentrant_double_check_keeps_a_concurrent_holders_lock(lock_file
     reader_acquired.set()
     thread.join(5)
 
-    assert "writer" in errors  # the upgrade was rejected with RuntimeError, as expected
+    assert "writer" in errors  # writer's upgrade rejected with RuntimeError
     assert lock._con.in_transaction is True  # the reader's transaction survived the writer's failure
     assert lock._lock_level == 1
     assert lock._current_mode == "read"

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -5,7 +5,7 @@ import socket
 import sys
 from errno import ENODEV, EPERM
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -17,11 +17,13 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-unix_only = pytest.mark.skipif(sys.platform == "win32", reason="unix-only stale lock detection")
-win_only = pytest.mark.skipif(sys.platform != "win32", reason="windows-only")
+_UNIX_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    sys.platform == "win32", reason="unix-only stale lock detection"
+)
+_WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != "win32", reason="windows-only")
 
-HOST = socket.gethostname()
-DEAD_PID = 2**22 + 1
+_HOST: Final[str] = socket.gethostname()
+_DEAD_PID: Final[int] = 2**22 + 1
 
 
 @pytest.fixture
@@ -29,41 +31,26 @@ def lock_path(tmp_path: Path) -> Path:
     return tmp_path / "test.lock"
 
 
-def _holder(pid: int, *, host: str = HOST, creation_time: int | None = None) -> str:
-    lines = [str(pid), host, *([] if creation_time is None else [str(creation_time)])]
-    return "\n".join(lines) + "\n"
-
-
-def _assert_self_heals(lock_path: Path) -> None:
-    lock = SoftFileLock(lock_path, timeout=1)
-    with lock:
-        assert lock.is_locked
-
-
-def _assert_times_out(lock_path: Path) -> None:
-    lock = SoftFileLock(lock_path, timeout=0.1)
-    with pytest.raises(TimeoutError):
-        lock.acquire()
+def _holder(pid: int, *, host: str = _HOST, creation_time: int | None = None) -> str:
+    return "\n".join([str(pid), host, *([] if creation_time is None else [str(creation_time)])]) + "\n"
 
 
 def test_lock_writes_pid_and_hostname(lock_path: Path) -> None:
-    lock = SoftFileLock(lock_path)
-    with lock:
+    with SoftFileLock(lock_path):
         lines = lock_path.read_text(encoding="utf-8").strip().splitlines()
-        assert lines[0] == str(os.getpid())
-        assert lines[1] == HOST
         if sys.platform == "win32":
+            assert lines[:2] == [str(os.getpid()), _HOST]
             assert len(lines) == 3
-            int(lines[2])  # must be parseable as int (creation FILETIME)
+            int(lines[2])  # creation FILETIME must parse as int
         else:
-            assert len(lines) == 2
+            assert lines == [str(os.getpid()), _HOST]
 
 
 @pytest.mark.parametrize(
     "content",
     [
-        pytest.param(_holder(DEAD_PID), id="two_line"),
-        pytest.param(_holder(DEAD_PID, creation_time=123456789), id="three_line"),
+        pytest.param(_holder(_DEAD_PID), id="two_line"),
+        pytest.param(_holder(_DEAD_PID, creation_time=123456789), id="three_line"),
     ],
 )
 def test_stale_lock_broken_when_process_dead(lock_path: Path, mocker: MockerFixture, content: str) -> None:
@@ -79,11 +66,11 @@ def test_stale_lock_not_broken_when_process_alive(lock_path: Path, mocker: Mocke
 
 
 def test_stale_lock_not_broken_different_hostname(lock_path: Path) -> None:
-    lock_path.write_text(_holder(DEAD_PID, host="other-host.example.com"), encoding="utf-8")
+    lock_path.write_text(_holder(_DEAD_PID, host="other-host.example.com"), encoding="utf-8")
     _assert_times_out(lock_path)
 
 
-@unix_only
+@_UNIX_ONLY
 @pytest.mark.parametrize(
     "errno",
     [pytest.param(EPERM, id="eperm"), pytest.param(ENODEV, id="unexpected_device")],
@@ -101,14 +88,14 @@ def test_stale_lock_not_broken_on_kill_error(lock_path: Path, mocker: MockerFixt
         pytest.param(b"", id="empty"),
         pytest.param(b"x" * (_MAX_LOCK_FILE_SIZE + 1), id="oversized"),
         pytest.param(b"not-a-pid\nhostname\n", id="two_line_bad_pid"),
-        pytest.param(f"{DEAD_PID}\nhostname\nnot-a-time\n".encode(), id="three_line_bad_creation_time"),
+        pytest.param(f"{_DEAD_PID}\nhostname\nnot-a-time\n".encode(), id="three_line_bad_creation_time"),
     ],
 )
 def test_unparseable_lock_evicted_when_old(lock_path: Path, content: bytes) -> None:
     lock_path.write_bytes(content)
     os.utime(lock_path, (0, 0))
-    # An unreadable lock (wrong line count, non-integer pid/creation time, empty, or oversized) must self-heal
-    # rather than stay stuck forever; line count alone is not enough to call a file well-formed.
+    # An unreadable lock (bad line count, non-integer pid/creation time, empty, or oversized) must self-heal
+    # instead of staying stuck; a matching line count alone does not make a file well-formed.
     _assert_self_heals(lock_path)
 
 
@@ -136,27 +123,27 @@ def test_unparseable_lock_not_evicted_when_fresh(lock_path: Path, content: bytes
 def test_out_of_range_pid_self_heals_when_old(lock_path: Path, pid: int) -> None:
     lock_path.write_text(_holder(pid), encoding="utf-8")
     os.utime(lock_path, (0, 0))
-    # A pid of 0 or -1 makes os.kill() probe the caller's own process group (read as alive) so the lock is
-    # never reclaimed, and an oversized pid raises OverflowError out of stale detection. Such a holder is
-    # malformed and must self-heal like any other unparsable one, matching what _parse_marker_bytes rejects.
+    # pid 0 or -1 makes os.kill probe the caller's own process group (reads as alive), so the lock is never
+    # reclaimed; an oversized pid raises OverflowError out of stale detection. Both are malformed and must
+    # self-heal, matching what _parse_marker_bytes rejects.
     _assert_self_heals(lock_path)
 
 
 def test_out_of_range_pid_not_evicted_when_fresh(lock_path: Path) -> None:
     lock_path.write_text(_holder(0), encoding="utf-8")
     # A fresh out-of-range pid is malformed too, but like any malformed lock it is left alone until it ages
-    # past the threshold, so a peer mid-write is never mistaken for a stale lock.
+    # past the threshold, so a peer mid-write is not mistaken for a stale lock.
     _assert_times_out(lock_path)
 
 
 def test_stale_lock_rename_race(lock_path: Path, mocker: MockerFixture) -> None:
-    lock_path.write_text(_holder(DEAD_PID), encoding="utf-8")
+    lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
     mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=False)
     mocker.patch.object(Path, "rename", side_effect=FileNotFoundError("already gone"))
     _assert_times_out(lock_path)
 
 
-@unix_only
+@_UNIX_ONLY
 def test_symlinked_lock_file_is_not_followed(tmp_path: Path, lock_path: Path) -> None:
     target = tmp_path / "target"
     target.write_text(_holder(99999), encoding="utf-8")
@@ -182,7 +169,7 @@ def test_stale_detection_errors_suppressed(lock_path: Path, mocker: MockerFixtur
     mock_read.assert_called()
 
 
-@win_only
+@_WINDOWS_ONLY
 def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path, mocker: MockerFixture) -> None:
     lock_path.write_text(_holder(1234, creation_time=100000000), encoding="utf-8")
     mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
@@ -190,7 +177,7 @@ def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path, mocker: Mo
     _assert_self_heals(lock_path)
 
 
-@win_only
+@_WINDOWS_ONLY
 def test_windows_stale_lock_not_broken_same_creation_time(lock_path: Path, mocker: MockerFixture) -> None:
     creation_time = 100000000
     lock_path.write_text(_holder(1234, creation_time=creation_time), encoding="utf-8")
@@ -199,14 +186,14 @@ def test_windows_stale_lock_not_broken_same_creation_time(lock_path: Path, mocke
     _assert_times_out(lock_path)
 
 
-@win_only
+@_WINDOWS_ONLY
 def test_windows_stale_lock_conservative_without_creation_time(lock_path: Path, mocker: MockerFixture) -> None:
     lock_path.write_text(_holder(1234), encoding="utf-8")
     mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
     _assert_times_out(lock_path)
 
 
-@win_only
+@_WINDOWS_ONLY
 def test_get_process_creation_time_returns_int_on_windows() -> None:
     result = SoftFileLock._get_process_creation_time(os.getpid())
     assert result is not None
@@ -214,12 +201,12 @@ def test_get_process_creation_time_returns_int_on_windows() -> None:
     assert result > 0
 
 
-@win_only
+@_WINDOWS_ONLY
 def test_get_process_creation_time_returns_none_for_dead_pid() -> None:
-    assert SoftFileLock._get_process_creation_time(DEAD_PID) is None
+    assert SoftFileLock._get_process_creation_time(_DEAD_PID) is None
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="unix-only")
+@_UNIX_ONLY
 def test_get_process_creation_time_returns_none_on_unix() -> None:
     assert SoftFileLock._get_process_creation_time(os.getpid()) is None
 
@@ -281,3 +268,14 @@ def test_write_lock_info_errors_suppressed(lock_path: Path, mocker: MockerFixtur
     with lock:
         assert lock.is_locked
         assert not lock_path.read_text(encoding="utf-8")
+
+
+def _assert_self_heals(lock_path: Path) -> None:
+    lock = SoftFileLock(lock_path, timeout=1)
+    with lock:
+        assert lock.is_locked
+
+
+def _assert_times_out(lock_path: Path) -> None:
+    with pytest.raises(TimeoutError):
+        SoftFileLock(lock_path, timeout=0.1).acquire()

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -4,7 +4,7 @@ import os
 import socket
 import sys
 from errno import EIO, ENOSYS
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -16,14 +16,12 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-unix_only = pytest.mark.skipif(sys.platform == "win32", reason="unix-only flock fallback")
-_ENOSYS_SIDE_EFFECT = OSError(ENOSYS, "Function not implemented")
-_FLOCK_PATCH_TARGET = "filelock._unix.fcntl.flock"
+_UNIX_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform == "win32", reason="unix-only flock fallback")
 
 
-@unix_only
-def test_fallback_emits_warning(tmp_path: Path, mocker: MockerFixture) -> None:
-    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+@_UNIX_ONLY
+@pytest.mark.usefixtures("unsupported_flock")
+def test_fallback_emits_warning(tmp_path: Path) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
 
     with pytest.warns(UserWarning, match="flock not supported on this filesystem, falling back to SoftFileLock"):
@@ -31,10 +29,10 @@ def test_fallback_emits_warning(tmp_path: Path, mocker: MockerFixture) -> None:
     lock.release()
 
 
-@unix_only
+@_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
-def test_fallback_swaps_to_soft(tmp_path: Path, mocker: MockerFixture) -> None:
-    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+@pytest.mark.usefixtures("unsupported_flock")
+def test_fallback_swaps_to_soft(tmp_path: Path) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
 
     with lock:
@@ -42,23 +40,21 @@ def test_fallback_swaps_to_soft(tmp_path: Path, mocker: MockerFixture) -> None:
         assert isinstance(lock, SoftFileLock)
 
 
-@unix_only
+@_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
-def test_fallback_writes_pid_and_hostname(tmp_path: Path, mocker: MockerFixture) -> None:
+@pytest.mark.usefixtures("unsupported_flock")
+def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
-    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
-    lock = UnixFileLock(lock_path)
 
-    with lock:
-        content = lock_path.read_text(encoding="utf-8")
-        assert content == f"{os.getpid()}\n{socket.gethostname()}\n"
+    with UnixFileLock(lock_path):
+        assert lock_path.read_text(encoding="utf-8") == f"{os.getpid()}\n{socket.gethostname()}\n"
 
 
-@unix_only
+@_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
-def test_fallback_release_unlinks_file(tmp_path: Path, mocker: MockerFixture) -> None:
+@pytest.mark.usefixtures("unsupported_flock")
+def test_fallback_release_unlinks_file(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
-    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
     lock = UnixFileLock(lock_path)
 
     lock.acquire()
@@ -67,25 +63,24 @@ def test_fallback_release_unlinks_file(tmp_path: Path, mocker: MockerFixture) ->
     assert not lock_path.exists()
 
 
-@unix_only
+@_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
-def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, mocker: MockerFixture) -> None:
-    flock_mock: MagicMock = mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, unsupported_flock: MagicMock) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
 
     lock.acquire()
     lock.release()
-    flock_mock.reset_mock()
+    unsupported_flock.reset_mock()
 
     lock.acquire()
     lock.release()
-    flock_mock.assert_not_called()
+    unsupported_flock.assert_not_called()
 
 
-@unix_only
+@_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
-def test_fallback_reentrant_locking(tmp_path: Path, mocker: MockerFixture) -> None:
-    mocker.patch(_FLOCK_PATCH_TARGET, side_effect=_ENOSYS_SIDE_EFFECT)
+@pytest.mark.usefixtures("unsupported_flock")
+def test_fallback_reentrant_locking(tmp_path: Path) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
 
     with lock:
@@ -95,13 +90,13 @@ def test_fallback_reentrant_locking(tmp_path: Path, mocker: MockerFixture) -> No
     assert not lock.is_locked
 
 
-@unix_only
+@_UNIX_ONLY
 def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
     lock.acquire()
 
-    real_close = os.close
-    fd_to_fail = lock._context.lock_file_fd
+    real_close = os.close  # capture before the patch so the fd still closes for real
+    fd_to_fail = lock._context.lock_file_fd  # _release() nulls this before closing, so read it now
 
     def _close_eio(fd: int) -> None:
         real_close(fd)
@@ -111,3 +106,8 @@ def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) 
     mocker.patch("filelock._unix.os.close", side_effect=_close_eio)
     lock.release()
     assert not lock.is_locked
+
+
+@pytest.fixture
+def unsupported_flock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "Function not implemented"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import stat
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -13,6 +13,11 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pytest_mock import MockerFixture
+
+_SKIP_AS_ROOT: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    sys.platform != "win32" and os.geteuid() == 0,
+    reason="root can write a 0o444 file",
+)
 
 
 def test_break_lock_file_unlinks_unchanged_file(tmp_path: Path) -> None:
@@ -27,8 +32,8 @@ def test_break_lock_file_unlinks_unchanged_file(tmp_path: Path) -> None:
 def test_break_lock_file_preserves_file_when_mtime_advanced(tmp_path: Path) -> None:
     lock = tmp_path / "test.lock"
     lock.write_text("live", encoding="utf-8")
-    # A mtime_before older than the file's real mtime models a peer recreating the lock after our stale read: the
-    # live file is renamed aside but must not be unlinked, so the holder's content survives instead of two holders.
+    # An mtime_before older than the file's real mtime models a peer recreating the lock after our stale read.
+    # break_lock_file renames the live file aside but must not unlink it, so we never end with two live holders.
     break_lock_file(str(lock), mtime_before=0.0, ino_before=os.lstat(lock).st_ino)
     assert not lock.exists()
     leftover = list(tmp_path.glob("test.lock.break.*"))
@@ -104,10 +109,7 @@ def test_raise_on_not_writable_file_does_not_follow_symlink_to_dir(tmp_path: Pat
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="symlink + 0o444 semantics differ on Windows")
-@pytest.mark.skipif(
-    sys.platform != "win32" and os.geteuid() == 0,
-    reason="root can write a 0o444 file, so following the symlink would not raise",
-)
+@_SKIP_AS_ROOT
 def test_raise_on_not_writable_file_does_not_follow_symlink_to_readonly(tmp_path: Path) -> None:
     target = tmp_path / "readonly"
     target.write_text("x", encoding="utf-8")
@@ -127,10 +129,7 @@ def test_raise_on_not_writable_file_still_rejects_real_directory(tmp_path: Path)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have read only files in the same way")
-@pytest.mark.skipif(
-    sys.platform != "win32" and os.geteuid() == 0,
-    reason="root can write a 0o444 file",
-)
+@_SKIP_AS_ROOT
 def test_raise_on_not_writable_file_still_rejects_readonly_file(tmp_path: Path) -> None:
     path = tmp_path / "ro.lock"
     path.write_text("x", encoding="utf-8")


### PR DESCRIPTION
A readability pass over the whole repository, with no behavior change. Module-scope constants are typed `Final`, comments that only restate the code they annotate are removed, single-use locals are inlined, helpers are ordered below their callers, and a dead branch in the Windows reparse check (every arm returned `False` regardless of the error code) is collapsed. The same tightening is applied to the tests and docs.

This lands first so the open fix PRs (#593, #594, #595, #596) can rebase onto a clean baseline instead of each carrying incidental cleanup. Every change is covered by the existing suite, which stays green.
