### PR TITLE
🐛 fix(api): canonicalize singleton keys without following a final symlink

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -86,7 +86,22 @@ def _raise_body_and_release(body_error: BaseException, release_error: BaseExcept
 
 # On Windows os.path.realpath calls CreateFileW with share_mode=0, which blocks concurrent DeleteFileW and causes
 # livelocks under threaded contention with SoftFileLock. os.path.abspath is purely string-based and avoids this.
-_canonical: Final[Callable[[str], str]] = os.path.abspath if sys.platform == "win32" else os.path.realpath
+_resolve_dir: Final[Callable[[str], str]] = os.path.abspath if sys.platform == "win32" else os.path.realpath
+
+
+def _canonical(path: str | os.PathLike[str]) -> str:
+    """
+    Return one stable key for *path*, collapsing equivalent spellings without following a final symlink.
+
+    Relative, absolute, and ``./`` spellings of one lock file must map to a single singleton instance, deadlock-registry
+    entry, and removal key. Resolving the whole path with ``realpath`` would follow a final symlink and alias a lock
+    target the backend deliberately rejects, so the registry identity would differ from the backend's. Resolving only
+    the parent directory and re-appending the literal final component collapses the equivalent spellings while keeping a
+    final symlink a distinct key. On Windows the parent is resolved with ``abspath`` so junctions and reparse points are
+    not followed either.
+    """
+    parent, name = os.path.split(os.fspath(path))
+    return os.path.join(_resolve_dir(parent or os.curdir), name)  # noqa: PTH118  # string join matches abspath/realpath
 
 
 def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str) -> float | None:
@@ -165,10 +180,13 @@ class FileLockMeta(ABCMeta):
         # reentrant locking across instances end up with two "singletons" and acquire()'s deadlock check then
         # rejects a legitimate reentrant acquire; the unguarded writes to the WeakValueDictionary are a data
         # race besides. ReadWriteLock and SoftReadWriteLock already guard their singleton caches this way.
+        # Key the cache on the canonical form so equivalent spellings of one path share a singleton, and it matches the
+        # deadlock-registry key acquire() uses.
+        singleton_key = _canonical(lock_file)
         with cls._instances_lock:
-            if (instance := cls._instances.get(str(lock_file))) is None:
+            if (instance := cls._instances.get(singleton_key)) is None:
                 instance = cls._create_instance(lock_file, params)
-                cls._instances[str(lock_file)] = instance
+                cls._instances[singleton_key] = instance
                 return instance
 
         params_to_check = {

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -454,13 +454,14 @@ async def test_different_tasks_no_false_positive(tmp_path: Path, lock_type: type
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio
 async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
-    lock_path = tmp_path / "test.lock"
-    symlink_path = tmp_path / "link.lock"
-    symlink_path.symlink_to(lock_path)
+    # A symlinked parent directory resolves to the same canonical key; the final component stays literal.
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    (tmp_path / "link").symlink_to(real_dir)
 
-    lock1 = lock_type(lock_path)
+    lock1 = lock_type(str(real_dir / "test.lock"))
     async with lock1:
-        lock2 = lock_type(symlink_path)
+        lock2 = lock_type(str(tmp_path / "link" / "test.lock"))
         with pytest.raises(RuntimeError, match="Deadlock"):
             await lock2.acquire()
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1741,7 +1741,13 @@ def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
     finally:
         on_link.release(force=True)
         on_target.release(force=True)
-    # and the backend still refuses to lock through the final symlink (O_NOFOLLOW rejects it)
+
+
+@_UNIX_FLOCK_ONLY
+def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:
+    (tmp_path / "target").write_text("")
+    (tmp_path / "link").symlink_to(tmp_path / "target")
+    # Keeping the final symlink a distinct key is safe because the backend still refuses to lock through it.
     with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link"):
         FileLock(str(tmp_path / "link")).acquire()
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1295,13 +1295,15 @@ def test_different_threads_no_false_positive(tmp_path: Path, lock_type: type[Bas
 @pytest.mark.skipif(sys.platform == "win32", reason="unix-only symlink test")
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
-    lock_path = tmp_path / "test.lock"
-    symlink_path = tmp_path / "link.lock"
-    symlink_path.symlink_to(lock_path)
+    # A symlinked parent directory resolves to the same canonical key (the final component is kept literal, so a final
+    # symlink stays distinct — see test_final_symlink_stays_a_distinct_key).
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    (tmp_path / "link").symlink_to(real_dir)
 
-    lock1 = lock_type(lock_path)
+    lock1 = lock_type(str(real_dir / "test.lock"))
     with lock1:
-        lock2 = lock_type(symlink_path)
+        lock2 = lock_type(str(tmp_path / "link" / "test.lock"))
         with pytest.raises(RuntimeError, match="Deadlock"):
             lock2.acquire()
 
@@ -1701,3 +1703,55 @@ def test_singleton_rejects_different_close_policy(tmp_path: Path) -> None:
             FileLock(path, is_singleton=True, close_error_policy="suppress")
     finally:
         first.release(force=True)
+
+
+def test_singleton_shares_across_equivalent_spellings(tmp_path: Path) -> None:
+    (tmp_path / "sub").mkdir()
+    absolute = FileLock(str(tmp_path / "a"), is_singleton=True)
+    dot = FileLock(str(tmp_path) + "/./a", is_singleton=True)
+    dotdot = FileLock(str(tmp_path / "sub") + "/../a", is_singleton=True)
+    try:
+        assert absolute is dot is dotdot  # one instance for equivalent spellings of one path
+    finally:
+        absolute.release(force=True)
+
+
+@_UNIX_FLOCK_ONLY
+def test_singleton_shares_through_symlinked_parent(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    (tmp_path / "link").symlink_to(real)
+    via_real = FileLock(str(real / "a"), is_singleton=True)
+    via_link = FileLock(str(tmp_path / "link" / "a"), is_singleton=True)
+    try:
+        assert via_real is via_link  # a symlinked parent directory resolves to the same key
+    finally:
+        via_real.release(force=True)
+
+
+@_UNIX_FLOCK_ONLY
+def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.write_text("")
+    (tmp_path / "link").symlink_to(target)
+    on_link = FileLock(str(tmp_path / "link"), is_singleton=True)
+    on_target = FileLock(str(target), is_singleton=True)
+    try:
+        assert on_link is not on_target  # the final component is not resolved, so the symlink is its own key
+    finally:
+        on_link.release(force=True)
+        on_target.release(force=True)
+    # and the backend still refuses to lock through the final symlink (O_NOFOLLOW rejects it)
+    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link"):
+        FileLock(str(tmp_path / "link")).acquire()
+
+
+def test_separate_lock_classes_keep_separate_registries(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    native = FileLock(path, is_singleton=True)
+    soft = SoftFileLock(path, is_singleton=True)
+    try:
+        assert native is not soft  # each class caches its own singletons
+    finally:
+        native.release(force=True)
+        soft.release(force=True)


### PR DESCRIPTION
Two spellings of one lock path could produce two `is_singleton` instances. The singleton cache keyed on the raw string a caller passed, while the deadlock registry keyed on `realpath` of the whole path, so `FileLock("a", is_singleton=True)` and `FileLock("/abs/a", is_singleton=True)` cached separately and their reentrant acquire then tripped the cross-instance deadlock check. Registry insertion, deadlock detection, and registry removal each need one canonical key. Issue #599 reports this.

The unsafe part of resolving it is `realpath` on the *whole* path: it follows a final symlink, and the path-safety work deliberately rejects a final symlink as a lock target, so a key that resolved that link would alias the rejected path with its target and make the registry identity differ from what the backend actually locks. The fix resolves only the parent directory and re-appends the literal final component, through one `_canonical` helper now shared by the cache, the registry, and removal. Equivalent spellings — relative, absolute, `./`, or a symlinked parent directory — collapse to one key, while a final symlink stays a distinct key that the backend continues to refuse. 🔗 On Windows the parent is resolved with `abspath` rather than `realpath`, so junctions and reparse points are not followed either.

Behavior only changes for callers that were accidentally getting two singletons for one path; a lock through a final symlink keeps its own identity, matching the backend that rejects it. This supersedes #599's original approach, which resolved the full path with `realpath` and aliased the final symlink.

Fixes #599
