### PR TITLE
fail closed when a soft lock's holder record is only partially written

### DIFF
--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Final
 
 from ._api import BaseFileLock
-from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file
+from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file, write_all
 
 _WIN_SYNCHRONIZE: Final[int] = 0x100000
 _WIN_ERROR_INVALID_PARAMETER: Final[int] = 87
@@ -54,7 +54,17 @@ class SoftFileLock(BaseFileLock):
                 raise
             self._try_break_stale_lock()
         else:
-            self._write_lock_info(file_handler)
+            try:
+                self._write_lock_info(file_handler)
+            except OSError:
+                # Fail closed: a lock file without a complete pid/hostname record parses as malformed, and once
+                # it ages past the grace threshold a contender breaks it and acquires a fresh inode while we still
+                # hold this descriptor, so both processes own the lock. Drop the half-written file (it is ours, just
+                # created under O_EXCL) and let the poll loop retry rather than publish a reclaimable live lock.
+                os.close(file_handler)
+                with suppress(OSError):
+                    Path(self.lock_file).unlink()
+                return
             self._context.lock_file_fd = file_handler
 
     def _try_break_stale_lock(self) -> None:
@@ -136,11 +146,10 @@ class SoftFileLock(BaseFileLock):
 
     @staticmethod
     def _write_lock_info(fd: int) -> None:
-        with suppress(OSError):
-            info = f"{os.getpid()}\n{socket.gethostname()}\n"
-            if sys.platform == "win32" and (ct := SoftFileLock._get_process_creation_time(os.getpid())) is not None:
-                info += f"{ct}\n"
-            os.write(fd, info.encode())
+        info = f"{os.getpid()}\n{socket.gethostname()}\n"
+        if sys.platform == "win32" and (ct := SoftFileLock._get_process_creation_time(os.getpid())) is not None:
+            info += f"{ct}\n"
+        write_all(fd, info.encode())
 
     @property
     def pid(self) -> int | None:

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -22,7 +22,7 @@ from weakref import WeakValueDictionary
 from filelock._api import AcquireReturnProxy
 from filelock._error import Timeout
 from filelock._soft import SoftFileLock
-from filelock._util import ensure_directory_exists
+from filelock._util import ensure_directory_exists, write_all
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -837,7 +837,14 @@ def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -
     else:
         fd = os.open(name, flags, 0o600)
     try:
-        os.write(fd, f"{token}\n{os.getpid()}\n{socket.gethostname()}\n".encode("ascii"))
+        # Write the whole token/pid/hostname payload or none of it: a marker missing part of its payload parses as
+        # malformed, so the holder's own heartbeat stops refreshing it and a peer breaks it as stale while the caller
+        # still records the hold, admitting a second holder. On a partial write remove the marker and fail the claim.
+        try:
+            write_all(fd, f"{token}\n{os.getpid()}\n{socket.gethostname()}\n".encode("ascii"))
+        except OSError:
+            _unlink(name, dir_fd=dir_fd)
+            raise
     finally:
         os.close(fd)
 

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -50,6 +50,31 @@ def ensure_directory_exists(filename: Path | str) -> None:
     Path(filename).parent.mkdir(parents=True, exist_ok=True)
 
 
+def write_all(fd: int, data: bytes) -> None:
+    """
+    Write every byte of *data* to *fd*, looping over short writes.
+
+    ``os.write`` may write fewer bytes than requested, and a lock file or marker left with a partial holder record
+    parses as malformed. A peer then reclaims it after the malformed-lock grace period while this process still holds
+    the descriptor, so both own the same logical lock. The published record is coordination state, not diagnostics, so
+    it has to be written in full or not published at all.
+
+    :param fd: file descriptor to write to.
+    :param data: bytes to write in their entirety.
+
+    :raises OSError: if the underlying write fails before all bytes are written.
+
+    """
+    view = memoryview(data)
+    written = 0
+    while written < len(view):
+        count = os.write(fd, view[written:])
+        if count == 0:  # pragma: no cover - a blocking regular-file write never reports 0 for a non-empty buffer
+            msg = "wrote 0 bytes to the lock file"
+            raise OSError(msg)
+        written += count
+
+
 def break_lock_file(lock_file: str, mtime_before: float, ino_before: int) -> None:
     """
     Atomically break a stale lock file judged stale at modification time *mtime_before*.
@@ -92,4 +117,5 @@ __all__ = [
     "break_lock_file",
     "ensure_directory_exists",
     "raise_on_not_writable_file",
+    "write_all",
 ]

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -669,6 +669,22 @@ def test_stale_malformed_marker_is_evicted(lock_file: str, content: bytes) -> No
         lock.close()
 
 
+def test_reader_marker_write_failure_fails_closed(lock_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A marker whose payload cannot be written in full must not be published as a hold: it parses as malformed,
+    # the holder's heartbeat stops, and a peer breaks it as stale while this object still records the read lock.
+    # A persistent write failure therefore fails the acquire and leaves no marker behind in the readers dir.
+    monkeypatch.setattr(sync_mod, "write_all", lambda *_: (_ for _ in ()).throw(OSError("write failed")))
+    lock = _make_lock(lock_file)
+    try:
+        with pytest.raises((OSError, Timeout)):
+            lock.acquire_read(timeout=0.5)
+        readers = Path(f"{lock_file}.readers")
+        live = [e.name for e in os.scandir(readers) if not sync_mod._is_housekeeping_name(e.name)]
+        assert live == []
+    finally:
+        lock.close()
+
+
 def test_fifo_write_marker_does_not_block(lock_file: str) -> None:
     if sys.platform == "win32":
         pytest.skip("os.mkfifo is unix-only")  # also narrows sys.platform so ty resolves os.mkfifo below

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -295,13 +295,38 @@ def test_break_lock(lock_path: Path, *, exists: bool) -> None:
     assert not lock_path.exists()
 
 
-def test_write_lock_info_errors_suppressed(lock_path: Path, mocker: MockerFixture) -> None:
+def test_write_lock_info_failure_fails_closed(lock_path: Path, mocker: MockerFixture) -> None:
+    # A holder record that cannot be written in full must not be published as a held lock: an empty/partial
+    # file parses as malformed and a contender reclaims it after the grace period while this object still owns
+    # the descriptor, so both hold the lock. A persistent write error therefore times out instead of acquiring.
     mocker.patch("filelock._soft.os.write", side_effect=OSError("write failed"))
 
-    lock = SoftFileLock(lock_path)
+    lock = SoftFileLock(lock_path, timeout=0.3)
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+    assert not lock.is_locked
+    assert not lock_path.exists()
+
+
+def test_write_lock_info_short_write_completes(lock_path: Path, mocker: MockerFixture) -> None:
+    # A short os.write (fewer bytes than requested) must be retried until the whole record lands, not left partial.
+    real_write = os.write
+    calls = {"n": 0}
+
+    def short_once(fd: int, data: bytes) -> int:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real_write(fd, data[:1])
+        return real_write(fd, data)
+
+    mocker.patch("filelock._soft.os.write", side_effect=short_once)
+
+    lock = SoftFileLock(lock_path, timeout=1)
     with lock:
         assert lock.is_locked
-        assert not lock_path.read_text(encoding="utf-8")
+        # The full record landed despite the short first write, so it parses back to this process.
+        assert lock.pid == os.getpid()
+        assert lock_path.read_text(encoding="utf-8").startswith(f"{os.getpid()}\n{_HOST}\n")
 
 
 def _assert_self_heals(lock_path: Path) -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Final
 
 import pytest
 
-from filelock._util import break_lock_file, raise_on_not_writable_file
+from filelock._util import break_lock_file, raise_on_not_writable_file, write_all
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -18,6 +18,34 @@ _SKIP_AS_ROOT: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     sys.platform != "win32" and os.geteuid() == 0,
     reason="root can write a 0o444 file",
 )
+
+
+def test_write_all_writes_full_payload_over_short_writes(tmp_path: Path, mocker: MockerFixture) -> None:
+    path = tmp_path / "data"
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT, 0o600)
+    payload = b"1234\nsome-host\n"
+    real_write = os.write
+
+    def short_once(actual_fd: int, data: bytes) -> int:
+        # first write lands a single byte; write_all must loop to finish the rest
+        return real_write(actual_fd, data[:1] if actual_fd == fd else data)
+
+    mocker.patch("filelock._util.os.write", side_effect=short_once)
+    try:
+        write_all(fd, payload)
+    finally:
+        os.close(fd)
+    assert path.read_bytes() == payload
+
+
+def test_write_all_propagates_write_error(tmp_path: Path, mocker: MockerFixture) -> None:
+    fd = os.open(tmp_path / "data", os.O_WRONLY | os.O_CREAT, 0o600)
+    mocker.patch("filelock._util.os.write", side_effect=OSError("boom"))
+    try:
+        with pytest.raises(OSError, match="boom"):
+            write_all(fd, b"payload")
+    finally:
+        os.close(fd)
 
 
 def test_break_lock_file_unlinks_unchanged_file(tmp_path: Path) -> None:


### PR DESCRIPTION
SoftFileLock._write_lock_info suppressed write errors, and neither it nor the read/write lock's _atomic_create_marker checked the byte count os.write returns, so a failed or short write leaves the pid/hostname record (or the token/pid/hostname marker) empty or truncated while acquire still records the descriptor as held. That published file parses back as malformed rather than a live holder, so once it ages past the malformed-lock grace threshold a contender breaks it and takes a fresh inode while the original object still owns its descriptor, and you end up with two overlapping holders on the same logical lock; for SoftReadWriteLock the holder's own heartbeat also cannot parse its marker and quietly stops. I reproduced both with fault injection on os.write on macos, closing issues #601 and #602. The holder record is coordination state rather than diagnostics, so the fix writes it in full or not at all: a small write_all helper loops over short writes and raises on error, SoftFileLock drops its just-created O_EXCL file and lets the poll loop retry, and _atomic_create_marker unlinks the partial marker and fails the claim.