### PR TITLE
🐛 fix(soft): make marker writes and cleanup transactional

### DIFF
--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -11,13 +11,14 @@ from pathlib import Path
 from typing import Final
 
 from ._api import BaseFileLock
-from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file
+from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file, write_all
 
 _WIN_SYNCHRONIZE: Final[int] = 0x100000
 _WIN_ERROR_INVALID_PARAMETER: Final[int] = 87
 _WIN_PROCESS_QUERY_LIMITED_INFORMATION: Final[int] = 0x1000
 _MALFORMED_LOCK_AGE_THRESHOLD: Final[float] = 2.0
 _MAX_LOCK_FILE_SIZE: Final[int] = 1024
+_UNLINK_MAX_RETRIES: Final[int] = 10
 
 
 class SoftFileLock(BaseFileLock):
@@ -46,16 +47,31 @@ class SoftFileLock(BaseFileLock):
         if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:
             flags |= o_nofollow
         try:
-            file_handler = os.open(self.lock_file, flags, self._open_mode())
+            fd = os.open(self.lock_file, flags, self._open_mode())
         except OSError as exception:
             if not (
                 exception.errno == EEXIST or (exception.errno == EACCES and sys.platform == "win32")
             ):  # pragma: win32 no cover
                 raise
             self._try_break_stale_lock()
-        else:
-            self._write_lock_info(file_handler)
-            self._context.lock_file_fd = file_handler
+            return
+        self._publish_held_marker(fd)
+
+    def _publish_held_marker(self, fd: int) -> None:
+        # Publish held state only once the record is fully on disk. On any failure, including cancellation, close the
+        # descriptor and unlink the path only while it still names the file we opened, so a rollback never deletes a
+        # successor's marker that replaced ours at the same path after our lease expired.
+        identity: tuple[int, int] | None = None
+        try:
+            identity = _file_identity(os.fstat(fd))
+            self._write_lock_info(fd)
+        except BaseException:
+            os.close(fd)
+            with suppress(OSError):
+                if identity is not None and _file_identity(os.lstat(self.lock_file)) == identity:
+                    Path(self.lock_file).unlink()
+            raise
+        self._context.lock_file_fd = fd
 
     def _try_break_stale_lock(self) -> None:
         with suppress(OSError, ValueError):
@@ -136,11 +152,12 @@ class SoftFileLock(BaseFileLock):
 
     @staticmethod
     def _write_lock_info(fd: int) -> None:
-        with suppress(OSError):
-            info = f"{os.getpid()}\n{socket.gethostname()}\n"
-            if sys.platform == "win32" and (ct := SoftFileLock._get_process_creation_time(os.getpid())) is not None:
-                info += f"{ct}\n"
-            os.write(fd, info.encode())
+        # No suppression: a write failure must reach the acquisition rollback so it never publishes a half-written
+        # marker as held state.
+        info = f"{os.getpid()}\n{socket.gethostname()}\n"
+        if sys.platform == "win32" and (ct := SoftFileLock._get_process_creation_time(os.getpid())) is not None:
+            info += f"{ct}\n"
+        write_all(fd, info.encode())
 
     @property
     def pid(self) -> int | None:
@@ -177,30 +194,48 @@ class SoftFileLock(BaseFileLock):
             Path(self.lock_file).unlink()
 
     def _release(self) -> None:
-        assert self._context.lock_file_fd is not None  # noqa: S101
-        os.close(self._context.lock_file_fd)
+        fd = self._context.lock_file_fd
+        assert fd is not None  # noqa: S101
+        # Capture the held file's identity before closing so cleanup can refuse to unlink a successor's marker. A
+        # supported lifetime lease lets a peer break our expired marker and create its own at this path before we
+        # release; unlinking by path alone would then delete the successor's lock.
+        identity: tuple[int, int] | None = None
+        with suppress(OSError):
+            identity = _file_identity(os.fstat(fd))
+        os.close(fd)
         self._context.lock_file_fd = None
+        if identity is None:
+            return
         if sys.platform == "win32":
-            self._windows_unlink_with_retry()
+            self._windows_unlink_if_ours(identity)
         else:
             with suppress(OSError):
-                Path(self.lock_file).unlink()
+                if _file_identity(os.lstat(self.lock_file)) == identity:
+                    Path(self.lock_file).unlink()
 
-    def _windows_unlink_with_retry(self) -> None:
-        max_retries = 10
+    def _windows_unlink_if_ours(self, identity: tuple[int, int]) -> None:
         retry_delay = 0.001
-        for attempt in range(max_retries):
-            # Windows doesn't immediately release file handles after close, causing EACCES/EPERM on unlink
+        for attempt in range(_UNLINK_MAX_RETRIES):
+            # Windows doesn't immediately release file handles after close, causing EACCES/EPERM on unlink. Recheck
+            # identity each attempt: a failed unlink leaves a window for a successor to replace the marker at this path.
             try:
+                if _file_identity(os.lstat(self.lock_file)) != identity:
+                    return
                 Path(self.lock_file).unlink()
             except OSError as exc:  # noqa: PERF203
                 if exc.errno not in {EACCES, EPERM}:
                     return
-                if attempt < max_retries - 1:
+                if attempt < _UNLINK_MAX_RETRIES - 1:
                     time.sleep(retry_delay)
                     retry_delay *= 2
             else:
                 return
+
+
+def _file_identity(st: os.stat_result) -> tuple[int, int]:
+    # (st_dev, st_ino) names the concrete inode behind a path, so a marker recreated at the same pathname after an
+    # expired lease reads as a different file. CPython populates both on Windows from the volume serial and file index.
+    return st.st_dev, st.st_ino
 
 
 def _read_lock_file(path: str) -> tuple[str | None, float, int]:

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -22,7 +22,7 @@ from weakref import WeakValueDictionary
 from filelock._api import AcquireReturnProxy
 from filelock._error import Timeout
 from filelock._soft import SoftFileLock
-from filelock._util import ensure_directory_exists
+from filelock._util import ensure_directory_exists, write_all
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -836,10 +836,28 @@ def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -
         fd = os.open(name, flags, 0o600, dir_fd=dir_fd)
     else:
         fd = os.open(name, flags, 0o600)
+    # Write the whole record before the marker counts as created. On failure remove it only while the path still names
+    # the file we opened, so a rollback never deletes a marker a concurrent reader recreated at this name.
+    identity: tuple[int, int] | None = None
     try:
-        os.write(fd, f"{token}\n{os.getpid()}\n{socket.gethostname()}\n".encode("ascii"))
-    finally:
+        st = os.fstat(fd)
+        identity = st.st_dev, st.st_ino
+        write_all(fd, f"{token}\n{os.getpid()}\n{socket.gethostname()}\n".encode("ascii"))
+    except BaseException:
         os.close(fd)
+        if identity is not None and _same_file(name, identity, dir_fd=dir_fd):
+            _unlink(name, dir_fd=dir_fd)
+        raise
+    else:
+        os.close(fd)
+
+
+def _same_file(name: str, identity: tuple[int, int], *, dir_fd: int | None) -> bool:
+    try:
+        st = os.lstat(name, dir_fd=dir_fd) if _SUPPORTS_DIR_FD and dir_fd is not None else os.lstat(name)
+    except OSError:
+        return False
+    return (st.st_dev, st.st_ino) == identity
 
 
 def _touch(name: str, *, fd: int | None = None) -> None:

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -4,8 +4,29 @@ import os
 import secrets
 import stat
 import sys
-from errno import EACCES, EISDIR
+from errno import EACCES, EIO, EISDIR
 from pathlib import Path
+
+
+def write_all(fd: int, data: bytes) -> None:
+    """
+    Write the whole buffer to *fd*, looping over the short writes ``os.write`` is allowed to make.
+
+    A marker written with a bare ``os.write`` can land partially: a peer reading it mid-write parses a truncated record
+    as malformed or as a foreign holder. Looping until the buffer drains keeps the record atomic in the process and
+    kernel view. No ``fsync``: filelock needs a complete record, not crash-durable storage.
+
+    :param fd: file descriptor open for writing.
+    :param data: bytes to write in full.
+
+    :raises OSError: if a write reports zero progress before the record is complete.
+
+    """
+    remaining = memoryview(data)
+    while remaining:
+        if (written := os.write(fd, remaining)) == 0:
+            raise OSError(EIO, "os.write wrote 0 bytes before the record was complete")
+        remaining = remaining[written:]
 
 
 def raise_on_not_writable_file(filename: str) -> None:
@@ -92,4 +113,5 @@ __all__ = [
     "break_lock_file",
     "ensure_directory_exists",
     "raise_on_not_writable_file",
+    "write_all",
 ]

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Generator
     from multiprocessing.synchronize import Event as EventType
 
+    from pytest_mock import MockerFixture
+
 
 _REQUIRES_POSIX_SIGNALS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     sys.platform == "win32", reason="POSIX signals required"
@@ -1090,3 +1092,12 @@ def _fork_event() -> EventType:
         msg = "fork context is POSIX only"
         raise RuntimeError(msg)
     return mp.get_context("fork").Event()
+
+
+def test_write_marker_zero_write_rolls_back(lock_file: str, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._util.os.write", return_value=0)
+
+    lock = SoftReadWriteLock(lock_file, is_singleton=False)
+    with pytest.raises(OSError, match="0 bytes"):
+        lock.acquire_write(timeout=1)
+    assert not Path(f"{lock_file}.write").exists()

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -513,3 +513,13 @@ async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: Mo
         await task
     assert not lock.is_locked
     assert lock.lock_counter == 0
+
+
+@pytest.mark.asyncio
+async def test_async_zero_write_rolls_back_acquire(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._util.os.write", return_value=0)
+
+    lock = AsyncSoftFileLock(str(tmp_path / "a"))
+    with pytest.raises(OSError, match="0 bytes"):
+        await lock.acquire()
+    assert not lock.is_locked

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import socket
 import sys
-from errno import ENODEV, EPERM
+from errno import ENODEV, ENOSPC, EPERM
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
@@ -295,13 +295,14 @@ def test_break_lock(lock_path: Path, *, exists: bool) -> None:
     assert not lock_path.exists()
 
 
-def test_write_lock_info_errors_suppressed(lock_path: Path, mocker: MockerFixture) -> None:
-    mocker.patch("filelock._soft.os.write", side_effect=OSError("write failed"))
+def test_write_failure_rolls_back_acquire(lock_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._util.os.write", side_effect=OSError(ENOSPC, "No space left on device"))
 
     lock = SoftFileLock(lock_path)
-    with lock:
-        assert lock.is_locked
-        assert not lock_path.read_text(encoding="utf-8")
+    with pytest.raises(OSError, match="No space left on device"):
+        lock.acquire()
+    assert not lock.is_locked
+    assert not lock_path.exists()
 
 
 def _assert_self_heals(lock_path: Path) -> None:
@@ -313,3 +314,78 @@ def _assert_self_heals(lock_path: Path) -> None:
 def _assert_times_out(lock_path: Path) -> None:
     with pytest.raises(TimeoutError):
         SoftFileLock(lock_path, timeout=0.1).acquire()
+
+
+def _hold_reports_foreign_identity(mocker: MockerFixture) -> None:
+    # Make the held descriptor report a different inode than the file on disk, as if a peer replaced the marker at the
+    # path. fstat runs only on our own lock fd, so nothing else in acquire or release is disturbed.
+    mocker.patch("filelock._soft.os.fstat", return_value=mocker.Mock(st_dev=1, st_ino=999))
+
+
+def test_short_writes_still_write_the_whole_record(lock_path: Path, mocker: MockerFixture) -> None:
+    real_write = os.write
+    mocker.patch("filelock._util.os.write", side_effect=lambda fd, data: real_write(fd, bytes(data[:1])))
+
+    with SoftFileLock(lock_path):
+        lines = lock_path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == str(os.getpid())
+    assert lines[1] == _HOST
+
+
+def test_zero_write_rolls_back_acquire(lock_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._util.os.write", return_value=0)
+
+    lock = SoftFileLock(lock_path)
+    with pytest.raises(OSError, match="0 bytes"):
+        lock.acquire()
+    assert not lock.is_locked
+    assert not lock_path.exists()
+
+
+def test_failed_acquire_cleanup_spares_a_replacement(lock_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._util.os.write", side_effect=OSError(ENOSPC, "No space left on device"))
+    _hold_reports_foreign_identity(mocker)
+
+    lock = SoftFileLock(lock_path)
+    with pytest.raises(OSError, match="No space left on device"):
+        lock.acquire()
+    assert lock_path.exists()
+
+
+def test_release_without_identity_skips_unlink(lock_path: Path, mocker: MockerFixture) -> None:
+    lock = SoftFileLock(lock_path)
+    lock.acquire()
+    # The held descriptor can no longer be identified, so release cannot prove the path is still ours: it closes and
+    # clears held state without unlinking rather than risk deleting a successor's marker.
+    mocker.patch("filelock._soft.os.fstat", side_effect=OSError)
+    lock.release()
+    assert not lock.is_locked
+    assert lock_path.exists()
+
+
+def test_normal_release_removes_own_marker(lock_path: Path) -> None:
+    with SoftFileLock(lock_path):
+        assert lock_path.exists()
+    assert not lock_path.exists()
+
+
+@_UNIX_ONLY
+def test_stale_release_spares_a_successor(lock_path: Path) -> None:
+    holder = SoftFileLock(lock_path)
+    holder.acquire()
+    # A peer breaks the stale marker and installs its own at the same path; unlink first so it gets a fresh inode.
+    lock_path.unlink()
+    lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
+    holder.release()
+    assert lock_path.exists()
+    assert str(_DEAD_PID) in lock_path.read_text(encoding="utf-8")
+
+
+@_WINDOWS_ONLY
+def test_windows_release_spares_a_replacement(lock_path: Path, mocker: MockerFixture) -> None:
+    lock = SoftFileLock(lock_path)
+    lock.acquire()
+    _hold_reports_foreign_identity(mocker)
+    lock.release()
+    assert lock_path.exists()
+    lock_path.unlink()


### PR DESCRIPTION
`SoftFileLock` marked itself as holding the lock the moment it created the marker file, before writing the holder record, and cleaned up by removing the marker at its pathname. A short or failed `os.write` could leave an empty or half-written marker that a peer reads as malformed or as a different holder, so both processes conclude they own the lock (#601). Pathname-only cleanup compounds the problem: a supported `lifetime` lease lets a peer break an expired marker and create its own at the same path, so a rollback or a late release could delete that successor's marker, which #602 reports for the reader/writer variant.

Acquisition now writes the marker record in full before publishing any held state. A `write_all` helper loops over the short writes `os.write` is allowed to make and fails if a write reports no progress; it omits `fsync`, since the lock needs a complete record in the process and kernel view rather than crash-durable storage. The acquire path captures the opened file's `(st_dev, st_ino)` identity, writes the record, and only then records the descriptor as held; any failure closes the descriptor and unlinks the path while `lstat` still identifies that same file. Release captures the held descriptor's identity, closes it, clears local state, and removes the path when its current identity still matches, with Windows rechecking on each unlink retry because a failed unlink reopens the replacement window. The soft reader/writer marker gains the same complete-write and identity-checked rollback, so one reader never removes another's marker.

`break_lock` keeps its documented force semantics and ignores owner identity. 🔒

Fixes #601
Fixes #602
