### PR TITLE
🐛 fix(api): validate lifetime values

### DIFF
--- a/docs/changelog/644.bugfix.rst
+++ b/docs/changelog/644.bugfix.rst
@@ -1,0 +1,1 @@
+Reject negative and non-finite ``lifetime`` values during lock construction and assignment.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import inspect
 import logging
+import math
 import os
 import sys
 import time
@@ -199,7 +200,7 @@ class FileLockMeta(ABCMeta):
 
 def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str) -> float | None:
     """
-    Drop a ``lifetime`` a lock cannot honor.
+    Validate ``lifetime`` and drop a value the backend cannot honor.
 
     ``lifetime`` is a deliberate age-based lease: a lock file older than ``lifetime`` is broken even while its holder is
     still alive. That is only safe for existence locks (:class:`SoftFileLock`), where breaking means unlinking a
@@ -207,6 +208,13 @@ def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str)
     by age cannot revoke the kernel lock; a contender would lock a fresh inode and overlap the live holder (#590).
     Ignore the request with a warning rather than accept a setting that breaks mutual exclusion.
     """
+    if lifetime is not None:
+        if isinstance(lifetime, bool) or not isinstance(lifetime, (int, float)):
+            msg = f"lifetime must be a finite non-negative number or None, not {type(lifetime).__name__}"
+            raise TypeError(msg)
+        if lifetime < 0 or (isinstance(lifetime, float) and not math.isfinite(lifetime)):
+            msg = f"lifetime must be finite and non-negative, not {lifetime!r}"
+            raise ValueError(msg)
     if lifetime is not None and not supported:
         warnings.warn(
             f"lifetime is ignored for {cls_name}: a native OS lock cannot be broken safely by file age; "
@@ -556,17 +564,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
 
         :param value: the new value in seconds, or ``None`` to disable expiration
 
-        :raises ValueError: if *value* is a negative number
+        :raises ValueError: if *value* is negative or not finite
         :raises TypeError: if *value* is not ``None`` and not a real number
 
         """
-        if value is not None:
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                msg = f"lifetime must be a non-negative number or None, not {type(value).__name__}"
-                raise TypeError(msg)
-            if value < 0:
-                msg = f"lifetime must be non-negative, not {value!r}"
-                raise ValueError(msg)
         self._context.lifetime = _resolve_lifetime(
             value, supported=self._lifetime_supported, cls_name=type(self).__name__
         )

--- a/tests/test_lifetime_validation.py
+++ b/tests/test_lifetime_validation.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, cast
+
+import pytest
+
+from filelock import AsyncFileLock, AsyncSoftFileLock, FileLock, SoftFileLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    "lock_type",
+    [
+        pytest.param(FileLock, id="native-sync"),
+        pytest.param(SoftFileLock, id="soft-sync"),
+        pytest.param(AsyncFileLock, id="native-async"),
+        pytest.param(AsyncSoftFileLock, id="soft-async"),
+    ],
+)
+@pytest.mark.parametrize(
+    "entry_point",
+    [pytest.param("constructor", id="constructor"), pytest.param("setter", id="setter")],
+)
+@pytest.mark.parametrize(
+    ("bad_value", "error_type", "message"),
+    [
+        pytest.param(-1, ValueError, "finite and non-negative", id="negative-int"),
+        pytest.param(-0.5, ValueError, "finite and non-negative", id="negative-float"),
+        pytest.param(float("nan"), ValueError, "finite and non-negative", id="nan"),
+        pytest.param(float("inf"), ValueError, "finite and non-negative", id="positive-infinity"),
+        pytest.param(float("-inf"), ValueError, "finite and non-negative", id="negative-infinity"),
+        pytest.param(True, TypeError, "lifetime must be", id="true"),
+        pytest.param(False, TypeError, "lifetime must be", id="false"),
+        pytest.param("5", TypeError, "lifetime must be", id="string"),
+        pytest.param(b"5", TypeError, "lifetime must be", id="bytes"),
+        pytest.param([1], TypeError, "lifetime must be", id="list"),
+        pytest.param({1: 2}, TypeError, "lifetime must be", id="dict"),
+        pytest.param(complex(1, 0), TypeError, "lifetime must be", id="complex"),
+    ],
+)
+def test_lifetime_rejects_invalid_value(
+    lock_type: type[FileLock | AsyncFileLock],
+    entry_point: Literal["constructor", "setter"],
+    bad_value: str | bytes | list[int] | dict[int, int] | complex,
+    error_type: type[ValueError | TypeError],
+    message: str,
+    tmp_path: Path,
+) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock = lock_type(lock_path)
+    with pytest.raises(error_type, match=message):
+        _set_lifetime(lock_type, entry_point, lock, cast("float", bad_value))
+    assert (lock.lifetime, lock_path.exists()) == (None, False)
+
+
+@pytest.mark.parametrize(
+    "lock_type",
+    [pytest.param(SoftFileLock, id="sync"), pytest.param(AsyncSoftFileLock, id="async")],
+)
+@pytest.mark.parametrize(
+    "entry_point",
+    [pytest.param("constructor", id="constructor"), pytest.param("setter", id="setter")],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(None, id="none"),
+        pytest.param(0, id="zero-int"),
+        pytest.param(0.0, id="zero-float"),
+        pytest.param(2.5, id="positive-float"),
+        pytest.param(10**1000, id="large-int"),
+    ],
+)
+def test_lifetime_accepts_supported_value(
+    lock_type: type[SoftFileLock | AsyncSoftFileLock],
+    entry_point: Literal["constructor", "setter"],
+    value: float | None,
+    tmp_path: Path,
+) -> None:
+    lock_path = tmp_path / "test.lock"
+    if entry_point == "constructor":
+        lock = lock_type(lock_path, lifetime=value)
+    else:
+        lock = lock_type(lock_path)
+        lock.lifetime = value
+    assert lock.lifetime == value
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        pytest.param(-1, id="negative"),
+        pytest.param(float("nan"), id="nan"),
+        pytest.param(float("inf"), id="infinity"),
+    ],
+)
+def test_lifetime_singleton_rejection_preserves_instance(bad_value: float, tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    lock = SoftFileLock(lock_path, is_singleton=True, lifetime=10)
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        SoftFileLock(lock_path, is_singleton=True, lifetime=bad_value)
+
+    assert SoftFileLock(lock_path, is_singleton=True, lifetime=10) is lock
+
+
+def _set_lifetime(
+    lock_type: type[FileLock | AsyncFileLock],
+    entry_point: Literal["constructor", "setter"],
+    lock: FileLock | AsyncFileLock,
+    value: float,
+) -> None:
+    if entry_point == "constructor":
+        lock_type(lock.lock_file, lifetime=value)
+    else:
+        lock.lifetime = value


### PR DESCRIPTION
Filelock accepted negative and non-finite `lifetime` values during construction. Invalid comparisons in stale breaking could then allow two `SoftFileLock` holders for one path. This closes [issue #627](https://github.com/tox-dev/filelock/issues/627).

Filelock now validates constructor and setter input through one boundary before singleton lookup or backend handling. Valid native lifetimes keep their warning-and-ignore behavior; `None` and finite non-negative values remain compatible.
