### PR TITLE
✨ feat: add lock_descriptor for a caller-owned descriptor

### DIFF
--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -13,6 +13,7 @@ import warnings
 from typing import TYPE_CHECKING, Final
 
 from ._api import AcquireReturnProxy, BaseFileLock, CloseErrorPolicy, ContextErrorPolicy
+from ._descriptor import lock_descriptor, unlock_descriptor
 from ._error import Timeout
 
 if TYPE_CHECKING:
@@ -91,4 +92,6 @@ __all__ = [
     "UnixFileLock",
     "WindowsFileLock",
     "__version__",
+    "lock_descriptor",
+    "unlock_descriptor",
 ]

--- a/src/filelock/_descriptor.py
+++ b/src/filelock/_descriptor.py
@@ -1,0 +1,58 @@
+"""A minimal native lock over a caller-owned file descriptor, contending with :class:`FileLock` on the same file."""
+
+from __future__ import annotations
+
+import sys
+import time
+
+if sys.platform == "win32":  # pragma: win32 cover
+    from ._windows import _lock_fd_nonblocking, _unlock_fd
+else:  # pragma: win32 no cover
+    from ._unix import _lock_fd_nonblocking, _unlock_fd
+
+
+def lock_descriptor(fd: int, *, blocking: bool = True, poll_interval: float = 0.05) -> bool:
+    """
+    Take the native OS lock on *fd*, a file descriptor the caller opened and owns.
+
+    This is the same one-byte exclusive lock :class:`FileLock` uses, so a descriptor lock and a path lock on the same
+    file contend with each other. Unlike :class:`FileLock` it adds no path handling: it never opens, truncates, closes,
+    unlinks, chmods, canonicalizes, or falls back. The caller owns *fd* before, during, and after the call, and must
+    close it. On Windows *fd* must be a synchronous descriptor (its handle not opened with ``FILE_FLAG_OVERLAPPED``).
+
+    For timeout, reentrancy, singleton, lifetime, or stale-break behavior, use :class:`FileLock`. There is no async
+    wrapper: run this in an executor, or drive ``blocking=False`` from your own polling loop.
+
+    :param fd: an open file descriptor the caller owns.
+    :param blocking: when ``True`` (default), retry the nonblocking attempt every *poll_interval* seconds until it
+        succeeds; when ``False``, make one attempt.
+    :param poll_interval: seconds between attempts while blocking.
+
+    :returns: ``True`` once the lock is held, or ``False`` on contention when ``blocking`` is ``False``.
+
+    :raises OSError: for a permanent native failure, such as an invalid descriptor. The descriptor is left open.
+
+    """
+    if not blocking:
+        return _lock_fd_nonblocking(fd)
+    while not _lock_fd_nonblocking(fd):
+        time.sleep(poll_interval)
+    return True
+
+
+def unlock_descriptor(fd: int) -> None:
+    """
+    Release the native OS lock on *fd* without touching the descriptor.
+
+    :param fd: the descriptor a prior :func:`lock_descriptor` locked; the caller still owns and must close it.
+
+    :raises OSError: if the native unlock fails; the caller may retry on the same descriptor.
+
+    """
+    _unlock_fd(fd)
+
+
+__all__ = [
+    "lock_descriptor",
+    "unlock_descriptor",
+]

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -4,9 +4,9 @@ import os
 import sys
 import warnings
 from contextlib import suppress
-from errno import EAGAIN, ENOSYS, EWOULDBLOCK
+from errno import EACCES, EAGAIN, ENOSYS, EWOULDBLOCK
 from pathlib import Path
-from typing import cast
+from typing import Final, cast
 
 from ._api import BaseFileLock
 from ._util import ensure_directory_exists
@@ -33,6 +33,25 @@ else:  # pragma: win32 no cover
     else:
         has_fcntl = True
 
+    # Contention errnos for a nonblocking flock. EAGAIN/EWOULDBLOCK are the usual "held elsewhere" codes; some
+    # filesystems report EACCES instead, so treat it as contention too rather than a permanent error.
+    _CONTENTION_ERRNOS: Final[frozenset[int]] = frozenset({EACCES, EAGAIN, EWOULDBLOCK})
+
+    def _lock_fd_nonblocking(fd: int) -> bool:
+        # One nonblocking exclusive flock attempt shared by UnixFileLock and lock_descriptor, so both contend on the
+        # same lock and classify errors identically. True on acquisition, False on contention, raise otherwise. The
+        # caller owns fd; this never closes it.
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exception:
+            if exception.errno in _CONTENTION_ERRNOS:
+                return False
+            raise
+        return True
+
+    def _unlock_fd(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
     class UnixFileLock(BaseFileLock):
         """
         Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems.
@@ -42,7 +61,7 @@ else:  # pragma: win32 no cover
         same path.
         """
 
-        def _acquire(self) -> None:  # noqa: C901
+        def _acquire(self) -> None:
             ensure_directory_exists(self.lock_file)
             # Open without O_TRUNC and defer truncation and fchmod until after flock succeeds: a contender that loses
             # the lock must not truncate the holder's file (erasing caller diagnostics) or change its mode. The winner
@@ -71,29 +90,33 @@ else:  # pragma: win32 no cover
                 except FileNotFoundError:
                     return
             try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                locked = _lock_fd_nonblocking(fd)
             except OSError as exception:
-                if exception.errno == ENOSYS:
-                    # The filesystem does not implement flock. Capture the opened file's identity before closing so
-                    # the cleanup below removes only this attempt's placeholder, not a peer's replacement.
-                    identity: tuple[int, int] | None = None
-                    with suppress(OSError):
-                        identity = (fstat := os.fstat(fd)).st_dev, fstat.st_ino
+                if exception.errno != ENOSYS:
                     os.close(fd)
-                    if not self._fallback_to_soft:
-                        raise  # fail closed: the caller opted out of switching to existence-lock semantics (#603)
-                    with suppress(OSError):
-                        current = os.lstat(self.lock_file)
-                        if identity == (current.st_dev, current.st_ino):
-                            Path(self.lock_file).unlink()
-                    self._fallback_to_soft_lock()
-                    self._acquire()
-                    return
-                os.close(fd)
-                if exception.errno not in {EAGAIN, EWOULDBLOCK}:
-                    raise
-            else:
+                    raise  # contention returns False from _lock_fd_nonblocking, so any raise here is a real failure
+                self._switch_to_soft_lock(fd, exception)
+                return
+            if locked:
                 self._finalize_locked_fd(fd)
+            else:
+                os.close(fd)  # contention; let the retry loop try again
+
+        def _switch_to_soft_lock(self, fd: int, missing_flock: OSError) -> None:
+            # The filesystem does not implement flock. Capture the opened file's identity before closing so the cleanup
+            # below removes only this attempt's placeholder, not a peer's replacement.
+            identity: tuple[int, int] | None = None
+            with suppress(OSError):
+                identity = (fstat := os.fstat(fd)).st_dev, fstat.st_ino
+            os.close(fd)
+            if not self._fallback_to_soft:
+                raise missing_flock  # fail closed: the caller opted out of existence-lock semantics (#603)
+            with suppress(OSError):
+                current = os.lstat(self.lock_file)
+                if identity == (current.st_dev, current.st_ino):
+                    Path(self.lock_file).unlink()
+            self._fallback_to_soft_lock()
+            self._acquire()
 
         def _finalize_locked_fd(self, fd: int) -> None:
             # Runs with the flock held. Truncate and normalize mode under a guard so any failure closes fd rather than
@@ -131,7 +154,7 @@ else:  # pragma: win32 no cover
             # Retain the descriptor until flock succeeds: a failed unlock leaves the kernel lock held, so is_locked
             # must keep reporting held for a retry. Once flock commits, clear held state and close as post-unlock
             # cleanup; a close failure (EIO on FUSE/Docker bind mounts) does not make the kernel lock held again.
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            _unlock_fd(fd)
             self._context.lock_file_fd = None
             self._close_released_fd(fd, default_suppresses=True)
 

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -151,10 +151,9 @@ if sys.platform == "win32":  # pragma: win32 cover
         # One nonblocking exclusive LockFileEx attempt shared by WindowsFileLock and lock_descriptor, over the one-byte
         # range at offset 0. True on acquisition, False on contention, raise otherwise. The caller owns fd; the handle
         # from get_osfhandle belongs to the CRT descriptor and must not be closed here.
-        handle = msvcrt.get_osfhandle(fd)
         overlapped = _OVERLAPPED()  # zero-initialized, so Offset/OffsetHigh/hEvent are 0
         flags = _LOCKFILE_EXCLUSIVE_LOCK | _LOCKFILE_FAIL_IMMEDIATELY
-        if _kernel32.LockFileEx(handle, flags, 0, 1, 0, ctypes.byref(overlapped)):
+        if _kernel32.LockFileEx(msvcrt.get_osfhandle(fd), flags, 0, 1, 0, ctypes.byref(overlapped)):
             return True
         err = ctypes.get_last_error()
         if err == _ERROR_LOCK_VIOLATION:
@@ -162,9 +161,8 @@ if sys.platform == "win32":  # pragma: win32 cover
         raise ctypes.WinError(err)
 
     def _unlock_fd(fd: int) -> None:
-        handle = msvcrt.get_osfhandle(fd)
         overlapped = _OVERLAPPED()  # the same offset 0 and one-byte length the lock used
-        if not _kernel32.UnlockFileEx(handle, 0, 1, 0, ctypes.byref(overlapped)):
+        if not _kernel32.UnlockFileEx(msvcrt.get_osfhandle(fd), 0, 1, 0, ctypes.byref(overlapped)):
             raise ctypes.WinError(ctypes.get_last_error())
 
     class WindowsFileLock(BaseFileLock):

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import sys
 from contextlib import suppress
-from errno import EACCES
 from pathlib import Path
 from typing import Final, cast
 
@@ -34,6 +33,14 @@ if sys.platform == "win32":  # pragma: win32 cover
     _CREATE_OPTIONS: Final[int] = _FILE_SYNCHRONOUS_IO_NONALERT | _FILE_NON_DIRECTORY_FILE | _FILE_OPEN_REPARSE_POINT
     _OBJ_CASE_INSENSITIVE: Final[int] = 0x00000040  # Win32 name lookups are case-insensitive
     _OWNER_WRITE: Final[int] = 0o200
+
+    # LockFileEx locks a byte range at an offset carried in OVERLAPPED, independent of the descriptor's file position.
+    # msvcrt.locking starts at the current position instead, so a metadata write between lock and unlock could shift
+    # the byte a later unlock targets; the explicit offset removes that hazard for both the path lock and #608's
+    # descriptor lock.
+    _LOCKFILE_FAIL_IMMEDIATELY: Final[int] = 0x00000001
+    _LOCKFILE_EXCLUSIVE_LOCK: Final[int] = 0x00000002
+    _ERROR_LOCK_VIOLATION: Final[int] = 33  # another handle holds the byte range
 
     # NtCreateFile returns the raw NTSTATUS as its value, where CreateFileW collapses several of these into one
     # ERROR_ACCESS_DENIED. Telling them apart is the point (#604): a name pending deletion or a share conflict is
@@ -67,6 +74,15 @@ if sys.platform == "win32":  # pragma: win32 cover
         _fields_ = (
             ("Status", ctypes.c_void_p),  # a union of NTSTATUS and PVOID, so it is pointer-sized
             ("Information", ctypes.c_void_p),
+        )
+
+    class _OVERLAPPED(ctypes.Structure):  # mirrors the Win32 struct name
+        _fields_ = (
+            ("Internal", ctypes.c_void_p),  # ULONG_PTR: pointer-sized, not DWORD, or the x64 layout corrupts Offset
+            ("InternalHigh", ctypes.c_void_p),
+            ("Offset", wintypes.DWORD),  # the DUMMYUNIONNAME struct, flattened: low 32 bits of the byte offset
+            ("OffsetHigh", wintypes.DWORD),
+            ("hEvent", wintypes.HANDLE),
         )
 
     class _BY_HANDLE_FILE_INFORMATION(ctypes.Structure):  # noqa: N801  # mirrors the Win32 struct name
@@ -113,10 +129,47 @@ if sys.platform == "win32":  # pragma: win32 cover
     _kernel32.CloseHandle.restype = wintypes.BOOL
     _kernel32.GetFileInformationByHandle.argtypes = [wintypes.HANDLE, ctypes.POINTER(_BY_HANDLE_FILE_INFORMATION)]
     _kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+    _kernel32.LockFileEx.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_OVERLAPPED),
+    ]
+    _kernel32.LockFileEx.restype = wintypes.BOOL
+    _kernel32.UnlockFileEx.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_OVERLAPPED),
+    ]
+    _kernel32.UnlockFileEx.restype = wintypes.BOOL
+
+    def _lock_fd_nonblocking(fd: int) -> bool:
+        # One nonblocking exclusive LockFileEx attempt shared by WindowsFileLock and lock_descriptor, over the one-byte
+        # range at offset 0. True on acquisition, False on contention, raise otherwise. The caller owns fd; the handle
+        # from get_osfhandle belongs to the CRT descriptor and must not be closed here.
+        handle = msvcrt.get_osfhandle(fd)
+        overlapped = _OVERLAPPED()  # zero-initialized, so Offset/OffsetHigh/hEvent are 0
+        flags = _LOCKFILE_EXCLUSIVE_LOCK | _LOCKFILE_FAIL_IMMEDIATELY
+        if _kernel32.LockFileEx(handle, flags, 0, 1, 0, ctypes.byref(overlapped)):
+            return True
+        err = ctypes.get_last_error()
+        if err == _ERROR_LOCK_VIOLATION:
+            return False
+        raise ctypes.WinError(err)
+
+    def _unlock_fd(fd: int) -> None:
+        handle = msvcrt.get_osfhandle(fd)
+        overlapped = _OVERLAPPED()  # the same offset 0 and one-byte length the lock used
+        if not _kernel32.UnlockFileEx(handle, 0, 1, 0, ctypes.byref(overlapped)):
+            raise ctypes.WinError(ctypes.get_last_error())
 
     class WindowsFileLock(BaseFileLock):
         """
-        Uses the :func:`msvcrt.locking` function to hard lock the lock file on Windows systems.
+        Uses ``LockFileEx`` to hard lock a byte range of the lock file on Windows systems.
 
         Lock file cleanup: Windows attempts to delete the lock file after release, but deletion is
         not guaranteed in multi-threaded scenarios where another thread holds an open handle. The lock
@@ -133,20 +186,21 @@ if sys.platform == "win32":  # pragma: win32 cover
             if fd is None:
                 return  # open contention (share conflict or a name pending deletion); let the retry loop try again
             try:
-                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-            except OSError as exception:
+                locked = _lock_fd_nonblocking(fd)
+            except BaseException:
                 os.close(fd)
-                if exception.errno != EACCES:  # EACCES means another holder owns the byte-range lock
-                    raise
-            else:
+                raise
+            if locked:
                 self._context.lock_file_fd = fd
+            else:
+                os.close(fd)  # another holder owns the byte-range lock; let the retry loop try again
 
         def _release(self) -> None:
             fd = cast("int", self._context.lock_file_fd)
-            # Retain the descriptor until the OS unlock succeeds: if msvcrt.locking raises, the byte-range lock is
-            # still held, so is_locked must keep reporting held rather than losing the fd. Only after the unlock
-            # commits do close and unlink run as post-unlock cleanup; their failure cannot make the lock held again.
-            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            # Retain the descriptor until the OS unlock succeeds: if UnlockFileEx raises, the byte-range lock is still
+            # held, so is_locked must keep reporting held rather than losing the fd. Only after the unlock commits do
+            # close and unlink run as post-unlock cleanup; their failure cannot make the lock held again.
+            _unlock_fd(fd)
             self._context.lock_file_fd = None
             self._close_released_fd(fd, default_suppresses=False)
             with suppress(OSError):
@@ -254,7 +308,7 @@ if sys.platform == "win32":  # pragma: win32 cover
 else:  # pragma: win32 no cover
 
     class WindowsFileLock(BaseFileLock):
-        """Uses the :func:`msvcrt.locking` function to hard lock the lock file on Windows systems."""
+        """Uses ``LockFileEx`` to hard lock a byte range of the lock file on Windows systems."""
 
         def _acquire(self) -> None:
             raise NotImplementedError

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1875,16 +1875,27 @@ def test_filelock_and_descriptor_contend(tmp_path: Path, direction: str) -> None
 
 
 @_UNIX_FLOCK_ONLY
-def test_lock_descriptor_touches_no_paths(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:
     from filelock import lock_descriptor, unlock_descriptor
 
-    fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
+    path = tmp_path / "a"
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
     try:
-        spies = {name: mocker.spy(os, name) for name in ("open", "close", "unlink", "ftruncate", "fchmod")}
+        os.write(fd, b"payload")
+        before = os.fstat(fd)
         assert lock_descriptor(fd, blocking=False) is True
         unlock_descriptor(fd)
-        for name, spy in spies.items():
-            assert spy.call_count == 0, name  # the adapter only locks and unlocks; it owns no path work
+        after = os.fstat(fd)
+        # The adapter works purely on the descriptor: our fd stays open on the same inode with its size and mode
+        # intact, and the file keeps its contents. That rules out any open, close, unlink, truncate or chmod on our
+        # behalf without spying on hot global os functions, which unrelated tempfile cleanup would race and pollute.
+        assert (after.st_ino, after.st_dev, after.st_size, after.st_mode) == (
+            before.st_ino,
+            before.st_dev,
+            before.st_size,
+            before.st_mode,
+        )
+        assert path.read_bytes() == b"payload"
     finally:
         os.close(fd)
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1458,7 +1458,7 @@ def test_unix_context_exit_propagates_unlock_failure(tmp_path: Path, mocker: Moc
 def test_windows_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))
     lock.acquire()
-    mocker.patch("filelock._windows.msvcrt.locking", side_effect=[OSError(EIO, "unlock failed"), None])
+    mocker.patch("filelock._windows._unlock_fd", side_effect=[OSError(EIO, "unlock failed"), None])
     with pytest.raises(OSError, match="unlock failed"):
         lock.release()
     assert lock.is_locked
@@ -1807,3 +1807,112 @@ def test_singleton_rejects_different_fallback_to_soft(tmp_path: Path) -> None:
             FileLock(path, is_singleton=True, fallback_to_soft=False)
     finally:
         first.release(force=True)
+
+
+def test_lock_descriptor_roundtrip(tmp_path: Path) -> None:
+    from filelock import lock_descriptor, unlock_descriptor
+
+    fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
+    try:
+        assert lock_descriptor(fd, blocking=False) is True
+        os.write(fd, b"held")  # the descriptor stays usable while locked
+        unlock_descriptor(fd)
+        os.lseek(fd, 0, os.SEEK_SET)
+        assert os.read(fd, 4) == b"held"  # and after unlock
+    finally:
+        os.close(fd)
+
+
+def test_lock_descriptor_nonblocking_contention(tmp_path: Path) -> None:
+    from filelock import lock_descriptor, unlock_descriptor
+
+    path = str(tmp_path / "a")
+    holder = os.open(path, os.O_RDWR | os.O_CREAT)
+    contender = os.open(path, os.O_RDWR | os.O_CREAT)
+    try:
+        assert lock_descriptor(holder, blocking=False) is True
+        assert lock_descriptor(contender, blocking=False) is False  # a second descriptor sees the lock
+        unlock_descriptor(holder)
+        assert lock_descriptor(contender, blocking=False) is True  # free once the holder releases
+        unlock_descriptor(contender)
+    finally:
+        os.close(holder)
+        os.close(contender)
+
+
+def test_lock_descriptor_invalid_fd_raises(tmp_path: Path) -> None:
+    from filelock import lock_descriptor
+
+    fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
+    os.close(fd)  # a closed descriptor is invalid; the native lock must raise, not silently succeed or contend
+    with pytest.raises(OSError, match=r"Bad file descriptor|not open|invalid"):
+        lock_descriptor(fd, blocking=False)
+
+
+@pytest.mark.parametrize("direction", ["filelock_first", "descriptor_first"])
+def test_filelock_and_descriptor_contend(tmp_path: Path, direction: str) -> None:
+    from filelock import lock_descriptor, unlock_descriptor
+
+    path = str(tmp_path / "a")
+    lock = FileLock(path)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT)
+    try:
+        if direction == "filelock_first":
+            lock.acquire()
+            assert lock_descriptor(fd, blocking=False) is False  # the path lock blocks the descriptor lock
+            lock.release()
+            assert lock_descriptor(fd, blocking=False) is True
+            unlock_descriptor(fd)
+        else:
+            assert lock_descriptor(fd, blocking=False) is True
+            with pytest.raises(Timeout):
+                lock.acquire(timeout=0.2)  # the descriptor lock blocks the path lock
+            unlock_descriptor(fd)
+            lock.acquire()
+            lock.release()
+    finally:
+        os.close(fd)
+
+
+@_UNIX_FLOCK_ONLY
+def test_lock_descriptor_touches_no_paths(tmp_path: Path, mocker: MockerFixture) -> None:
+    from filelock import lock_descriptor, unlock_descriptor
+
+    fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
+    try:
+        spies = {name: mocker.spy(os, name) for name in ("open", "close", "unlink", "ftruncate", "fchmod")}
+        assert lock_descriptor(fd, blocking=False) is True
+        unlock_descriptor(fd)
+        for name, spy in spies.items():
+            assert spy.call_count == 0, name  # the adapter only locks and unlocks; it owns no path work
+    finally:
+        os.close(fd)
+
+
+@_UNIX_FLOCK_ONLY
+def test_unlock_descriptor_failure_allows_retry(tmp_path: Path, mocker: MockerFixture) -> None:
+    from filelock import lock_descriptor, unlock_descriptor
+
+    fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
+    try:
+        assert lock_descriptor(fd, blocking=False) is True
+        mocker.patch("filelock._unix.fcntl.flock", side_effect=[OSError(EIO, "unlock failed"), None])
+        with pytest.raises(OSError, match="unlock failed"):
+            unlock_descriptor(fd)
+        unlock_descriptor(fd)  # the same descriptor can retry
+    finally:
+        os.close(fd)
+
+
+def test_lock_descriptor_blocking_retries_until_free(tmp_path: Path, mocker: MockerFixture) -> None:
+    from filelock import lock_descriptor
+
+    fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
+    attempt = mocker.patch("filelock._descriptor._lock_fd_nonblocking", side_effect=[False, True])
+    sleep = mocker.patch("filelock._descriptor.time.sleep")
+    try:
+        assert lock_descriptor(fd, blocking=True, poll_interval=0.01) is True
+        assert attempt.call_count == 2  # retried once after contention
+        sleep.assert_called_once_with(0.01)
+    finally:
+        os.close(fd)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -19,7 +19,17 @@ from weakref import WeakValueDictionary
 
 import pytest
 
-from filelock import BaseFileLock, ContextErrorPolicy, FileLock, SoftFileLock, Timeout, UnixFileLock, WindowsFileLock
+from filelock import (
+    BaseFileLock,
+    ContextErrorPolicy,
+    FileLock,
+    SoftFileLock,
+    Timeout,
+    UnixFileLock,
+    WindowsFileLock,
+    lock_descriptor,
+    unlock_descriptor,
+)
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup, ExceptionGroup
@@ -1810,8 +1820,6 @@ def test_singleton_rejects_different_fallback_to_soft(tmp_path: Path) -> None:
 
 
 def test_lock_descriptor_roundtrip(tmp_path: Path) -> None:
-    from filelock import lock_descriptor, unlock_descriptor
-
     fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
     try:
         assert lock_descriptor(fd, blocking=False) is True
@@ -1824,8 +1832,6 @@ def test_lock_descriptor_roundtrip(tmp_path: Path) -> None:
 
 
 def test_lock_descriptor_nonblocking_contention(tmp_path: Path) -> None:
-    from filelock import lock_descriptor, unlock_descriptor
-
     path = str(tmp_path / "a")
     holder = os.open(path, os.O_RDWR | os.O_CREAT)
     contender = os.open(path, os.O_RDWR | os.O_CREAT)
@@ -1841,8 +1847,6 @@ def test_lock_descriptor_nonblocking_contention(tmp_path: Path) -> None:
 
 
 def test_lock_descriptor_invalid_fd_raises(tmp_path: Path) -> None:
-    from filelock import lock_descriptor
-
     fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
     os.close(fd)  # a closed descriptor is invalid; the native lock must raise, not silently succeed or contend
     with pytest.raises(OSError, match=r"Bad file descriptor|not open|invalid"):
@@ -1851,8 +1855,6 @@ def test_lock_descriptor_invalid_fd_raises(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("direction", ["filelock_first", "descriptor_first"])
 def test_filelock_and_descriptor_contend(tmp_path: Path, direction: str) -> None:
-    from filelock import lock_descriptor, unlock_descriptor
-
     path = str(tmp_path / "a")
     lock = FileLock(path)
     fd = os.open(path, os.O_RDWR | os.O_CREAT)
@@ -1876,8 +1878,6 @@ def test_filelock_and_descriptor_contend(tmp_path: Path, direction: str) -> None
 
 @_UNIX_FLOCK_ONLY
 def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:
-    from filelock import lock_descriptor, unlock_descriptor
-
     path = tmp_path / "a"
     fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
     try:
@@ -1902,8 +1902,6 @@ def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:
 
 @_UNIX_FLOCK_ONLY
 def test_unlock_descriptor_failure_allows_retry(tmp_path: Path, mocker: MockerFixture) -> None:
-    from filelock import lock_descriptor, unlock_descriptor
-
     fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
     try:
         assert lock_descriptor(fd, blocking=False) is True
@@ -1916,14 +1914,17 @@ def test_unlock_descriptor_failure_allows_retry(tmp_path: Path, mocker: MockerFi
 
 
 def test_lock_descriptor_blocking_retries_until_free(tmp_path: Path, mocker: MockerFixture) -> None:
-    from filelock import lock_descriptor
-
-    fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
-    attempt = mocker.patch("filelock._descriptor._lock_fd_nonblocking", side_effect=[False, True])
-    sleep = mocker.patch("filelock._descriptor.time.sleep")
+    path = str(tmp_path / "a")
+    holder = os.open(path, os.O_RDWR | os.O_CREAT)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT)
+    assert lock_descriptor(holder, blocking=False) is True
+    # Drive the real blocking loop: the first attempt sees contention, the mocked sleep frees the holder, and the
+    # second attempt wins. Only the clock is mocked, so a single sleep call proves exactly one retry happened.
+    sleep = mocker.patch("filelock._descriptor.time.sleep", side_effect=lambda _: unlock_descriptor(holder))
     try:
         assert lock_descriptor(fd, blocking=True, poll_interval=0.01) is True
-        assert attempt.call_count == 2  # retried once after contention
         sleep.assert_called_once_with(0.01)
+        unlock_descriptor(fd)
     finally:
+        os.close(holder)
         os.close(fd)


### PR DESCRIPTION
Callers that already hold an open descriptor, for example one shared across a fork or handed in by a framework, had no way to take filelock's native OS lock on it without going through a path and letting `FileLock` open, truncate, and unlink for them. This adds `lock_descriptor(fd, *, blocking=True, poll_interval=0.05)` and `unlock_descriptor(fd)`, a minimal adapter that locks the descriptor and nothing else: it never opens, closes, truncates, unlinks, chmods, canonicalizes, or falls back, and the caller owns the descriptor before, during, and after.

To make the two APIs contend on the *same* lock, each native backend now exposes one nonblocking lock attempt and one unlock, and both `FileLock` and the descriptor functions call them. On Unix that is `flock(LOCK_EX | LOCK_NB)` classifying `EACCES`/`EAGAIN`/`EWOULDBLOCK` as contention. On Windows it replaces `msvcrt.locking` with `LockFileEx`/`UnlockFileEx` on the handle from `msvcrt.get_osfhandle`, locking one byte at offset 0. 🔒 `msvcrt.locking` locks relative to the descriptor's *current file position*, so a metadata write or seek between lock and unlock could target a different byte; `LockFileEx` carries the offset explicitly in an `OVERLAPPED`, which removes that hazard for the path lock and the descriptor lock alike.

The first version stays deliberately small: an integer descriptor, no timeout, recursion, singleton, lifetime, or async policy. Those live on `FileLock`; an application that wants the descriptor API in async code can run the blocking call in an executor or drive `blocking=False` from its own loop. On Windows the descriptor must be synchronous, which is what filelock's own `NtCreateFile` open already produces.

The `LockFileEx` recipe here follows the Win32 byte-range-locking documentation and the `portalocker` reference implementation. (An earlier plan cited PostgreSQL; on checking, PostgreSQL's data-directory interlock is a PID/nonce scheme, not `LockFileEx`, so it is not the model.)

Fixes #608
