### PR TITLE
📝 docs: correct Unix lock-file cleanup and flock claims

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -145,14 +145,14 @@ the lock file additionally stores the process creation time to guard against PID
     correctness.
 
 **Unix and macOS**
-    Uses the :class:`UnixFileLock <filelock.UnixFileLock>` class, backed by ``fcntl.flock``. This is the POSIX standard
-    for file locking and enforced by the kernel.
+    Uses the :class:`UnixFileLock <filelock.UnixFileLock>` class, backed by the kernel's ``fcntl.flock`` interface. The
+    interface is common on Unix systems but is not specified by POSIX. The lock is exclusive and enforced by the kernel.
 
-    Works best on local filesystems. Network filesystems (NFS) may have issues; locking isn't always reliable on NFS even
-    in POSIX-compliant systems.
+    Works best on local filesystems. Network filesystems (NFS) may have issues; locking isn't always reliable on NFS.
 
-    Lock file cleanup: Unix and macOS delete the lock file reliably after release, even in multi-threaded scenarios.
-    Unlike Windows, Unix allows unlinking files that other processes have open.
+    Lock file cleanup: the native lock file remains after release. A persistent empty file does not indicate ownership.
+    Keeping one pathname prevents contenders from coordinating through different inodes, which would break mutual
+    exclusion; remove the file only after the complete lock protocol has stopped using it.
 
 **Other platforms without fcntl**
     Falls back to :class:`SoftFileLock <filelock.SoftFileLock>` and emits a warning. The lock is not enforced by the OS,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -126,7 +126,7 @@ Choose the right lock for your use case:
     .. grid-item-card::
         **Unix / macOS**
 
-        Uses ``fcntl.flock``. POSIX standard, kernel-enforced.
+        Uses ``fcntl.flock``. Common on Unix but not POSIX; kernel-enforced.
 
         - ✓ Native support
         - ✓ Stale detection


### PR DESCRIPTION
The concepts guide told readers that Unix and macOS delete the native lock file after release. `UnixFileLock._release` does the opposite: it leaves the file in place on purpose. Removing a locked pathname lets a waiter create and lock a fresh inode while another process still holds the old one, so two processes coordinating through the same path end up on different inodes and the lock stops being mutually exclusive. A reader who trusted the old text might treat a leftover empty lock file as an orphan and delete it, reintroducing exactly that hazard.

This rewrites the Unix cleanup paragraph to say the file remains after release and that its presence does not indicate ownership, and corrects the adjacent claim that `fcntl.flock` is the POSIX standard: `flock` is common on Unix but is not specified by POSIX (the POSIX byte-range API is `fcntl`). The same "POSIX standard" phrasing on the landing page is fixed too. Windows best-effort deletion and the soft existence-lock's deletion stay in their own paragraphs, since those backends really do remove the file.

Fixes #609
