### PR TITLE
✨ feat(api): add context_error_policy for dual context failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
 test = [
   "covdefaults>=2.3",
   "diff-cover>=10.2",
+  "exceptiongroup>=1.2; python_version<'3.11'",
   "pytest>=9.0.3",
   "pytest-asyncio>=1.3",
   "pytest-cov>=7.1",

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -12,7 +12,7 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Final
 
-from ._api import AcquireReturnProxy, BaseFileLock
+from ._api import AcquireReturnProxy, BaseFileLock, ContextErrorPolicy
 from ._error import Timeout
 
 if TYPE_CHECKING:
@@ -81,6 +81,7 @@ __all__ = [
     "AsyncWindowsFileLock",
     "BaseAsyncFileLock",
     "BaseFileLock",
+    "ContextErrorPolicy",
     "FileLock",
     "ReadWriteLock",
     "SoftFileLock",

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -10,7 +10,7 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import Lock, local
-from typing import TYPE_CHECKING, Any, Final, TypeVar
+from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, TypeVar, cast
 from weakref import WeakValueDictionary
 
 from ._error import Timeout
@@ -19,6 +19,10 @@ from ._util import break_lock_file
 #: No explicit file permission mode was passed. Lock files then open with 0o666 so umask and default ACLs pick
 #: the final permissions, and fchmod is skipped to preserve POSIX default ACL inheritance.
 _UNSET_FILE_MODE: Final[int] = -1
+
+#: How a context manager reconciles a body failure with a release failure on exit (see the property of this name).
+ContextErrorPolicy = Literal["chain", "group"]
+_CONTEXT_ERROR_POLICIES: Final[frozenset[str]] = frozenset({"chain", "group"})
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -34,6 +38,40 @@ if TYPE_CHECKING:
 
 
 _LOGGER: Final[logging.Logger] = logging.getLogger("filelock")
+
+
+def _exception_group_cls() -> type[BaseException]:
+    # BaseExceptionGroup is a builtin on 3.11+; on 3.10 it needs the exceptiongroup backport. filelock keeps zero
+    # runtime dependencies, so the backport is imported lazily rather than required, and only group mode needs it.
+    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+        return BaseExceptionGroup  # noqa: F821  # builtin on 3.11+
+    # Alias the import so BaseExceptionGroup above stays the builtin rather than an unbound local of this function.
+    from exceptiongroup import BaseExceptionGroup as _Backport  # noqa: PLC0415  # pragma: no cover (<py311)
+
+    return _Backport  # pragma: no cover (<py311)
+
+
+def _resolve_context_error_policy(policy: str) -> ContextErrorPolicy:
+    if policy not in _CONTEXT_ERROR_POLICIES:
+        msg = f"context_error_policy must be 'chain' or 'group', got {policy!r}"
+        raise ValueError(msg)
+    if policy == "group":  # fail fast at construction rather than only when a dual failure happens to occur
+        try:
+            _exception_group_cls()
+        except ImportError as exc:  # pragma: no cover  # only on 3.10 without the exceptiongroup backport
+            msg = "context_error_policy='group' requires Python 3.11+ or the 'exceptiongroup' backport installed"
+            raise ValueError(msg) from exc
+    return cast("ContextErrorPolicy", policy)
+
+
+def _raise_body_and_release(body_error: BaseException, release_error: BaseException) -> NoReturn:
+    # Group mode: surface the body failure and the release failure as sibling leaves instead of letting one hide in the
+    # other's __context__. BaseExceptionGroup returns a plain ExceptionGroup when both leaves subclass Exception, so
+    # ``except*`` and ``except Exception`` still catch them; a BaseException leaf (KeyboardInterrupt, CancelledError)
+    # keeps the group outside ordinary handlers. ``from None`` stops the group itself gaining a redundant __context__.
+    msg = "lock body and release both failed"
+    raise _exception_group_cls()(msg, (body_error, release_error)) from None
+
 
 # On Windows os.path.realpath calls CreateFileW with share_mode=0, which blocks concurrent DeleteFileW and causes
 # livelocks under threaded contention with SoftFileLock. os.path.abspath is purely string-based and avoids this.
@@ -87,9 +125,13 @@ class FileLockMeta(ABCMeta):
         is_singleton: bool = False,
         poll_interval: float = 0.05,
         lifetime: float | None = None,
+        context_error_policy: ContextErrorPolicy = "chain",
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
         lifetime = _resolve_lifetime(lifetime, supported=cls._lifetime_supported, cls_name=cls.__name__)
+        # Validate before building the instance: a raise inside __init__ would leave a half-constructed object whose
+        # __del__ then trips over the missing context.
+        context_error_policy = _resolve_context_error_policy(context_error_policy)
         params = {
             "timeout": timeout,
             "mode": mode,
@@ -98,6 +140,7 @@ class FileLockMeta(ABCMeta):
             "is_singleton": is_singleton,
             "poll_interval": poll_interval,
             "lifetime": lifetime,
+            "context_error_policy": context_error_policy,
             **kwargs,
         }
         if not is_singleton:
@@ -121,6 +164,7 @@ class FileLockMeta(ABCMeta):
             "blocking": (blocking, instance.blocking),
             "poll_interval": (poll_interval, instance.poll_interval),
             "lifetime": (lifetime, instance.lifetime),
+            "context_error_policy": (context_error_policy, instance.context_error_policy),
         }
         non_matching_params = {
             name: (passed_param, set_param)
@@ -180,6 +224,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         is_singleton: bool = False,
         poll_interval: float = 0.05,
         lifetime: float | None = None,
+        context_error_policy: ContextErrorPolicy = "chain",
     ) -> None:
         """
         Create a new lock object.
@@ -207,10 +252,15 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             waiting process breaks a lock file whose modification time is older than ``lifetime`` seconds, even if the
             holder is still alive. ``None`` (the default) means locks never expire. Native OS locks (:class:`FileLock`)
             cannot be revoked by file age and ignore a non-``None`` ``lifetime`` with a warning.
+        :param context_error_policy: how a context manager reconciles a failure in its body with a failure while
+            releasing on exit. ``"chain"`` (the default) keeps Python's behavior: the release error propagates with the
+            body error in its ``__context__``. ``"group"`` raises a :class:`BaseExceptionGroup` holding the body error
+            first and the release error second, so neither hides the other.
 
         """
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
+        self._context_error_policy = context_error_policy  # already validated by the metaclass
 
         # External code reaches these values through the public properties, not through _context directly.
         kwargs: dict[str, Any] = {
@@ -236,6 +286,16 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
 
         """
         return self._is_singleton
+
+    @property
+    def context_error_policy(self) -> ContextErrorPolicy:
+        """
+        How a context manager reconciles a body failure with a release failure on exit.
+
+        .. versionadded:: 3.27.0
+
+        """
+        return self._context_error_policy
 
     @property
     def lock_file(self) -> str:
@@ -381,8 +441,18 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        """Release the lock."""
-        self.release()
+        """Release the lock, reconciling a release failure with any body failure per :attr:`context_error_policy`."""
+        self._release_in_context(exc_value)
+
+    def _release_in_context(self, body_error: BaseException | None) -> None:
+        # Release from a context-manager exit. "chain" lets a release failure propagate with the body error already in
+        # its __context__ (Python's default); "group" raises both as sibling leaves so neither one hides the other.
+        try:
+            self.release()
+        except BaseException as release_error:
+            if body_error is None or self._context_error_policy == "chain":
+                raise
+            _raise_body_and_release(body_error, release_error)
 
     def __del__(self) -> None:
         """Force-release so a dropped reference never leaks a held lock."""
@@ -626,7 +696,10 @@ class AcquireReturnProxy:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        self.lock.release()
+        if isinstance(self.lock, BaseFileLock):
+            self.lock._release_in_context(exc_value)  # noqa: SLF001
+        else:  # a reader/writer lock does not carry a context_error_policy
+            self.lock.release()
 
 
 @dataclass

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -12,7 +12,15 @@ from inspect import iscoroutinefunction
 from threading import local
 from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar
 
-from ._api import _UNSET_FILE_MODE, BaseFileLock, FileLockContext, FileLockMeta, _canonical
+from ._api import (
+    _UNSET_FILE_MODE,
+    BaseFileLock,
+    ContextErrorPolicy,
+    FileLockContext,
+    FileLockMeta,
+    _canonical,
+    _raise_body_and_release,
+)
 from ._error import Timeout
 from ._soft import SoftFileLock
 from ._unix import UnixFileLock
@@ -47,6 +55,7 @@ class AsyncFileLockMeta(FileLockMeta):
         is_singleton: bool = False,
         poll_interval: float = 0.05,
         lifetime: float | None = None,
+        context_error_policy: ContextErrorPolicy = "chain",
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -63,6 +72,7 @@ class AsyncFileLockMeta(FileLockMeta):
             is_singleton=is_singleton,
             poll_interval=poll_interval,
             lifetime=lifetime,
+            context_error_policy=context_error_policy,
             loop=loop,
             run_in_executor=run_in_executor,
             executor=executor,
@@ -90,6 +100,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         is_singleton: bool = False,
         poll_interval: float = 0.05,
         lifetime: float | None = None,
+        context_error_policy: ContextErrorPolicy = "chain",
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -121,6 +132,10 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             even if the holder is still alive. ``None`` (the default) means locks never expire. Native OS locks
             (:class:`AsyncFileLock`) cannot be revoked by file age and ignore a non-``None`` ``lifetime``, with a
             warning.
+        :param context_error_policy: how a context manager reconciles a failure in its body with a failure while
+            releasing on exit. ``"chain"`` (the default) keeps Python's behavior: the release error propagates with the
+            body error in its ``__context__``. ``"group"`` raises a :class:`BaseExceptionGroup` holding the body error
+            first and the release error second, so neither hides the other.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.
@@ -128,6 +143,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         """
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
+        self._context_error_policy = context_error_policy  # already validated by the metaclass
 
         # External code goes through this class's properties, not the context directly.
         kwargs: dict[str, Any] = {
@@ -347,14 +363,25 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         traceback: TracebackType | None,
     ) -> None:
         """
-        Release the lock.
+        Release the lock, reconciling a release failure with any body failure per :attr:`context_error_policy`.
 
         :param exc_type: the exception type if raised
         :param exc_value: the exception value if raised
         :param traceback: the exception traceback if raised
 
         """
-        await self.release()
+        await self._release_in_context(exc_value)
+
+    async def _release_in_context(  # ty: ignore[invalid-method-override]
+        self, body_error: BaseException | None
+    ) -> None:
+        # The async counterpart of BaseFileLock._release_in_context: await release, then apply the same policy.
+        try:
+            await self.release()
+        except BaseException as release_error:
+            if body_error is None or self._context_error_policy == "chain":
+                raise
+            _raise_body_and_release(body_error, release_error)
 
     def __del__(self) -> None:
         """Release on deletion — safe to call during GC even when no event loop is running."""
@@ -404,7 +431,7 @@ class AsyncAcquireReturnProxy:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        await self.lock.release()
+        await self.lock._release_in_context(exc_value)  # noqa: SLF001
 
 
 class AsyncSoftFileLock(SoftFileLock, BaseAsyncFileLock):

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -12,9 +12,16 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from filelock import AsyncFileLock, AsyncSoftFileLock, BaseAsyncFileLock, Timeout
+from filelock import AsyncFileLock, AsyncSoftFileLock, BaseAsyncFileLock, ContextErrorPolicy, Timeout
+
+if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+    from builtins import BaseExceptionGroup, ExceptionGroup
+else:  # pragma: no cover (<py311)
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
 if TYPE_CHECKING:
+    from contextlib import AbstractAsyncContextManager
+
     from pytest_mock import MockerFixture
 
 _UNIX_FLOCK_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="native flock semantics are Unix-only")
@@ -523,3 +530,68 @@ async def test_async_zero_write_rolls_back_acquire(tmp_path: Path, mocker: Mocke
     with pytest.raises(OSError, match="0 bytes"):
         await lock.acquire()
     assert not lock.is_locked
+
+
+async def _acquire_cm(lock: AsyncSoftFileLock, *, use_proxy: bool) -> AbstractAsyncContextManager[BaseAsyncFileLock]:
+    return await lock.acquire() if use_proxy else lock  # proxy exercises AsyncAcquireReturnProxy.__aexit__
+
+
+@pytest.mark.parametrize("use_proxy", [False, True], ids=["direct", "proxy"])
+@pytest.mark.asyncio
+async def test_context_group_reports_both_failures(tmp_path: Path, mocker: MockerFixture, use_proxy: bool) -> None:
+    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy="group")
+    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+    cm = await _acquire_cm(lock, use_proxy=use_proxy)
+    with pytest.raises(ExceptionGroup) as info:
+        async with cm:
+            raise ValueError
+    body, release = info.value.exceptions
+    assert isinstance(body, ValueError)
+    assert isinstance(release, OSError)
+
+
+@pytest.mark.parametrize("use_proxy", [False, True], ids=["direct", "proxy"])
+@pytest.mark.asyncio
+async def test_context_chain_keeps_release_error_with_body_in_context(
+    tmp_path: Path, mocker: MockerFixture, use_proxy: bool
+) -> None:
+    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy="chain")
+    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+    cm = await _acquire_cm(lock, use_proxy=use_proxy)
+    with pytest.raises(OSError, match="release failed") as info:
+        async with cm:
+            raise ValueError
+    assert isinstance(info.value.__context__, ValueError)
+
+
+@pytest.mark.parametrize("policy", ["chain", "group"])
+@pytest.mark.asyncio
+async def test_context_body_only_failure_propagates_body(tmp_path: Path, policy: ContextErrorPolicy) -> None:
+    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy=policy)
+    body = ValueError("body failed")
+    with pytest.raises(ValueError, match="body failed"):
+        async with lock:
+            raise body
+
+
+@pytest.mark.parametrize("policy", ["chain", "group"])
+@pytest.mark.asyncio
+async def test_context_release_only_failure_propagates_release(
+    tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
+) -> None:
+    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy=policy)
+    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+    with pytest.raises(OSError, match="release failed"):
+        async with lock:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_context_group_base_exception_leaf_is_base_group(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy="group")
+    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+    with pytest.raises(BaseExceptionGroup) as info:
+        async with lock:
+            raise KeyboardInterrupt
+    assert not isinstance(info.value, ExceptionGroup)
+    assert [type(leaf) for leaf in info.value.exceptions] == [KeyboardInterrupt, OSError]

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -19,10 +19,16 @@ from weakref import WeakValueDictionary
 
 import pytest
 
-from filelock import BaseFileLock, FileLock, SoftFileLock, Timeout, UnixFileLock, WindowsFileLock
+from filelock import BaseFileLock, ContextErrorPolicy, FileLock, SoftFileLock, Timeout, UnixFileLock, WindowsFileLock
+
+if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+    from builtins import BaseExceptionGroup, ExceptionGroup
+else:  # pragma: no cover (<py311)
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
 
     from pytest_mock import MockerFixture
 
@@ -1512,3 +1518,82 @@ def test_windows_delete_in_progress_is_contention_not_denial(tmp_path: Path) -> 
             FileLock(target, timeout=0.3).acquire()
     finally:
         kernel32.CloseHandle(handle)
+
+
+def _enter_direct(lock: SoftFileLock) -> AbstractContextManager[object]:
+    return lock
+
+
+def _enter_proxy(lock: SoftFileLock) -> AbstractContextManager[object]:
+    return lock.acquire()  # exercises AcquireReturnProxy.__exit__ instead of BaseFileLock.__exit__
+
+
+_CONTEXT_ENTRIES: Final = [pytest.param(_enter_direct, id="direct"), pytest.param(_enter_proxy, id="proxy")]
+
+
+@pytest.mark.parametrize("enter", _CONTEXT_ENTRIES)
+def test_context_group_reports_both_failures(
+    tmp_path: Path, mocker: MockerFixture, enter: Callable[[SoftFileLock], AbstractContextManager[object]]
+) -> None:
+    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy="group")
+    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+    with pytest.raises(ExceptionGroup) as info, enter(lock):
+        raise ValueError
+    body, release = info.value.exceptions
+    assert isinstance(body, ValueError)
+    assert isinstance(release, OSError)
+    assert body.__traceback__ is not None  # leaves keep their own frames
+    assert release.__traceback__ is not None
+
+
+@pytest.mark.parametrize("enter", _CONTEXT_ENTRIES)
+def test_context_chain_keeps_release_error_with_body_in_context(
+    tmp_path: Path, mocker: MockerFixture, enter: Callable[[SoftFileLock], AbstractContextManager[object]]
+) -> None:
+    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy="chain")
+    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+    with pytest.raises(OSError, match="release failed") as info, enter(lock):
+        raise ValueError
+    assert isinstance(info.value.__context__, ValueError)
+
+
+@pytest.mark.parametrize("policy", ["chain", "group"])
+def test_context_body_only_failure_propagates_body(tmp_path: Path, policy: ContextErrorPolicy) -> None:
+    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy=policy)
+    body = ValueError("body failed")
+    with pytest.raises(ValueError, match="body failed"), lock:
+        raise body
+
+
+@pytest.mark.parametrize("policy", ["chain", "group"])
+def test_context_release_only_failure_propagates_release(
+    tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
+) -> None:
+    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy=policy)
+    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+    with pytest.raises(OSError, match="release failed"), lock:
+        pass
+
+
+def test_context_group_base_exception_leaf_is_base_group(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy="group")
+    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+    with pytest.raises(BaseExceptionGroup) as info, lock:
+        raise KeyboardInterrupt
+    assert not isinstance(info.value, ExceptionGroup)  # a BaseException leaf stays outside except Exception
+    assert [type(leaf) for leaf in info.value.exceptions] == [KeyboardInterrupt, OSError]
+
+
+def test_invalid_context_error_policy_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="context_error_policy must be"):
+        SoftFileLock(str(tmp_path / "a"), context_error_policy="explode")  # ty: ignore[invalid-argument-type]
+
+
+def test_singleton_rejects_different_context_policy(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    first = SoftFileLock(path, is_singleton=True, context_error_policy="chain")
+    try:
+        with pytest.raises(ValueError, match="context_error_policy"):
+            SoftFileLock(path, is_singleton=True, context_error_policy="group")
+    finally:
+        first.release(force=True)


### PR DESCRIPTION
When a `with` block's body raises and releasing the lock on exit also raises, Python keeps only the release error and tucks the body error into its `__context__`. A caller that handles the release `OSError` never sees that its actual work failed, and issue #606 asks for a way to surface both.

This adds an opt-in `context_error_policy` constructor argument on the sync and async locks. The default, `"chain"`, is unchanged: the release error propagates with the body error in its `__context__`, so existing handlers keep working. `"group"` raises a `BaseExceptionGroup` with the body error first and the release error second, so neither hides the other and `except*` can pick them apart. The same policy drives all four context exits — `BaseFileLock.__exit__`, `AcquireReturnProxy.__exit__`, `BaseAsyncFileLock.__aexit__`, and `AsyncAcquireReturnProxy.__aexit__` — through one shared helper, and it participates in the singleton argument check so a second handle cannot silently disagree.

`BaseExceptionGroup` is a builtin on Python 3.11 and later. On 3.10 it needs the `exceptiongroup` backport, and filelock keeps zero runtime dependencies, so the backport is imported lazily and only when group mode actually runs. A 3.10 process that asks for `"group"` without the backport installed fails fast at construction with a clear message rather than only at the moment a dual failure occurs. 🔗 The handoff proposed a conditional runtime dependency; I chose the lazy import instead to preserve filelock's dependency-free install, and added `exceptiongroup` to the test extras only. Existing callers are unaffected: the default policy and behavior do not change.

Fixes #606
