### PR TITLE
✨ feat(api): add on_acquired post-acquisition hook

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -55,26 +55,6 @@ def _exception_group_cls() -> type[BaseException]:
     return _Backport  # pragma: no cover (<py311)
 
 
-def _resolve_context_error_policy(policy: str) -> ContextErrorPolicy:
-    if policy not in _CONTEXT_ERROR_POLICIES:
-        msg = f"context_error_policy must be 'chain' or 'group', got {policy!r}"
-        raise ValueError(msg)
-    if policy == "group":  # fail fast at construction rather than only when a dual failure happens to occur
-        try:
-            _exception_group_cls()
-        except ImportError as exc:  # pragma: no cover  # only on 3.10 without the exceptiongroup backport
-            msg = "context_error_policy='group' requires Python 3.11+ or the 'exceptiongroup' backport installed"
-            raise ValueError(msg) from exc
-    return cast("ContextErrorPolicy", policy)
-
-
-def _resolve_close_error_policy(policy: str) -> CloseErrorPolicy:
-    if policy not in _CLOSE_ERROR_POLICIES:
-        msg = f"close_error_policy must be 'default', 'raise', or 'suppress', got {policy!r}"
-        raise ValueError(msg)
-    return cast("CloseErrorPolicy", policy)
-
-
 def _raise_body_and_release(body_error: BaseException, release_error: BaseException) -> NoReturn:
     # Group mode: surface the body failure and the release failure as sibling leaves instead of letting one hide in the
     # other's __context__. BaseExceptionGroup returns a plain ExceptionGroup when both leaves subclass Exception, so
@@ -102,55 +82,6 @@ def _canonical(path: str | os.PathLike[str]) -> str:
     """
     parent, name = os.path.split(os.fspath(path))
     return os.path.join(_resolve_dir(parent or os.curdir), name)  # noqa: PTH118  # string join matches abspath/realpath
-
-
-def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str) -> float | None:
-    """
-    Drop a ``lifetime`` a lock cannot honor.
-
-    ``lifetime`` is a deliberate age-based lease: a lock file older than ``lifetime`` is broken even while its holder is
-    still alive. That is only safe for existence locks (:class:`SoftFileLock`), where breaking means unlinking a
-    pathname the protocol already treats as reclaimable. A native OS lock lives on the inode, so unlinking the pathname
-    by age cannot revoke the kernel lock; a contender would lock a fresh inode and overlap the live holder (#590).
-    Ignore the request with a warning rather than accept a setting that breaks mutual exclusion.
-    """
-    if lifetime is not None and not supported:
-        warnings.warn(
-            f"lifetime is ignored for {cls_name}: a native OS lock cannot be broken safely by file age; "
-            f"only SoftFileLock supports lifetime-based expiry",
-            stacklevel=3,
-        )
-        return None
-    return lifetime
-
-
-def _resolve_preserve_lock_file(preserve: bool, *, supported: bool, cls_name: str) -> bool:  # noqa: FBT001
-    # An existence lock unlinks its marker to release, so preserving the pathname would defeat unlocking. Reject the
-    # request rather than silently ignore it, since a caller asking for a stable identity must know it cannot be kept.
-    if preserve and not supported:
-        msg = f"preserve_lock_file=True is not supported by {cls_name}: unlinking its marker is how it releases"
-        raise ValueError(msg)
-    return preserve
-
-
-def _resolve_on_acquired(
-    on_acquired: Callable[[int], None] | None, *, supported: bool, cls_name: str
-) -> Callable[[int], None] | None:
-    if on_acquired is None:
-        return None
-    # An existence lock stores protocol state in its marker, so a caller writing through the descriptor would corrupt
-    # stale detection and ownership metadata; only native locks lend out the descriptor.
-    if not supported:
-        msg = f"on_acquired is not supported by {cls_name}: only native locks expose the lock descriptor"
-        raise ValueError(msg)
-    # A hook that fails and then also fails to release surfaces both errors as a BaseExceptionGroup. Require that class
-    # at construction rather than at the rare moment both fail, matching how context_error_policy='group' validates.
-    try:
-        _exception_group_cls()
-    except ImportError as exc:  # pragma: no cover  # only on 3.10 without the exceptiongroup backport
-        msg = "on_acquired requires Python 3.11+ or the 'exceptiongroup' backport for its rollback error path"
-        raise ValueError(msg) from exc
-    return on_acquired
 
 
 class _ThreadLocalRegistry(local):
@@ -264,6 +195,75 @@ class FileLockMeta(ABCMeta):
         # descendant's signature, so passing the full set breaks it (tox-dev/filelock#340).
         present_params = inspect.signature(cls.__init__).parameters
         return super().__call__(lock_file, **{key: value for key, value in params.items() if key in present_params})
+
+
+def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str) -> float | None:
+    """
+    Drop a ``lifetime`` a lock cannot honor.
+
+    ``lifetime`` is a deliberate age-based lease: a lock file older than ``lifetime`` is broken even while its holder is
+    still alive. That is only safe for existence locks (:class:`SoftFileLock`), where breaking means unlinking a
+    pathname the protocol already treats as reclaimable. A native OS lock lives on the inode, so unlinking the pathname
+    by age cannot revoke the kernel lock; a contender would lock a fresh inode and overlap the live holder (#590).
+    Ignore the request with a warning rather than accept a setting that breaks mutual exclusion.
+    """
+    if lifetime is not None and not supported:
+        warnings.warn(
+            f"lifetime is ignored for {cls_name}: a native OS lock cannot be broken safely by file age; "
+            f"only SoftFileLock supports lifetime-based expiry",
+            stacklevel=3,
+        )
+        return None
+    return lifetime
+
+
+def _resolve_context_error_policy(policy: str) -> ContextErrorPolicy:
+    if policy not in _CONTEXT_ERROR_POLICIES:
+        msg = f"context_error_policy must be 'chain' or 'group', got {policy!r}"
+        raise ValueError(msg)
+    if policy == "group":  # fail fast at construction rather than only when a dual failure happens to occur
+        try:
+            _exception_group_cls()
+        except ImportError as exc:  # pragma: no cover  # only on 3.10 without the exceptiongroup backport
+            msg = "context_error_policy='group' requires Python 3.11+ or the 'exceptiongroup' backport installed"
+            raise ValueError(msg) from exc
+    return cast("ContextErrorPolicy", policy)
+
+
+def _resolve_close_error_policy(policy: str) -> CloseErrorPolicy:
+    if policy not in _CLOSE_ERROR_POLICIES:
+        msg = f"close_error_policy must be 'default', 'raise', or 'suppress', got {policy!r}"
+        raise ValueError(msg)
+    return cast("CloseErrorPolicy", policy)
+
+
+def _resolve_preserve_lock_file(preserve: bool, *, supported: bool, cls_name: str) -> bool:  # noqa: FBT001
+    # An existence lock unlinks its marker to release, so preserving the pathname would defeat unlocking. Reject the
+    # request rather than silently ignore it, since a caller asking for a stable identity must know it cannot be kept.
+    if preserve and not supported:
+        msg = f"preserve_lock_file=True is not supported by {cls_name}: unlinking its marker is how it releases"
+        raise ValueError(msg)
+    return preserve
+
+
+def _resolve_on_acquired(
+    on_acquired: Callable[[int], None] | None, *, supported: bool, cls_name: str
+) -> Callable[[int], None] | None:
+    if on_acquired is None:
+        return None
+    # An existence lock stores protocol state in its marker, so a caller writing through the descriptor would corrupt
+    # stale detection and ownership metadata; only native locks lend out the descriptor.
+    if not supported:
+        msg = f"on_acquired is not supported by {cls_name}: only native locks expose the lock descriptor"
+        raise ValueError(msg)
+    # A hook that fails and then also fails to release surfaces both errors as a BaseExceptionGroup. Require that class
+    # at construction rather than at the rare moment both fail, matching how context_error_policy='group' validates.
+    try:
+        _exception_group_cls()
+    except ImportError as exc:  # pragma: no cover  # only on 3.10 without the exceptiongroup backport
+        msg = "on_acquired requires Python 3.11+ or the 'exceptiongroup' backport for its rollback error path"
+        raise ValueError(msg) from exc
+    return on_acquired
 
 
 class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa: PLR0904  # public config properties

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -133,6 +133,26 @@ def _resolve_preserve_lock_file(preserve: bool, *, supported: bool, cls_name: st
     return preserve
 
 
+def _resolve_on_acquired(
+    on_acquired: Callable[[int], None] | None, *, supported: bool, cls_name: str
+) -> Callable[[int], None] | None:
+    if on_acquired is None:
+        return None
+    # An existence lock stores protocol state in its marker, so a caller writing through the descriptor would corrupt
+    # stale detection and ownership metadata; only native locks lend out the descriptor.
+    if not supported:
+        msg = f"on_acquired is not supported by {cls_name}: only native locks expose the lock descriptor"
+        raise ValueError(msg)
+    # A hook that fails and then also fails to release surfaces both errors as a BaseExceptionGroup. Require that class
+    # at construction rather than at the rare moment both fail, matching how context_error_policy='group' validates.
+    try:
+        _exception_group_cls()
+    except ImportError as exc:  # pragma: no cover  # only on 3.10 without the exceptiongroup backport
+        msg = "on_acquired requires Python 3.11+ or the 'exceptiongroup' backport for its rollback error path"
+        raise ValueError(msg) from exc
+    return on_acquired
+
+
 class _ThreadLocalRegistry(local):
     def __init__(self) -> None:
         super().__init__()
@@ -164,6 +184,7 @@ class FileLockMeta(ABCMeta):
         close_error_policy: CloseErrorPolicy = "default",
         fallback_to_soft: bool = True,
         preserve_lock_file: bool = False,
+        on_acquired: Callable[[int], None] | None = None,
         **kwargs: Any,  # capture remaining kwargs for subclasses  # noqa: ANN401
     ) -> _T:
         lifetime = _resolve_lifetime(lifetime, supported=cls._lifetime_supported, cls_name=cls.__name__)
@@ -174,6 +195,7 @@ class FileLockMeta(ABCMeta):
         preserve_lock_file = _resolve_preserve_lock_file(
             preserve_lock_file, supported=cls._preserve_lock_file_supported, cls_name=cls.__name__
         )
+        on_acquired = _resolve_on_acquired(on_acquired, supported=cls._on_acquired_supported, cls_name=cls.__name__)
         params = {
             "timeout": timeout,
             "mode": mode,
@@ -186,6 +208,7 @@ class FileLockMeta(ABCMeta):
             "close_error_policy": close_error_policy,
             "fallback_to_soft": fallback_to_soft,
             "preserve_lock_file": preserve_lock_file,
+            "on_acquired": on_acquired,
             **kwargs,
         }
         if not is_singleton:
@@ -222,13 +245,18 @@ class FileLockMeta(ABCMeta):
             for name, (passed_param, set_param) in params_to_check.items()
             if passed_param != set_param
         }
-        if not non_matching_params:
+        # Callables compare by identity, not equality: two equal callables can close over different state, so a
+        # singleton must reject a different hook object even if it compares equal. Keep it out of the scalar dict above.
+        hook_mismatch = on_acquired is not instance.on_acquired
+        if not non_matching_params and not hook_mismatch:
             return instance  # ty: ignore[invalid-return-type]  # https://github.com/astral-sh/ty/issues/3231
 
         msg = "Singleton lock instances cannot be initialized with differing arguments"
         msg += "\nNon-matching arguments: "
         for param_name, (passed_param, set_param) in non_matching_params.items():
             msg += f"\n\t{param_name} (existing lock has {set_param} but {passed_param} was passed)"
+        if hook_mismatch:
+            msg += f"\n\ton_acquired (existing lock has {instance.on_acquired} but {on_acquired} was passed)"
         raise ValueError(msg)
 
     def _create_instance(cls: type[_T], lock_file: str | os.PathLike[str], params: dict[str, Any]) -> _T:
@@ -262,6 +290,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     #: it; existence locks unlink their marker to release and reject it.
     _preserve_lock_file_supported: bool = True
 
+    #: Whether an :attr:`on_acquired` hook may be set. Native locks lend the descriptor out; existence locks keep
+    #: protocol state in the marker and reject it.
+    _on_acquired_supported: bool = True
+
     def __init_subclass__(cls, **kwargs: dict[str, Any]) -> None:
         """Give each lock subclass its own singleton registry and lock."""
         super().__init_subclass__(**kwargs)
@@ -283,6 +315,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         close_error_policy: CloseErrorPolicy = "default",
         fallback_to_soft: bool = True,
         preserve_lock_file: bool = False,
+        on_acquired: Callable[[int], None] | None = None,
     ) -> None:
         """
         Create a new lock object.
@@ -329,6 +362,12 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             Windows skips its post-release unlink and Unix refuses to enter the ``ENOSYS`` soft fallback (which releases
             by unlinking). :class:`SoftFileLock` rejects ``True``. The promise covers filelock's own release path only;
             it cannot stop another process or the filesystem from removing the pathname.
+        :param on_acquired: for native locks (:class:`FileLock`), a callable invoked with the borrowed lock descriptor
+            once per physical acquisition, after filelock holds the native lock and finished backend initialization but
+            before :meth:`acquire` returns. Recursive acquisitions do not call it again. The callback may read, write,
+            seek, truncate, or set metadata through ``os`` on the descriptor, but must not close, unlock, or take
+            ownership of it, and filelock does not fsync its writes. If it raises, filelock releases the lock and
+            re-raises. :class:`SoftFileLock` rejects the hook.
 
         """
         self._is_thread_local = thread_local
@@ -337,6 +376,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         self._close_error_policy = close_error_policy  # already validated by the metaclass
         self._fallback_to_soft = fallback_to_soft
         self._preserve_lock_file = preserve_lock_file  # already validated by the metaclass
+        self._on_acquired = on_acquired  # already validated by the metaclass
 
         # External code reaches these values through the public properties, not through _context directly.
         kwargs: dict[str, Any] = {
@@ -420,6 +460,19 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
 
         """
         return self._preserve_lock_file
+
+    @property
+    def on_acquired(self) -> Callable[[int], None] | None:
+        """
+        The callback run with the borrowed lock descriptor once per physical acquisition, or ``None``.
+
+        Native locks only. It runs after the native lock is held and backend initialization finished, before
+        :meth:`acquire` returns; a raise rolls back the acquisition. :class:`SoftFileLock` rejects it.
+
+        .. versionadded:: 3.27.0
+
+        """
+        return self._on_acquired
 
     @property
     def lock_file(self) -> str:
@@ -656,7 +709,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
                 start_time=start_time,
             )
         except BaseException:
-            self._undo_acquire(canonical)
+            self._reconcile_failed_acquire(canonical)
             raise
         self._commit_acquire(canonical)
         return AcquireReturnProxy(lock=self)
@@ -736,6 +789,34 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             msg = "Lock %s not acquired on %s, waiting %s seconds ..."
             _LOGGER.debug(msg, lock_id, lock_filename, poll_interval)
             time.sleep(poll_interval)
+
+    def _reconcile_failed_acquire(self, canonical: str) -> None:
+        # An acquire that raised while still holding the native lock (a hook that failed and whose rollback could not
+        # release) must keep the registry entry so a later release can retry the OS unlock; otherwise roll the counter
+        # back. is_locked was already reconciled by whichever release ran.
+        if self.is_locked:
+            self._commit_acquire(canonical)
+        else:
+            self._undo_acquire(canonical)
+
+    def _invoke_on_acquired(self) -> None:
+        # Runs inside the backend _acquire (in the executor for async locks), once the native lock is held and the
+        # descriptor is set, before acquire() commits the registry. Fires once per physical acquisition; a recursive
+        # acquire never reaches here because the poll loop skips _acquire while the lock is held.
+        if self._on_acquired is None or self._context.lock_counter != 1:
+            return
+        try:
+            self._on_acquired(cast("int", self._context.lock_file_fd))
+        except BaseException as callback_error:  # arbitrary caller code; roll back on any failure
+            # Undo the native acquisition so the failed hook does not leave the lock held. Call the backend _release
+            # directly rather than the public release(): the counter and thread-local deadlock registry are reconciled
+            # by acquire() on the owning thread, and the async release() is a coroutine this synchronous path cannot
+            # await. A release that also fails surfaces both errors; is_locked then tells acquire() how to reconcile.
+            try:
+                self._release()
+            except BaseException as release_error:  # noqa: BLE001  # both errors surface via the group below
+                _raise_body_and_release(callback_error, release_error)
+            raise
 
     def _undo_acquire(self, canonical: str) -> None:
         """Roll back the counter after a failed acquire, dropping the registry entry once nothing holds the path."""

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -41,6 +41,9 @@ class SoftFileLock(BaseFileLock):
     #: An existence lock unlinks its marker to release, so it cannot promise to keep the pathname.
     _preserve_lock_file_supported: bool = False
 
+    #: An existence lock keeps protocol state in its marker, so it cannot lend the descriptor to an on_acquired hook.
+    _on_acquired_supported: bool = False
+
     def _acquire(self) -> None:
         raise_on_not_writable_file(self.lock_file)
         ensure_directory_exists(self.lock_file)

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -109,9 +109,9 @@ else:  # pragma: win32 no cover
             with suppress(OSError):
                 identity = (fstat := os.fstat(fd)).st_dev, fstat.st_ino
             os.close(fd)
-            if not self._fallback_to_soft or self._preserve_lock_file:
-                # Fail closed: the caller opted out of existence-lock semantics (#603), or asked to preserve the
-                # pathname (#605), which the soft fallback would unlink to release.
+            if not self._fallback_to_soft or self._preserve_lock_file or self._on_acquired is not None:
+                # Fail closed: the caller opted out of existence-lock semantics (#603), asked to preserve the pathname
+                # (#605), or set an on_acquired hook (#607), none of which a soft lock can honor.
                 raise missing_flock
             with suppress(OSError):
                 current = os.lstat(self.lock_file)
@@ -134,7 +134,8 @@ else:  # pragma: win32 no cover
                 os.close(fd)
                 raise
             if keep:
-                self._context.lock_file_fd = fd
+                self._context.lock_file_fd = fd  # the lock is held; run the hook now that truncation and mode are set
+                self._invoke_on_acquired()
             else:
                 os.close(fd)
 

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -190,6 +190,7 @@ if sys.platform == "win32":  # pragma: win32 cover
                 raise
             if locked:
                 self._context.lock_file_fd = fd
+                self._invoke_on_acquired()
             else:
                 os.close(fd)  # another holder owns the byte-range lock; let the retry loop try again
 

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -60,6 +60,7 @@ class AsyncFileLockMeta(FileLockMeta):
         close_error_policy: CloseErrorPolicy = "default",
         fallback_to_soft: bool = True,
         preserve_lock_file: bool = False,
+        on_acquired: Callable[[int], None] | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -80,6 +81,7 @@ class AsyncFileLockMeta(FileLockMeta):
             close_error_policy=close_error_policy,
             fallback_to_soft=fallback_to_soft,
             preserve_lock_file=preserve_lock_file,
+            on_acquired=on_acquired,
             loop=loop,
             run_in_executor=run_in_executor,
             executor=executor,
@@ -111,6 +113,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         close_error_policy: CloseErrorPolicy = "default",
         fallback_to_soft: bool = True,
         preserve_lock_file: bool = False,
+        on_acquired: Callable[[int], None] | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
@@ -155,6 +158,10 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             the lock pathname on release. ``False`` (default) keeps each backend's cleanup; ``True`` keeps a stable file
             identity (Windows skips its unlink, Unix refuses the ``ENOSYS`` soft fallback). :class:`AsyncSoftFileLock`
             rejects ``True``.
+        :param on_acquired: for native locks (:class:`AsyncFileLock`), a callable invoked with the borrowed lock
+            descriptor once per physical acquisition, after the lock is held but before :meth:`acquire` returns. With
+            ``run_in_executor=True`` (the default) it runs in the backend executor. It must not close or unlock the
+            descriptor; a raise rolls the acquisition back. :class:`AsyncSoftFileLock` rejects it.
         :param loop: The event loop to use. If not specified, the running event loop will be used.
         :param run_in_executor: If this is set to ``True`` then the lock will be acquired in an executor.
         :param executor: The executor to use. If not specified, the default executor will be used.
@@ -166,6 +173,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         self._close_error_policy = close_error_policy  # already validated by the metaclass
         self._fallback_to_soft = fallback_to_soft
         self._preserve_lock_file = preserve_lock_file  # already validated by the metaclass
+        self._on_acquired = on_acquired  # already validated by the metaclass
 
         # External code goes through this class's properties, not the context directly.
         kwargs: dict[str, Any] = {
@@ -271,7 +279,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 start_time=time.perf_counter(),
             )
         except BaseException:
-            self._undo_acquire(canonical)
+            self._reconcile_failed_acquire(canonical)
             raise
         self._commit_acquire(canonical)
         return AsyncAcquireReturnProxy(lock=self)

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -674,19 +674,20 @@ def test_on_acquired_async_soft_rejects(tmp_path: Path) -> None:
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
 async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:
-    seen: dict[str, object] = {}
+    hook_thread = -1
+    fd_while_held = -1
 
     def hook(fd: int) -> None:
-        seen["thread"] = threading.get_ident()
-        seen["held"] = lock.is_locked
-        seen["fd_is_int"] = isinstance(fd, int)
+        nonlocal hook_thread, fd_while_held
+        hook_thread = threading.get_ident()
+        if lock.is_locked:
+            fd_while_held = fd
 
     lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, on_acquired=hook)
     await lock.acquire()
     try:
-        assert seen["held"] is True
-        assert seen["fd_is_int"] is True
-        assert seen["thread"] != threading.get_ident()  # ran in the executor, not the event-loop thread
+        assert fd_while_held >= 0  # the hook ran while the lock was held, with a real descriptor
+        assert hook_thread != threading.get_ident()  # in the backend executor, not the event-loop thread
     finally:
         await lock.release()
 

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -5,6 +5,7 @@ import gc
 import logging
 import os
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from errno import EIO, ENOSYS
@@ -658,3 +659,43 @@ async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -
     await lock.release()
     assert path.exists()  # the native pathname survives an async release
     assert type(lock).__name__ == "AsyncUnixFileLock"
+
+
+def _failing_on_acquired(_fd: int) -> None:
+    msg = "hook failed"
+    raise RuntimeError(msg)
+
+
+def test_on_acquired_async_soft_rejects(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="on_acquired"):
+        AsyncSoftFileLock(str(tmp_path / "a"), on_acquired=lambda _fd: None)
+
+
+@_UNIX_FLOCK_ONLY
+@pytest.mark.asyncio
+async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:
+    seen: dict[str, object] = {}
+
+    def hook(fd: int) -> None:
+        seen["thread"] = threading.get_ident()
+        seen["held"] = lock.is_locked
+        seen["fd_is_int"] = isinstance(fd, int)
+
+    lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, on_acquired=hook)
+    await lock.acquire()
+    try:
+        assert seen["held"] is True
+        assert seen["fd_is_int"] is True
+        assert seen["thread"] != threading.get_ident()  # ran in the executor, not the event-loop thread
+    finally:
+        await lock.release()
+
+
+@_UNIX_FLOCK_ONLY
+@pytest.mark.asyncio
+async def test_on_acquired_async_failure_releases(tmp_path: Path) -> None:
+    lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, on_acquired=_failing_on_acquired)
+    with pytest.raises(RuntimeError, match="hook failed"):
+        await lock.acquire()
+    assert not lock.is_locked
+    assert lock.lock_counter == 0

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -2015,3 +2015,159 @@ def test_preserve_lock_file_windows_kept_after_forced_release(tmp_path: Path) ->
     lock.release(force=True)  # drop every level and run the release path once
     assert not lock.is_locked
     assert path.exists()  # preserved even through a forced release
+
+
+def _noop_on_acquired(_fd: int) -> None:
+    pass
+
+
+def _failing_on_acquired(_fd: int) -> None:
+    msg = "hook failed"
+    raise RuntimeError(msg)
+
+
+def test_on_acquired_defaults_none(tmp_path: Path) -> None:
+    assert FileLock(str(tmp_path / "a")).on_acquired is None
+
+
+def test_on_acquired_property_reflects_argument(tmp_path: Path) -> None:
+    assert FileLock(str(tmp_path / "a"), on_acquired=_noop_on_acquired).on_acquired is _noop_on_acquired
+
+
+def test_on_acquired_runs_before_acquire_returns(tmp_path: Path) -> None:
+    observed: dict[str, object] = {}
+
+    def hook(fd: int) -> None:
+        observed["fd_is_int"] = isinstance(fd, int)
+        observed["held_during_hook"] = lock.is_locked
+
+    lock = FileLock(str(tmp_path / "a"), on_acquired=hook)
+    lock.acquire()
+    try:
+        assert observed == {"fd_is_int": True, "held_during_hook": True}
+    finally:
+        lock.release()
+
+
+def test_on_acquired_fires_once_per_physical_acquire(tmp_path: Path) -> None:
+    calls: list[int] = []
+    lock = FileLock(str(tmp_path / "a"), on_acquired=calls.append)
+    lock.acquire()
+    lock.acquire()  # recursive: the poll loop skips _acquire, so the hook does not run again
+    try:
+        assert len(calls) == 1
+    finally:
+        lock.release()
+        lock.release()
+
+
+def test_on_acquired_not_called_for_contender(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    holder = FileLock(path)
+    holder.acquire()
+    calls: list[int] = []
+    contender = FileLock(path, on_acquired=calls.append)
+    try:
+        with pytest.raises(Timeout):
+            contender.acquire(timeout=0.1)
+        assert calls == []  # a contender that never acquires never runs the hook
+    finally:
+        holder.release()
+
+
+@_UNIX_FLOCK_ONLY
+def test_on_acquired_runs_after_truncation_and_mode(tmp_path: Path) -> None:
+    path = tmp_path / "a"
+    path.write_bytes(b"stale content")
+    seen: dict[str, int] = {}
+
+    def hook(fd: int) -> None:
+        stat_result = os.fstat(fd)
+        seen["size"] = stat_result.st_size
+        seen["mode"] = S_IMODE(stat_result.st_mode)
+
+    lock = FileLock(str(path), mode=0o600, on_acquired=hook)
+    lock.acquire()
+    try:
+        assert seen == {"size": 0, "mode": 0o600}  # backend truncation and mode setup finished before the hook
+    finally:
+        lock.release()
+
+
+@_UNIX_FLOCK_ONLY
+def test_on_acquired_writes_survive_contention(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+
+    def write_metadata(fd: int) -> None:
+        os.write(fd, b"holder-metadata")
+
+    writer = FileLock(path, on_acquired=write_metadata)
+    writer.acquire()
+    try:
+        contender = FileLock(path)
+        with pytest.raises(Timeout):
+            contender.acquire(timeout=0.1)  # a losing contender must not truncate the holder's file
+        assert Path(path).read_bytes() == b"holder-metadata"
+    finally:
+        writer.release()
+
+
+def test_on_acquired_failure_releases_lock(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    lock = FileLock(path, on_acquired=_failing_on_acquired)
+    with pytest.raises(RuntimeError, match="hook failed"):
+        lock.acquire()
+    assert not lock.is_locked
+    assert lock.lock_counter == 0
+    other = FileLock(path)
+    other.acquire()  # the native lock was released, so a fresh acquire succeeds at once
+    other.release()
+
+
+@_UNIX_FLOCK_ONLY
+def test_on_acquired_and_release_failure_group(tmp_path: Path, mocker: MockerFixture) -> None:
+    path = str(tmp_path / "a")
+    lock = FileLock(path, on_acquired=_failing_on_acquired)
+    mocker.patch("filelock._unix._unlock_fd", side_effect=[OSError(EIO, "unlock failed"), None])
+    with pytest.raises(BaseExceptionGroup) as info:
+        lock.acquire()
+    assert {type(error) for error in info.value.exceptions} == {RuntimeError, OSError}
+    assert lock.is_locked  # the OS unlock failed, so the lock stays held for a retry
+    assert lock.lock_counter == 1
+    lock.release()  # the second unlock succeeds
+
+
+@_UNIX_FLOCK_ONLY
+def test_on_acquired_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
+    calls: list[int] = []
+    lock = FileLock(str(tmp_path / "a"), on_acquired=calls.append)
+    with pytest.raises(OSError, match="no flock"):
+        lock.acquire()
+    assert not lock.is_locked
+    assert type(lock).__name__ == "UnixFileLock"  # a soft lock cannot run the hook, so no fallback
+    assert calls == []
+
+
+def test_on_acquired_rejected_by_soft_lock(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="on_acquired"):
+        SoftFileLock(str(tmp_path / "a"), on_acquired=_noop_on_acquired)
+
+
+def test_singleton_shares_same_on_acquired(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    first = FileLock(path, is_singleton=True, on_acquired=_noop_on_acquired)
+    try:
+        assert FileLock(path, is_singleton=True, on_acquired=_noop_on_acquired) is first
+    finally:
+        first.release(force=True)
+
+
+def test_singleton_rejects_different_on_acquired(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    first = FileLock(path, is_singleton=True, on_acquired=_noop_on_acquired)
+    try:
+        with pytest.raises(ValueError, match="on_acquired"):
+            FileLock(path, is_singleton=True, on_acquired=_failing_on_acquired)
+    finally:
+        first.release(force=True)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -2035,16 +2035,17 @@ def test_on_acquired_property_reflects_argument(tmp_path: Path) -> None:
 
 
 def test_on_acquired_runs_before_acquire_returns(tmp_path: Path) -> None:
-    observed: dict[str, object] = {}
+    fd_while_held = -1
 
     def hook(fd: int) -> None:
-        observed["fd_is_int"] = isinstance(fd, int)
-        observed["held_during_hook"] = lock.is_locked
+        nonlocal fd_while_held
+        if lock.is_locked:
+            fd_while_held = fd
 
     lock = FileLock(str(tmp_path / "a"), on_acquired=hook)
     lock.acquire()
     try:
-        assert observed == {"fd_is_int": True, "held_during_hook": True}
+        assert fd_while_held >= 0  # the hook ran, saw the lock held, and got a real descriptor, all before acquire()
     finally:
         lock.release()
 


### PR DESCRIPTION
Callers that want to stamp holder metadata onto a lock file, apply an ACL, or record an owner have no sound moment to do it. Doing it before `acquire()` races other contenders, and doing it after `acquire()` returns runs outside the lock's transaction, so a write that fails cannot roll the acquisition back. This adds `on_acquired`, a callback filelock runs on the locked descriptor at the one point where the lock is held but acquisition has not yet committed.

The hook receives the borrowed descriptor once per physical acquisition, after filelock holds the native lock and finished backend initialization (Unix truncation and mode setup included) but before `acquire()` returns. A recursive acquire does not call it again. The descriptor stays owned by filelock: the callback may read, write, seek, truncate, or set metadata through `os`, but must not close or unlock it, and filelock does not fsync its writes. If the callback raises, filelock releases through the native release path and re-raises; when that release also fails, it surfaces both errors as a `BaseExceptionGroup` and keeps the lock held for a retry if the OS unlock did not commit. To support that case, filelock now commits the registry when a failed acquire leaves the lock held rather than rolling the counter back.

The hook is native-only. `SoftFileLock` stores protocol state in its marker, so it rejects the option, and a Unix `flock` that returns `ENOSYS` fails closed instead of downgrading to an existence lock that cannot run the hook, composing with the `fallback_to_soft` and `preserve_lock_file` opt-outs. The callback stays synchronous: `AsyncFileLock` already runs its backend `_acquire()` in an executor, so the hook runs there in the same call with `run_in_executor=True`, and a coroutine callback would open a cancellation boundary while the native lock is held. Singleton compatibility compares the callback by identity, since two equal callables can close over different state.

Fixes [#607](https://github.com/tox-dev/filelock/issues/607).
