### PR TITLE
✨ feat(unix): add fallback_to_soft opt-out for native locks

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -153,6 +153,7 @@ class FileLockMeta(ABCMeta):
         lifetime: float | None = None,
         context_error_policy: ContextErrorPolicy = "chain",
         close_error_policy: CloseErrorPolicy = "default",
+        fallback_to_soft: bool = True,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
         lifetime = _resolve_lifetime(lifetime, supported=cls._lifetime_supported, cls_name=cls.__name__)
@@ -170,6 +171,7 @@ class FileLockMeta(ABCMeta):
             "lifetime": lifetime,
             "context_error_policy": context_error_policy,
             "close_error_policy": close_error_policy,
+            "fallback_to_soft": fallback_to_soft,
             **kwargs,
         }
         if not is_singleton:
@@ -198,6 +200,7 @@ class FileLockMeta(ABCMeta):
             "lifetime": (lifetime, instance.lifetime),
             "context_error_policy": (context_error_policy, instance.context_error_policy),
             "close_error_policy": (close_error_policy, instance.close_error_policy),
+            "fallback_to_soft": (fallback_to_soft, instance.fallback_to_soft),
         }
         non_matching_params = {
             name: (passed_param, set_param)
@@ -220,7 +223,7 @@ class FileLockMeta(ABCMeta):
         return super().__call__(lock_file, **{key: value for key, value in params.items() if key in present_params})
 
 
-class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
+class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa: PLR0904  # public config properties
     """
     Abstract base class for a file lock object.
 
@@ -259,6 +262,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
         lifetime: float | None = None,
         context_error_policy: ContextErrorPolicy = "chain",
         close_error_policy: CloseErrorPolicy = "default",
+        fallback_to_soft: bool = True,
     ) -> None:
         """
         Create a new lock object.
@@ -295,12 +299,17 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             FUSE/Docker ``EIO``, Windows propagates); ``"raise"`` always propagates the ``OSError``; ``"suppress"``
             always ignores it. Held state is released either way. It does not affect unlock failures or lock-file
             deletion.
+        :param fallback_to_soft: for :class:`UnixFileLock`, whether to switch to :class:`SoftFileLock` when the
+            filesystem's ``flock`` returns ``ENOSYS``. ``True`` (the default) keeps the historical fallback;
+            ``False`` fails closed, letting the ``ENOSYS`` propagate so a caller that needs kernel-enforced
+            locking is never silently downgraded. It has no effect on Windows or :class:`SoftFileLock`.
 
         """
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
         self._context_error_policy = context_error_policy  # already validated by the metaclass
         self._close_error_policy = close_error_policy  # already validated by the metaclass
+        self._fallback_to_soft = fallback_to_soft
 
         # External code reaches these values through the public properties, not through _context directly.
         kwargs: dict[str, Any] = {
@@ -358,6 +367,19 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):
             if self._close_error_policy == "suppress" or (self._close_error_policy == "default" and default_suppresses):
                 return
             raise
+
+    @property
+    def fallback_to_soft(self) -> bool:
+        """
+        Whether a :class:`FileLock` falls back to :class:`SoftFileLock` when the filesystem lacks ``flock``.
+
+        Only :class:`UnixFileLock` acts on it: when ``False`` an ``ENOSYS`` from ``flock`` propagates instead of
+        switching to existence-lock semantics.
+
+        .. versionadded:: 3.27.0
+
+        """
+        return self._fallback_to_soft
 
     @property
     def lock_file(self) -> str:

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -73,13 +73,23 @@ else:  # pragma: win32 no cover
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except OSError as exception:
-                os.close(fd)
                 if exception.errno == ENOSYS:
+                    # The filesystem does not implement flock. Capture the opened file's identity before closing so
+                    # the cleanup below removes only this attempt's placeholder, not a peer's replacement.
+                    identity: tuple[int, int] | None = None
                     with suppress(OSError):
-                        Path(self.lock_file).unlink()
+                        identity = (fstat := os.fstat(fd)).st_dev, fstat.st_ino
+                    os.close(fd)
+                    if not self._fallback_to_soft:
+                        raise  # fail closed: the caller opted out of switching to existence-lock semantics (#603)
+                    with suppress(OSError):
+                        current = os.lstat(self.lock_file)
+                        if identity == (current.st_dev, current.st_ino):
+                            Path(self.lock_file).unlink()
                     self._fallback_to_soft_lock()
                     self._acquire()
                     return
+                os.close(fd)
                 if exception.errno not in {EAGAIN, EWOULDBLOCK}:
                     raise
             else:

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -58,6 +58,7 @@ class AsyncFileLockMeta(FileLockMeta):
         lifetime: float | None = None,
         context_error_policy: ContextErrorPolicy = "chain",
         close_error_policy: CloseErrorPolicy = "default",
+        fallback_to_soft: bool = True,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -76,6 +77,7 @@ class AsyncFileLockMeta(FileLockMeta):
             lifetime=lifetime,
             context_error_policy=context_error_policy,
             close_error_policy=close_error_policy,
+            fallback_to_soft=fallback_to_soft,
             loop=loop,
             run_in_executor=run_in_executor,
             executor=executor,
@@ -105,6 +107,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         lifetime: float | None = None,
         context_error_policy: ContextErrorPolicy = "chain",
         close_error_policy: CloseErrorPolicy = "default",
+        fallback_to_soft: bool = True,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -143,6 +146,8 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         :param close_error_policy: for native locks (:class:`AsyncFileLock`), what to do with an ``os.close`` failure
             after the OS unlock has already committed. ``"default"`` keeps each platform's historical behavior,
             ``"raise"`` always propagates the ``OSError``, and ``"suppress"`` always ignores it.
+        :param fallback_to_soft: for :class:`AsyncFileLock`, whether to fall back to soft existence locking when
+            ``flock`` returns ``ENOSYS``. ``True`` (default) keeps the fallback; ``False`` propagates the error.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.
@@ -152,6 +157,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         self._is_singleton = is_singleton
         self._context_error_policy = context_error_policy  # already validated by the metaclass
         self._close_error_policy = close_error_policy  # already validated by the metaclass
+        self._fallback_to_soft = fallback_to_soft
 
         # External code goes through this class's properties, not the context directly.
         kwargs: dict[str, Any] = {

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
-from errno import EIO
+from errno import EIO, ENOSYS
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING
 
@@ -636,9 +636,7 @@ async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: Mo
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
 async def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
-    import errno
-
-    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(errno.ENOSYS, "no flock"))
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = AsyncFileLock(str(tmp_path / "a"), fallback_to_soft=False)
     with pytest.raises(OSError, match="no flock"):
         await lock.acquire()

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -631,3 +631,16 @@ async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: Mo
     _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
     await lock.release()
     assert not lock.is_locked
+
+
+@_UNIX_FLOCK_ONLY
+@pytest.mark.asyncio
+async def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
+    import errno
+
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(errno.ENOSYS, "no flock"))
+    lock = AsyncFileLock(str(tmp_path / "a"), fallback_to_soft=False)
+    with pytest.raises(OSError, match="no flock"):
+        await lock.acquire()
+    assert not lock.is_locked
+    assert type(lock).__name__ == "AsyncUnixFileLock"  # not swapped to the soft class

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1761,3 +1761,49 @@ def test_separate_lock_classes_keep_separate_registries(tmp_path: Path) -> None:
     finally:
         native.release(force=True)
         soft.release(force=True)
+
+
+@_UNIX_FLOCK_ONLY
+def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
+    lock = FileLock(str(tmp_path / "a"), fallback_to_soft=False)
+    with pytest.raises(OSError, match="no flock") as info:
+        lock.acquire()
+    assert info.value.errno == ENOSYS  # the original error, not a soft-lock timeout
+    assert not lock.is_locked
+    assert type(lock).__name__ == "UnixFileLock"  # the class is not swapped to SoftFileLock
+    assert lock.lock_counter == 0  # the failed acquire left no holder count
+
+
+@_UNIX_FLOCK_ONLY
+def test_fallback_to_soft_default_switches_to_soft(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
+    lock = FileLock(str(tmp_path / "a"))  # default fallback_to_soft=True
+    with pytest.warns(UserWarning, match="falling back to SoftFileLock"):
+        lock.acquire()
+    try:
+        assert lock.is_locked
+        assert isinstance(lock, SoftFileLock)  # switched to existence-lock semantics
+    finally:
+        lock.release()
+
+
+@_UNIX_FLOCK_ONLY
+def test_fallback_disabled_recursive_reraises(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
+    lock = FileLock(str(tmp_path / "a"), fallback_to_soft=False)
+    for _ in range(2):  # a repeat acquire keeps failing the same way, never a soft downgrade
+        with pytest.raises(OSError, match="no flock"):
+            lock.acquire()
+        assert not lock.is_locked
+
+
+@_UNIX_FLOCK_ONLY
+def test_singleton_rejects_different_fallback_to_soft(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    first = FileLock(path, is_singleton=True, fallback_to_soft=True)
+    try:
+        with pytest.raises(ValueError, match="fallback_to_soft"):
+            FileLock(path, is_singleton=True, fallback_to_soft=False)
+    finally:
+        first.release(force=True)


### PR DESCRIPTION
When a filesystem reports that it does not implement `flock` (an `ENOSYS` error, seen on some network and container mounts), `UnixFileLock` quietly rewrites itself into a `SoftFileLock` and locks by file existence instead. That trade is right for many callers, but a process that relies on kernel-enforced mutual exclusion, for example to guard a shared device or a cross-user resource, was downgraded to advisory existence locking with no warning it could act on and no way to refuse. Issue #603 asks for that refusal.

This adds a `fallback_to_soft` argument, defaulting to `True` so existing behavior is unchanged. With `False`, an `ENOSYS` from `flock` propagates: the native descriptor closes, the lock class is not swapped, no pathname is unlinked, and no fallback warning fires, so the caller sees the real error and can decide for itself. 🔒 Only `ENOSYS` is treated this way — permission errors, invalid paths, and other `OSError` values keep their original meaning, since `ENOSYS` alone means the operation is unimplemented rather than that it failed. The argument threads through the base context, the singleton identity check, and the async variants, and has no effect on Windows or `SoftFileLock`.

While here, the default fallback path is tightened to remove only the placeholder file this acquisition opened, checked by inode identity, rather than unlinking the pathname blindly, so a peer's replacement is never deleted on the way into soft mode.

Fixes #603
