### PR TITLE
fix(windows): propagate lock file open denials

### DIFF
--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -39,20 +39,15 @@ if sys.platform == "win32":  # pragma: win32 cover
                 msg = f"Lock file is a reparse point (symlink/junction): {self.lock_file}"
                 raise OSError(msg)
 
+            fd = os.open(self.lock_file, os.O_RDWR | os.O_CREAT, self._open_mode())
             try:
-                fd = os.open(self.lock_file, os.O_RDWR | os.O_CREAT, self._open_mode())
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
             except OSError as exception:
-                if exception.errno != EACCES:
+                os.close(fd)
+                if exception.errno != EACCES:  # EACCES means another holder owns the byte-range lock
                     raise
             else:
-                try:
-                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-                except OSError as exception:
-                    os.close(fd)
-                    if exception.errno != EACCES:  # EACCES means another holder owns the byte-range lock
-                        raise
-                else:
-                    self._context.lock_file_fd = fd
+                self._context.lock_file_fd = fd
 
         def _release(self) -> None:
             fd = cast("int", self._context.lock_file_fd)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import ctypes
+import importlib
+import sys
+from errno import EACCES
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+def test_open_permission_error_is_not_reported_as_contention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """A permanent descriptor-open denial must escape before the polling loop."""
+    import filelock._windows as windows_module
+
+    fake_kernel32 = mocker.Mock()
+    fake_kernel32.GetFileAttributesW = mocker.Mock(return_value=0xFFFFFFFF)
+    fake_msvcrt = mocker.Mock()
+    fake_msvcrt.LK_NBLCK = 1
+    fake_msvcrt.LK_UNLCK = 0
+    fake_msvcrt.locking = mocker.Mock()
+
+    original_platform = sys.platform
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(ctypes, "WinDLL", mocker.Mock(return_value=fake_kernel32), raising=False)
+
+    try:
+        windows_module = importlib.reload(windows_module)
+        lock_path = tmp_path / "denied.lock"
+        denial = PermissionError(EACCES, "access denied", str(lock_path))
+        mocker.patch.object(windows_module.os, "open", side_effect=denial)
+
+        lock = windows_module.WindowsFileLock(lock_path, timeout=0)
+        with pytest.raises(PermissionError) as raised:
+            lock.acquire()
+
+        assert raised.value is denial
+        fake_msvcrt.locking.assert_not_called()
+    finally:
+        monkeypatch.setattr(sys, "platform", original_platform)
+        importlib.reload(windows_module)


### PR DESCRIPTION
## Summary

- propagate permanent `os.open()` permission failures from `WindowsFileLock`
- keep treating `EACCES` from `msvcrt.locking()` as byte-range lock contention
- add a platform-simulated regression test that exercises the Windows backend on any CI host

Fixes #604.

## Testing

- `pytest -q tests/test_windows.py` — 1 passed
- `pytest -q tests/test_windows.py tests/test_filelock.py` — 145 passed, 20 skipped before a formatter-only change
- changed-file Ruff lint and format checks pass
