### PR TITLE
✨ feat(api): add preserve_lock_file to keep the lock pathname

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -124,6 +124,15 @@ def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str)
     return lifetime
 
 
+def _resolve_preserve_lock_file(preserve: bool, *, supported: bool, cls_name: str) -> bool:  # noqa: FBT001
+    # An existence lock unlinks its marker to release, so preserving the pathname would defeat unlocking. Reject the
+    # request rather than silently ignore it, since a caller asking for a stable identity must know it cannot be kept.
+    if preserve and not supported:
+        msg = f"preserve_lock_file=True is not supported by {cls_name}: unlinking its marker is how it releases"
+        raise ValueError(msg)
+    return preserve
+
+
 class _ThreadLocalRegistry(local):
     def __init__(self) -> None:
         super().__init__()
@@ -154,6 +163,7 @@ class FileLockMeta(ABCMeta):
         context_error_policy: ContextErrorPolicy = "chain",
         close_error_policy: CloseErrorPolicy = "default",
         fallback_to_soft: bool = True,
+        preserve_lock_file: bool = False,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
         lifetime = _resolve_lifetime(lifetime, supported=cls._lifetime_supported, cls_name=cls.__name__)
@@ -161,6 +171,9 @@ class FileLockMeta(ABCMeta):
         # __del__ then trips over the missing context.
         context_error_policy = _resolve_context_error_policy(context_error_policy)
         close_error_policy = _resolve_close_error_policy(close_error_policy)
+        preserve_lock_file = _resolve_preserve_lock_file(
+            preserve_lock_file, supported=cls._preserve_lock_file_supported, cls_name=cls.__name__
+        )
         params = {
             "timeout": timeout,
             "mode": mode,
@@ -172,6 +185,7 @@ class FileLockMeta(ABCMeta):
             "context_error_policy": context_error_policy,
             "close_error_policy": close_error_policy,
             "fallback_to_soft": fallback_to_soft,
+            "preserve_lock_file": preserve_lock_file,
             **kwargs,
         }
         if not is_singleton:
@@ -201,6 +215,7 @@ class FileLockMeta(ABCMeta):
             "context_error_policy": (context_error_policy, instance.context_error_policy),
             "close_error_policy": (close_error_policy, instance.close_error_policy),
             "fallback_to_soft": (fallback_to_soft, instance.fallback_to_soft),
+            "preserve_lock_file": (preserve_lock_file, instance.preserve_lock_file),
         }
         non_matching_params = {
             name: (passed_param, set_param)
@@ -243,6 +258,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     #: unlinking a pathname); native OS locks leave it ``False`` since a kernel lock cannot be revoked by file age.
     _lifetime_supported: bool = False
 
+    #: Whether :attr:`preserve_lock_file` may be ``True``. Native locks keep the pathname on release, so they support
+    #: it; existence locks unlink their marker to release and reject it.
+    _preserve_lock_file_supported: bool = True
+
     def __init_subclass__(cls, **kwargs: dict[str, Any]) -> None:
         """Give each lock subclass its own singleton registry and lock."""
         super().__init_subclass__(**kwargs)
@@ -263,6 +282,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         context_error_policy: ContextErrorPolicy = "chain",
         close_error_policy: CloseErrorPolicy = "default",
         fallback_to_soft: bool = True,
+        preserve_lock_file: bool = False,
     ) -> None:
         """
         Create a new lock object.
@@ -303,6 +323,12 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             filesystem's ``flock`` returns ``ENOSYS``. ``True`` (the default) keeps the historical fallback;
             ``False`` fails closed, letting the ``ENOSYS`` propagate so a caller that needs kernel-enforced
             locking is never silently downgraded. It has no effect on Windows or :class:`SoftFileLock`.
+        :param preserve_lock_file: for native locks (:class:`FileLock`), whether filelock promises not to unlink the
+            lock pathname on release. ``False`` (the default) keeps each backend's cleanup: Windows removes the lock
+            file, Unix already leaves it. ``True`` keeps a stable file identity for ACLs, auditing, and holder metadata:
+            Windows skips its post-release unlink and Unix refuses to enter the ``ENOSYS`` soft fallback (which releases
+            by unlinking). :class:`SoftFileLock` rejects ``True``. The promise covers filelock's own release path only;
+            it cannot stop another process or the filesystem from removing the pathname.
 
         """
         self._is_thread_local = thread_local
@@ -310,6 +336,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         self._context_error_policy = context_error_policy  # already validated by the metaclass
         self._close_error_policy = close_error_policy  # already validated by the metaclass
         self._fallback_to_soft = fallback_to_soft
+        self._preserve_lock_file = preserve_lock_file  # already validated by the metaclass
 
         # External code reaches these values through the public properties, not through _context directly.
         kwargs: dict[str, Any] = {
@@ -380,6 +407,19 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
 
         """
         return self._fallback_to_soft
+
+    @property
+    def preserve_lock_file(self) -> bool:
+        """
+        Whether filelock promises not to unlink the lock pathname on release.
+
+        When ``True``, Windows skips its post-release unlink and Unix refuses the ``ENOSYS`` soft fallback.
+        :class:`SoftFileLock` rejects ``True`` because unlinking its marker is how it releases.
+
+        .. versionadded:: 3.27.0
+
+        """
+        return self._preserve_lock_file
 
     @property
     def lock_file(self) -> str:

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -38,6 +38,9 @@ class SoftFileLock(BaseFileLock):
     #: Existence locks reclaim by unlinking a pathname, so an age-based lease may break one; a native inode lock cannot.
     _lifetime_supported: bool = True
 
+    #: An existence lock unlinks its marker to release, so it cannot promise to keep the pathname.
+    _preserve_lock_file_supported: bool = False
+
     def _acquire(self) -> None:
         raise_on_not_writable_file(self.lock_file)
         ensure_directory_exists(self.lock_file)

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -109,8 +109,10 @@ else:  # pragma: win32 no cover
             with suppress(OSError):
                 identity = (fstat := os.fstat(fd)).st_dev, fstat.st_ino
             os.close(fd)
-            if not self._fallback_to_soft:
-                raise missing_flock  # fail closed: the caller opted out of existence-lock semantics (#603)
+            if not self._fallback_to_soft or self._preserve_lock_file:
+                # Fail closed: the caller opted out of existence-lock semantics (#603), or asked to preserve the
+                # pathname (#605), which the soft fallback would unlink to release.
+                raise missing_flock
             with suppress(OSError):
                 current = os.lstat(self.lock_file)
                 if identity == (current.st_dev, current.st_ino):

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -201,8 +201,9 @@ if sys.platform == "win32":  # pragma: win32 cover
             _unlock_fd(fd)
             self._context.lock_file_fd = None
             self._close_released_fd(fd, default_suppresses=False)
-            with suppress(OSError):
-                Path(self.lock_file).unlink()
+            if not self._preserve_lock_file:  # preserve_lock_file keeps a stable file identity for the caller (#605)
+                with suppress(OSError):
+                    Path(self.lock_file).unlink()
 
     def _open_non_reparse_fd(path: str, mode: int) -> int | None:
         """

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -59,6 +59,7 @@ class AsyncFileLockMeta(FileLockMeta):
         context_error_policy: ContextErrorPolicy = "chain",
         close_error_policy: CloseErrorPolicy = "default",
         fallback_to_soft: bool = True,
+        preserve_lock_file: bool = False,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -78,6 +79,7 @@ class AsyncFileLockMeta(FileLockMeta):
             context_error_policy=context_error_policy,
             close_error_policy=close_error_policy,
             fallback_to_soft=fallback_to_soft,
+            preserve_lock_file=preserve_lock_file,
             loop=loop,
             run_in_executor=run_in_executor,
             executor=executor,
@@ -108,6 +110,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         context_error_policy: ContextErrorPolicy = "chain",
         close_error_policy: CloseErrorPolicy = "default",
         fallback_to_soft: bool = True,
+        preserve_lock_file: bool = False,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -148,6 +151,10 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             ``"raise"`` always propagates the ``OSError``, and ``"suppress"`` always ignores it.
         :param fallback_to_soft: for :class:`AsyncFileLock`, whether to fall back to soft existence locking when
             ``flock`` returns ``ENOSYS``. ``True`` (default) keeps the fallback; ``False`` propagates the error.
+        :param preserve_lock_file: for native locks (:class:`AsyncFileLock`), whether filelock promises not to unlink
+            the lock pathname on release. ``False`` (default) keeps each backend's cleanup; ``True`` keeps a stable file
+            identity (Windows skips its unlink, Unix refuses the ``ENOSYS`` soft fallback). :class:`AsyncSoftFileLock`
+            rejects ``True``.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.
@@ -158,6 +165,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         self._context_error_policy = context_error_policy  # already validated by the metaclass
         self._close_error_policy = close_error_policy  # already validated by the metaclass
         self._fallback_to_soft = fallback_to_soft
+        self._preserve_lock_file = preserve_lock_file  # already validated by the metaclass
 
         # External code goes through this class's properties, not the context directly.
         kwargs: dict[str, Any] = {

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -642,3 +642,19 @@ async def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: M
         await lock.acquire()
     assert not lock.is_locked
     assert type(lock).__name__ == "AsyncUnixFileLock"  # not swapped to the soft class
+
+
+def test_preserve_lock_file_async_soft_rejects(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="preserve_lock_file"):
+        AsyncSoftFileLock(str(tmp_path / "a"), preserve_lock_file=True)
+
+
+@_UNIX_FLOCK_ONLY
+@pytest.mark.asyncio
+async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -> None:
+    path = tmp_path / "a"
+    lock = AsyncFileLock(str(path), preserve_lock_file=True)
+    await lock.acquire()
+    await lock.release()
+    assert path.exists()  # the native pathname survives an async release
+    assert type(lock).__name__ == "AsyncUnixFileLock"

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1928,3 +1928,90 @@ def test_lock_descriptor_blocking_retries_until_free(tmp_path: Path, mocker: Moc
     finally:
         os.close(holder)
         os.close(fd)
+
+
+def test_preserve_lock_file_defaults_off(tmp_path: Path) -> None:
+    assert FileLock(str(tmp_path / "a")).preserve_lock_file is False
+
+
+def test_preserve_lock_file_property_reflects_argument(tmp_path: Path) -> None:
+    assert FileLock(str(tmp_path / "a"), preserve_lock_file=True).preserve_lock_file is True
+
+
+def test_preserve_lock_file_rejected_by_soft_lock(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="preserve_lock_file"):
+        SoftFileLock(str(tmp_path / "a"), preserve_lock_file=True)
+
+
+def test_singleton_rejects_different_preserve_lock_file(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    first = FileLock(path, is_singleton=True, preserve_lock_file=False)
+    try:
+        with pytest.raises(ValueError, match="preserve_lock_file"):
+            FileLock(path, is_singleton=True, preserve_lock_file=True)
+    finally:
+        first.release(force=True)
+
+
+@_UNIX_FLOCK_ONLY
+def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:
+    path = tmp_path / "a"
+    lock = FileLock(str(path), preserve_lock_file=True)
+    lock.acquire()
+    lock.release()
+    assert path.exists()  # Unix leaves the native pathname in place
+    assert type(lock).__name__ == "UnixFileLock"
+
+
+@_UNIX_FLOCK_ONLY
+def test_preserve_lock_file_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
+    lock = FileLock(str(tmp_path / "a"), preserve_lock_file=True)  # fallback_to_soft still defaults to True
+    with pytest.raises(OSError, match="no flock"):
+        lock.acquire()
+    assert not lock.is_locked
+    assert type(lock).__name__ == "UnixFileLock"  # preserve overrides the soft fallback that would unlink to release
+
+
+@_WINDOWS_ONLY
+def test_preserve_lock_file_windows_default_removes_file(tmp_path: Path) -> None:
+    path = tmp_path / "a"
+    lock = FileLock(str(path))
+    lock.acquire()
+    lock.release()
+    assert not path.exists()  # the default Windows cleanup unlinks the lock file
+
+
+@_WINDOWS_ONLY
+def test_preserve_lock_file_windows_keeps_file(tmp_path: Path) -> None:
+    path = tmp_path / "a"
+    lock = FileLock(str(path), preserve_lock_file=True)
+    lock.acquire()
+    lock.release()
+    assert path.exists()  # preserve_lock_file skips the post-release unlink
+
+
+@_WINDOWS_ONLY
+def test_preserve_lock_file_windows_reacquires_same_identity(tmp_path: Path) -> None:
+    path = tmp_path / "a"
+    lock = FileLock(str(path), preserve_lock_file=True)
+    lock.acquire()
+    lock.release()
+    kept = path.stat()
+    lock.acquire()
+    try:
+        current = path.stat()
+        assert (current.st_dev, current.st_ino) == (kept.st_dev, kept.st_ino)  # same file across acquisitions
+    finally:
+        lock.release()
+
+
+@_WINDOWS_ONLY
+def test_preserve_lock_file_windows_kept_after_forced_release(tmp_path: Path) -> None:
+    path = tmp_path / "a"
+    lock = FileLock(str(path), preserve_lock_file=True)
+    lock.acquire()
+    lock.acquire()  # reentrant second level
+    lock.release(force=True)  # drop every level and run the release path once
+    assert not lock.is_locked
+    assert path.exists()  # preserved even through a forced release


### PR DESCRIPTION
Callers that reuse a native lock file for ACLs, auditing, or holder metadata need a guarantee that filelock will not remove the pathname out from under them. Two defaults break that. Windows unlinks the lock file after release (the cleanup [#511](https://github.com/tox-dev/filelock/pull/511) restored), and a Unix `flock` `ENOSYS` fallback switches to an existence lock that releases by unlinking its marker. Both destroy the stable file identity these callers depend on.

This adds `preserve_lock_file`, a portable intent rather than a Windows-specific inverse flag. `False` (the default) keeps each backend's current cleanup. `True` promises filelock will not unlink the lock pathname on its own release path: Windows skips its post-release unlink, Unix already leaves the file in place and now refuses the `ENOSYS` soft fallback so the error propagates instead of downgrading to an existence lock, and `SoftFileLock` rejects `True` because unlinking its marker is how it releases. Construction validates the setting, stores it on the instance, and compares it in the singleton compatibility check across both the sync and async paths; a `preserve_lock_file` property reads it back.

The guarantee covers filelock's own release path. 🔒 It cannot stop another process, user, or filesystem from removing the pathname. The default is unchanged, so #511's Windows cleanup stays intact, and the setting stays separate from the close-error policy.

Fixes [#605](https://github.com/tox-dev/filelock/issues/605).
