### PR TITLE
✨ feat(api): add close_error_policy for post-unlock close errors

### DIFF
--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -12,7 +12,7 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Final
 
-from ._api import AcquireReturnProxy, BaseFileLock, ContextErrorPolicy
+from ._api import AcquireReturnProxy, BaseFileLock, CloseErrorPolicy, ContextErrorPolicy
 from ._error import Timeout
 
 if TYPE_CHECKING:
@@ -81,6 +81,7 @@ __all__ = [
     "AsyncWindowsFileLock",
     "BaseAsyncFileLock",
     "BaseFileLock",
+    "CloseErrorPolicy",
     "ContextErrorPolicy",
     "FileLock",
     "ReadWriteLock",

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -24,6 +24,10 @@ _UNSET_FILE_MODE: Final[int] = -1
 ContextErrorPolicy = Literal["chain", "group"]
 _CONTEXT_ERROR_POLICIES: Final[frozenset[str]] = frozenset({"chain", "group"})
 
+#: What a native backend does with an ``os.close`` failure after the OS unlock committed (see the property).
+CloseErrorPolicy = Literal["default", "raise", "suppress"]
+_CLOSE_ERROR_POLICIES: Final[frozenset[str]] = frozenset({"default", "raise", "suppress"})
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from types import TracebackType
@@ -62,6 +66,13 @@ def _resolve_context_error_policy(policy: str) -> ContextErrorPolicy:
             msg = "context_error_policy='group' requires Python 3.11+ or the 'exceptiongroup' backport installed"
             raise ValueError(msg) from exc
     return cast("ContextErrorPolicy", policy)
+
+
+def _resolve_close_error_policy(policy: str) -> CloseErrorPolicy:
+    if policy not in _CLOSE_ERROR_POLICIES:
+        msg = f"close_error_policy must be 'default', 'raise', or 'suppress', got {policy!r}"
+        raise ValueError(msg)
+    return cast("CloseErrorPolicy", policy)
 
 
 def _raise_body_and_release(body_error: BaseException, release_error: BaseException) -> NoReturn:
@@ -126,12 +137,14 @@ class FileLockMeta(ABCMeta):
         poll_interval: float = 0.05,
         lifetime: float | None = None,
         context_error_policy: ContextErrorPolicy = "chain",
+        close_error_policy: CloseErrorPolicy = "default",
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
         lifetime = _resolve_lifetime(lifetime, supported=cls._lifetime_supported, cls_name=cls.__name__)
         # Validate before building the instance: a raise inside __init__ would leave a half-constructed object whose
         # __del__ then trips over the missing context.
         context_error_policy = _resolve_context_error_policy(context_error_policy)
+        close_error_policy = _resolve_close_error_policy(close_error_policy)
         params = {
             "timeout": timeout,
             "mode": mode,
@@ -141,6 +154,7 @@ class FileLockMeta(ABCMeta):
             "poll_interval": poll_interval,
             "lifetime": lifetime,
             "context_error_policy": context_error_policy,
+            "close_error_policy": close_error_policy,
             **kwargs,
         }
         if not is_singleton:
@@ -165,6 +179,7 @@ class FileLockMeta(ABCMeta):
             "poll_interval": (poll_interval, instance.poll_interval),
             "lifetime": (lifetime, instance.lifetime),
             "context_error_policy": (context_error_policy, instance.context_error_policy),
+            "close_error_policy": (close_error_policy, instance.close_error_policy),
         }
         non_matching_params = {
             name: (passed_param, set_param)
@@ -225,6 +240,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         poll_interval: float = 0.05,
         lifetime: float | None = None,
         context_error_policy: ContextErrorPolicy = "chain",
+        close_error_policy: CloseErrorPolicy = "default",
     ) -> None:
         """
         Create a new lock object.
@@ -256,11 +272,17 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             releasing on exit. ``"chain"`` (the default) keeps Python's behavior: the release error propagates with the
             body error in its ``__context__``. ``"group"`` raises a :class:`BaseExceptionGroup` holding the body error
             first and the release error second, so neither hides the other.
+        :param close_error_policy: for native locks (:class:`FileLock`), what to do with an ``os.close`` failure after
+            the OS unlock has already committed. ``"default"`` keeps each platform's historical behavior (Unix drops a
+            FUSE/Docker ``EIO``, Windows propagates); ``"raise"`` always propagates the ``OSError``; ``"suppress"``
+            always ignores it. Held state is released either way. It does not affect unlock failures or lock-file
+            deletion.
 
         """
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
         self._context_error_policy = context_error_policy  # already validated by the metaclass
+        self._close_error_policy = close_error_policy  # already validated by the metaclass
 
         # External code reaches these values through the public properties, not through _context directly.
         kwargs: dict[str, Any] = {
@@ -296,6 +318,28 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
 
         """
         return self._context_error_policy
+
+    @property
+    def close_error_policy(self) -> CloseErrorPolicy:
+        """
+        What a native lock does with an ``os.close`` failure after the OS unlock committed.
+
+        .. versionadded:: 3.27.0
+
+        """
+        return self._close_error_policy
+
+    def _close_released_fd(self, fd: int, *, default_suppresses: bool) -> None:
+        # Close the descriptor after the OS unlock has committed. CPython never retries close() after EINTR because the
+        # descriptor number may already be reused, so neither does this. close_error_policy decides the error's fate:
+        # "raise" propagates, "suppress" drops it, "default" keeps the backend's historical behavior (Unix suppresses a
+        # FUSE/Docker EIO, Windows propagates). Held state is already cleared, so the lock stays released either way.
+        try:
+            os.close(fd)
+        except OSError:
+            if self._close_error_policy == "suppress" or (self._close_error_policy == "default" and default_suppresses):
+                return
+            raise
 
     @property
     def lock_file(self) -> str:

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -123,8 +123,7 @@ else:  # pragma: win32 no cover
             # cleanup; a close failure (EIO on FUSE/Docker bind mounts) does not make the kernel lock held again.
             fcntl.flock(fd, fcntl.LOCK_UN)
             self._context.lock_file_fd = None
-            with suppress(OSError):
-                os.close(fd)
+            self._close_released_fd(fd, default_suppresses=True)
 
 
 __all__ = [

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -148,7 +148,7 @@ if sys.platform == "win32":  # pragma: win32 cover
             # commits do close and unlink run as post-unlock cleanup; their failure cannot make the lock held again.
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
             self._context.lock_file_fd = None
-            os.close(fd)
+            self._close_released_fd(fd, default_suppresses=False)
             with suppress(OSError):
                 Path(self.lock_file).unlink()
 

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar
 from ._api import (
     _UNSET_FILE_MODE,
     BaseFileLock,
+    CloseErrorPolicy,
     ContextErrorPolicy,
     FileLockContext,
     FileLockMeta,
@@ -56,6 +57,7 @@ class AsyncFileLockMeta(FileLockMeta):
         poll_interval: float = 0.05,
         lifetime: float | None = None,
         context_error_policy: ContextErrorPolicy = "chain",
+        close_error_policy: CloseErrorPolicy = "default",
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -73,6 +75,7 @@ class AsyncFileLockMeta(FileLockMeta):
             poll_interval=poll_interval,
             lifetime=lifetime,
             context_error_policy=context_error_policy,
+            close_error_policy=close_error_policy,
             loop=loop,
             run_in_executor=run_in_executor,
             executor=executor,
@@ -101,6 +104,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         poll_interval: float = 0.05,
         lifetime: float | None = None,
         context_error_policy: ContextErrorPolicy = "chain",
+        close_error_policy: CloseErrorPolicy = "default",
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -136,6 +140,9 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             releasing on exit. ``"chain"`` (the default) keeps Python's behavior: the release error propagates with the
             body error in its ``__context__``. ``"group"`` raises a :class:`BaseExceptionGroup` holding the body error
             first and the release error second, so neither hides the other.
+        :param close_error_policy: for native locks (:class:`AsyncFileLock`), what to do with an ``os.close`` failure
+            after the OS unlock has already committed. ``"default"`` keeps each platform's historical behavior,
+            ``"raise"`` always propagates the ``OSError``, and ``"suppress"`` always ignores it.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.
@@ -144,6 +151,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
         self._context_error_policy = context_error_policy  # already validated by the metaclass
+        self._close_error_policy = close_error_policy  # already validated by the metaclass
 
         # External code goes through this class's properties, not the context directly.
         kwargs: dict[str, Any] = {

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import logging
+import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -595,3 +596,37 @@ async def test_context_group_base_exception_leaf_is_base_group(tmp_path: Path, m
             raise KeyboardInterrupt
     assert not isinstance(info.value, ExceptionGroup)
     assert [type(leaf) for leaf in info.value.exceptions] == [KeyboardInterrupt, OSError]
+
+
+def _fail_close_of(mocker: MockerFixture, lock: BaseAsyncFileLock, error: OSError) -> None:
+    # Fail os.close only for this lock's descriptor, so an unrelated lock's __del__ close during the test is untouched.
+    fd = lock._context.lock_file_fd
+    real_close = os.close
+
+    def close(target: int) -> None:
+        if target == fd:
+            raise error
+        real_close(target)
+
+    mocker.patch("filelock._api.os.close", side_effect=close)
+
+
+@_UNIX_FLOCK_ONLY
+@pytest.mark.asyncio
+async def test_close_error_raise_propagates(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = AsyncFileLock(str(tmp_path / "a"), close_error_policy="raise")
+    await lock.acquire()
+    _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
+    with pytest.raises(OSError, match="close failed"):
+        await lock.release()
+    assert not lock.is_locked
+
+
+@_UNIX_FLOCK_ONLY
+@pytest.mark.asyncio
+async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = AsyncFileLock(str(tmp_path / "a"))  # default policy
+    await lock.acquire()
+    _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
+    await lock.release()
+    assert not lock.is_locked

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -8,7 +8,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from errno import EAGAIN, EIO, ENOSPC, ENOSYS, EWOULDBLOCK
+from errno import EAGAIN, EINTR, EIO, ENOSPC, ENOSYS, EWOULDBLOCK
 from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IMODE, S_IWGRP, S_IWOTH, S_IWUSR, filemode
@@ -1595,5 +1595,109 @@ def test_singleton_rejects_different_context_policy(tmp_path: Path) -> None:
     try:
         with pytest.raises(ValueError, match="context_error_policy"):
             SoftFileLock(path, is_singleton=True, context_error_policy="group")
+    finally:
+        first.release(force=True)
+
+
+def _fail_close_of(mocker: MockerFixture, lock: BaseFileLock, error: OSError) -> list[int]:
+    # Fail os.close only for this lock's own descriptor, and record each attempt on it. A blanket patch would also hit
+    # the close another test's lock runs from __del__ during this test, turning an unrelated garbage collection into a
+    # spurious failure. Returns the list of attempts so a caller can assert close is not retried.
+    fd = lock._context.lock_file_fd
+    real_close = os.close
+    attempts: list[int] = []
+
+    def close(target: int) -> None:
+        if target == fd:
+            attempts.append(target)
+            raise error
+        real_close(target)
+
+    mocker.patch("filelock._api.os.close", side_effect=close)
+    return attempts
+
+
+@_UNIX_FLOCK_ONLY
+def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = FileLock(str(tmp_path / "a"))  # default policy
+    lock.acquire()
+    _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
+    lock.release()  # Unix default drops a FUSE/Docker EIO
+    assert not lock.is_locked
+
+
+@_WINDOWS_ONLY
+def test_close_error_default_raises_on_windows(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = FileLock(str(tmp_path / "a"))  # default policy
+    lock.acquire()
+    _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
+    with pytest.raises(OSError, match="close failed"):
+        lock.release()
+    assert not lock.is_locked
+
+
+def test_close_error_suppress(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = FileLock(str(tmp_path / "a"), close_error_policy="suppress")
+    lock.acquire()
+    _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
+    lock.release()
+    assert not lock.is_locked
+
+
+@pytest.mark.parametrize("errno", [EINTR, EIO, ENOSPC])
+def test_close_error_raise_is_exact_and_committed(tmp_path: Path, mocker: MockerFixture, errno: int) -> None:
+    lock = FileLock(str(tmp_path / "a"), close_error_policy="raise")
+    lock.acquire()
+    injected = OSError(errno, "close failed")
+    attempts = _fail_close_of(mocker, lock, injected)
+    with pytest.raises(OSError, match="close failed") as info:
+        lock.release()
+    assert info.value is injected  # the original error, no wrapper
+    assert len(attempts) == 1  # os.close is never retried, even after EINTR
+    assert not lock.is_locked  # the unlock committed even though close failed
+    assert lock.lock_counter == 0
+
+
+@_UNIX_FLOCK_ONLY
+def test_close_not_reached_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = FileLock(str(tmp_path / "a"), close_error_policy="raise")
+    lock.acquire()
+    fd = lock._context.lock_file_fd
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=[OSError(EIO, "unlock failed"), None])
+    real_close = os.close
+    closed: list[int] = []
+    mocker.patch("filelock._api.os.close", side_effect=lambda target: closed.append(target) or real_close(target))
+    with pytest.raises(OSError, match="unlock failed"):
+        lock.release()
+    assert lock.is_locked  # the kernel unlock failed, so the lock is still held
+    assert fd not in closed  # close is not reached while the lock is still held
+    lock.release()  # retry: unlock succeeds and close runs
+    assert not lock.is_locked
+    assert fd in closed
+
+
+def test_dual_body_and_close_failure_grouped(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = FileLock(str(tmp_path / "a"), close_error_policy="raise", context_error_policy="group")
+    lock.acquire()
+    _fail_close_of(mocker, lock, OSError("close failed"))
+    body = ValueError("body failed")
+    with pytest.raises(ExceptionGroup) as info:
+        lock._release_in_context(body)  # what __exit__ runs; the close failure joins the body failure
+    leaf_body, close = info.value.exceptions
+    assert isinstance(leaf_body, ValueError)
+    assert isinstance(close, OSError)
+
+
+def test_invalid_close_error_policy_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="close_error_policy must be"):
+        FileLock(str(tmp_path / "a"), close_error_policy="explode")  # ty: ignore[invalid-argument-type]
+
+
+def test_singleton_rejects_different_close_policy(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    first = FileLock(path, is_singleton=True, close_error_policy="raise")
+    try:
+        with pytest.raises(ValueError, match="close_error_policy"):
+            FileLock(path, is_singleton=True, close_error_policy="suppress")
     finally:
         first.release(force=True)


### PR DESCRIPTION
A native lock closes its descriptor after the OS unlock has already committed. Unix has always dropped a `FUSE`/Docker `EIO` from that `os.close`, Windows has always propagated it, and a caller had no way to choose. Issue #610 asks for that choice, and to see the real error rather than a wrapper.

This adds a `close_error_policy` constructor argument on the native locks. `"default"` keeps each platform's historical behavior, `"raise"` always propagates the `OSError`, and `"suppress"` always ignores it. The policy governs only the post-unlock close: the lock is already released when it runs, so held state, the recursion counter, and the singleton registry all commit to released whichever way the error goes, and the original `OSError` reaches the caller with its errno, filename, and platform intact. `os.close` is called once and never retried after `EINTR`, matching CPython, because the descriptor number may already have been reused. 🔒

The policy joins the singleton compatibility check and is threaded through async construction, so all four context exits honor it. This composes with the `context_error_policy` from #606: when a `with` body fails and the close also fails under `"raise"`, group mode surfaces the body error first and the close error second.

This PR is stacked on #606 (`feat/606-dual-failure-context`); its own diff is the close-error policy alone. Existing callers are unaffected — the default policy and behavior do not change.

Fixes #610
