### PR TITLE
Fix singleton lookup for equivalent lock paths

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -82,15 +82,17 @@ class FileLockMeta(ABCMeta):
         if not is_singleton:
             return cls._create_instance(lock_file, params)
 
+        cache_key = _canonical(os.fspath(lock_file))
+
         # Look up, build and store under one lock. Without it two threads racing the first construction for a
         # path both miss the cache and each build their own instance, so callers relying on is_singleton for
         # reentrant locking across instances end up with two "singletons" and acquire()'s deadlock check then
         # rejects a legitimate reentrant acquire; the unguarded writes to the WeakValueDictionary are a data
         # race besides. ReadWriteLock and SoftReadWriteLock already guard their singleton caches this way.
         with cls._instances_lock:
-            if (instance := cls._instances.get(str(lock_file))) is None:
+            if (instance := cls._instances.get(cache_key)) is None:
                 instance = cls._create_instance(lock_file, params)
-                cls._instances[str(lock_file)] = instance
+                cls._instances[cache_key] = instance
                 return instance
 
         params_to_check = {

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -791,6 +791,17 @@ def test_singleton_locks_are_the_same(lock_type: type[BaseFileLock], tmp_path: P
     assert lock_2 is lock_1
 
 
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_singleton_locks_are_the_same_for_equivalent_paths(
+    lock_type: type[BaseFileLock], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    lock_1 = lock_type("a", is_singleton=True)
+
+    lock_2 = lock_type(tmp_path / "a", is_singleton=True)
+    assert lock_2 is lock_1
+
+
 def test_singleton_locks_survive_concurrent_first_construction(tmp_path: Path) -> None:
     # Two threads constructing the same is_singleton=True lock at once must still share one instance. A slow
     # __init__ widens the window between the cache miss and the store so the race is hit deterministically.


### PR DESCRIPTION
Singleton locks were cached by the exact path spelling, so relative and absolute paths to the same file created separate instances and a nested acquire raised a deadlock error despite `is_singleton=True`.

Canonicalizing the cache key makes equivalent paths share the promised singleton. The regression test fails for both UnixFileLock and SoftFileLock without the fix and passes with it.
