### PR TITLE
🐛 fix(win32): capture process probe errors

### DIFF
--- a/docs/changelog/645.bugfix.rst
+++ b/docs/changelog/645.bugfix.rst
@@ -1,0 +1,1 @@
+Read the saved Windows process-probe error before deciding that a soft-lock holder has exited.

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -13,8 +13,27 @@ from typing import Final
 from ._api import BaseFileLock
 from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file, write_all
 
+if sys.platform == "win32":  # pragma: win32 cover
+    import ctypes
+    from ctypes import wintypes
+
+    _KERNEL32: Final[ctypes.WinDLL] = ctypes.WinDLL("kernel32", use_last_error=True)
+    _KERNEL32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _KERNEL32.CloseHandle.restype = wintypes.BOOL
+    _KERNEL32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    _KERNEL32.GetProcessTimes.restype = wintypes.BOOL
+    _KERNEL32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    _KERNEL32.OpenProcess.restype = wintypes.HANDLE
+
 _WIN_SYNCHRONIZE: Final[int] = 0x100000
 _WIN_ERROR_INVALID_PARAMETER: Final[int] = 87
+_WIN_INHERIT_HANDLE: Final[bool] = False
 _WIN_PROCESS_QUERY_LIMITED_INFORMATION: Final[int] = 0x1000
 _MALFORMED_LOCK_AGE_THRESHOLD: Final[float] = 2.0
 _MAX_LOCK_FILE_SIZE: Final[int] = 1024
@@ -109,14 +128,11 @@ class SoftFileLock(BaseFileLock):
     @staticmethod
     def _is_process_alive(pid: int) -> bool:
         if sys.platform == "win32":  # pragma: win32 cover
-            import ctypes  # noqa: PLC0415
-
-            kernel32 = ctypes.windll.kernel32
-            handle = kernel32.OpenProcess(_WIN_SYNCHRONIZE, 0, pid)
+            handle = _KERNEL32.OpenProcess(_WIN_SYNCHRONIZE, _WIN_INHERIT_HANDLE, pid)
             if handle:
-                kernel32.CloseHandle(handle)
+                _KERNEL32.CloseHandle(handle)
                 return True
-            return kernel32.GetLastError() != _WIN_ERROR_INVALID_PARAMETER
+            return ctypes.get_last_error() != _WIN_ERROR_INVALID_PARAMETER
         try:
             os.kill(pid, 0)
         except OSError as exc:
@@ -132,11 +148,7 @@ class SoftFileLock(BaseFileLock):
         """Return the process creation FILETIME as an integer on Windows, ``None`` otherwise."""
         if sys.platform != "win32":  # pragma: win32 no cover
             return None
-        import ctypes  # pragma: win32 cover  # noqa: PLC0415
-        from ctypes import wintypes  # noqa: PLC0415
-
-        kernel32 = ctypes.windll.kernel32
-        handle = kernel32.OpenProcess(_WIN_PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
+        handle = _KERNEL32.OpenProcess(_WIN_PROCESS_QUERY_LIMITED_INFORMATION, _WIN_INHERIT_HANDLE, pid)
         if not handle:
             return None
         try:
@@ -144,7 +156,7 @@ class SoftFileLock(BaseFileLock):
             exit_time = wintypes.FILETIME()
             kernel_time = wintypes.FILETIME()
             user_time = wintypes.FILETIME()
-            if not kernel32.GetProcessTimes(
+            if not _KERNEL32.GetProcessTimes(
                 handle,
                 ctypes.byref(creation),
                 ctypes.byref(exit_time),
@@ -153,7 +165,7 @@ class SoftFileLock(BaseFileLock):
             ):
                 return None
         finally:
-            kernel32.CloseHandle(handle)
+            _KERNEL32.CloseHandle(handle)
         return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
 
     @staticmethod

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -24,6 +24,8 @@ _WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != 
 
 _HOST: Final[str] = socket.gethostname()
 _DEAD_PID: Final[int] = 2**22 + 1
+_WIN_ERROR_ACCESS_DENIED: Final[int] = 5
+_WIN_ERROR_INVALID_PARAMETER: Final[int] = 87
 
 
 @pytest.fixture
@@ -204,45 +206,74 @@ def test_stale_detection_errors_suppressed(lock_path: Path, mocker: MockerFixtur
 
 
 @_WINDOWS_ONLY
-def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path, mocker: MockerFixture) -> None:
-    lock_path.write_text(_holder(1234, creation_time=100000000), encoding="utf-8")
-    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
-    mocker.patch.object(SoftFileLock, "_get_process_creation_time", return_value=999999999)
+@pytest.mark.parametrize(
+    ("captured_error", "ambient_error", "acquires"),
+    [
+        pytest.param(_WIN_ERROR_INVALID_PARAMETER, _WIN_ERROR_ACCESS_DENIED, True, id="dead"),
+        pytest.param(_WIN_ERROR_ACCESS_DENIED, _WIN_ERROR_INVALID_PARAMETER, False, id="access-denied"),
+    ],
+)
+def test_windows_stale_lock_uses_captured_process_error(
+    lock_path: Path,
+    mocker: MockerFixture,
+    captured_error: int,
+    ambient_error: int,
+    *,
+    acquires: bool,
+) -> None:
+    if sys.platform != "win32":
+        pytest.skip("windows-only")
+    import ctypes
+
+    def fail_open_process(_access: int, _inherit_handle: bool, _pid: int) -> None:
+        ctypes.set_last_error(captured_error)
+        ctypes.windll.kernel32.SetLastError(ambient_error)
+
+    # ctypes function pointers do not expose a Python signature for autospec.
+    mocker.patch("filelock._soft._KERNEL32.OpenProcess", side_effect=fail_open_process)
+    lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
+    if acquires:
+        _assert_self_heals(lock_path)
+    else:
+        _assert_times_out(lock_path)
+
+
+@_WINDOWS_ONLY
+def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path) -> None:
+    process_marker = lock_path.with_suffix(".process")
+    with SoftFileLock(process_marker):
+        creation_time = int(process_marker.read_text(encoding="utf-8").splitlines()[2])
+    lock_path.write_text(_holder(os.getpid(), creation_time=creation_time + 1), encoding="utf-8")
     _assert_self_heals(lock_path)
 
 
 @_WINDOWS_ONLY
-def test_windows_stale_lock_not_broken_same_creation_time(lock_path: Path, mocker: MockerFixture) -> None:
-    creation_time = 100000000
-    lock_path.write_text(_holder(1234, creation_time=creation_time), encoding="utf-8")
-    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
-    mocker.patch.object(SoftFileLock, "_get_process_creation_time", return_value=creation_time)
+def test_windows_live_process_marker_retained(lock_path: Path) -> None:
+    lock = SoftFileLock(lock_path)
+    lock.acquire()
+    try:
+        _assert_times_out(lock_path)
+    finally:
+        lock.release()
+
+
+@_WINDOWS_ONLY
+def test_windows_live_process_marker_without_creation_time_retained(lock_path: Path) -> None:
+    lock_path.write_text(_holder(os.getpid()), encoding="utf-8")
     _assert_times_out(lock_path)
 
 
 @_WINDOWS_ONLY
-def test_windows_stale_lock_conservative_without_creation_time(lock_path: Path, mocker: MockerFixture) -> None:
-    lock_path.write_text(_holder(1234), encoding="utf-8")
-    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
-    _assert_times_out(lock_path)
-
-
-@_WINDOWS_ONLY
-def test_get_process_creation_time_returns_int_on_windows() -> None:
-    result = SoftFileLock._get_process_creation_time(os.getpid())
-    assert result is not None
-    assert isinstance(result, int)
-    assert result > 0
-
-
-@_WINDOWS_ONLY
-def test_get_process_creation_time_returns_none_for_dead_pid() -> None:
-    assert SoftFileLock._get_process_creation_time(_DEAD_PID) is None
-
-
-@_UNIX_ONLY
-def test_get_process_creation_time_returns_none_on_unix() -> None:
-    assert SoftFileLock._get_process_creation_time(os.getpid()) is None
+def test_windows_process_probe_closes_handles(lock_path: Path) -> None:
+    lock = SoftFileLock(lock_path)
+    lock.acquire()
+    try:
+        handle_count = _current_process_handle_count()
+        for _attempt in range(50):
+            _assert_times_out(lock_path, timeout=0)
+        assert _current_process_handle_count() == handle_count
+    finally:
+        lock.release()
 
 
 @pytest.mark.parametrize(
@@ -311,9 +342,27 @@ def _assert_self_heals(lock_path: Path) -> None:
         assert lock.is_locked
 
 
-def _assert_times_out(lock_path: Path) -> None:
+def _assert_times_out(lock_path: Path, *, timeout: float = 0.1) -> None:
     with pytest.raises(TimeoutError):
-        SoftFileLock(lock_path, timeout=0.1).acquire()
+        SoftFileLock(lock_path, timeout=timeout).acquire()
+
+
+def _current_process_handle_count() -> int:
+    if sys.platform != "win32":
+        pytest.skip("windows-only")
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetCurrentProcess.argtypes = []
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessHandleCount.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+    count = wintypes.DWORD()
+    assert kernel32.GetProcessHandleCount(kernel32.GetCurrentProcess(), ctypes.byref(count)), ctypes.WinError(
+        ctypes.get_last_error()
+    )
+    return count.value
 
 
 def _hold_reports_foreign_identity(mocker: MockerFixture) -> None:


### PR DESCRIPTION
Windows `SoftFileLock` process probes read `GetLastError()` through a plain ctypes loader. Another ctypes call could overwrite the thread error after `OpenProcess` failed, causing filelock to classify a dead PID as live. This closes [issue #630](https://github.com/tox-dev/filelock/issues/630).

Filelock now binds kernel32 with `use_last_error=True`, declares each function signature, and reads `ctypes.get_last_error()` after a failed probe. Access-denied and unverifiable probes continue to treat the recorded holder as live.
