### PR TITLE
🐛 fix(api): reject dropped lock options

### DIFF
--- a/docs/changelog/646.bugfix.rst
+++ b/docs/changelog/646.bugfix.rst
@@ -1,0 +1,2 @@
+Reject non-default lock options that a narrow subclass constructor cannot honor, and forward all options through
+subclasses that accept arbitrary keyword arguments.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -11,7 +11,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import Lock, local
 from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, TypeVar, cast
-from weakref import WeakValueDictionary
+from weakref import WeakKeyDictionary, WeakValueDictionary
 
 from ._error import Timeout
 from ._util import break_lock_file
@@ -191,10 +191,57 @@ class FileLockMeta(ABCMeta):
         raise ValueError(msg)
 
     def _create_instance(cls: type[_T], lock_file: str | os.PathLike[str], params: dict[str, Any]) -> _T:
-        # Keep only the params this subclass's __init__ accepts. virtualenv narrows its BaseFileLock
-        # descendant's signature, so passing the full set breaks it (tox-dev/filelock#340).
-        present_params = inspect.signature(cls.__init__).parameters
-        return super().__call__(lock_file, **{key: value for key, value in params.items() if key in present_params})
+        model = _init_parameter_model(cls)
+        if model.accepts_kwargs:
+            return super().__call__(lock_file, **params)
+
+        unsupported = sorted(
+            name
+            for name, value in params.items()
+            if name not in model.accepted_params
+            and ((parameter := model.default_params.get(name)) is None or value != parameter.default)
+        )
+        if unsupported:
+            msg = f"{cls.__name__} does not support non-default lock options: {', '.join(unsupported)}"
+            raise TypeError(msg)
+        # virtualenv narrows a BaseFileLock descendant's signature; omit base defaults it does not accept (#340).
+        return super().__call__(
+            lock_file,
+            **{name: value for name, value in params.items() if name in model.accepted_params},
+        )
+
+
+_INIT_PARAMETER_MODELS: Final[WeakKeyDictionary[type[BaseFileLock], _InitParameterModel]] = WeakKeyDictionary()
+_INIT_PARAMETER_MODELS_LOCK: Final[Lock] = Lock()
+
+
+def _init_parameter_model(cls: type[BaseFileLock]) -> _InitParameterModel:
+    # A strong cache would keep dynamically created subclasses alive for the process lifetime.
+    with _INIT_PARAMETER_MODELS_LOCK:
+        if (model := _INIT_PARAMETER_MODELS.get(cls)) is None:
+            parameters = inspect.signature(cls.__init__).parameters.values()
+            model = _InitParameterModel(
+                accepted_params=frozenset(
+                    parameter.name
+                    for parameter in parameters
+                    if parameter.kind in {inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY}
+                ),
+                accepts_kwargs=any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters),
+                default_params={
+                    name: parameter
+                    for name, parameter in inspect.signature(type(cls).__call__).parameters.items()
+                    if parameter.default is not inspect.Parameter.empty
+                },
+            )
+            _INIT_PARAMETER_MODELS[cls] = model
+        return model
+
+
+@dataclass(frozen=True)
+class _InitParameterModel:
+    accepted_params: frozenset[str]
+    accepts_kwargs: bool
+    default_params: dict[str, inspect.Parameter]
 
 
 def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str) -> float | None:

--- a/tests/test_subclass_options.py
+++ b/tests/test_subclass_options.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Literal, Protocol, TypedDict, cast
+from weakref import ref
+
+import pytest
+
+from filelock import BaseAsyncFileLock, BaseFileLock, CloseErrorPolicy, ContextErrorPolicy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from concurrent.futures import Executor
+    from pathlib import Path
+
+    from typing_extensions import Unpack
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        pytest.param("timeout", 1, id="timeout"),
+        pytest.param("mode", 0o600, id="mode"),
+        pytest.param("thread_local", False, id="thread-local"),
+        pytest.param("blocking", False, id="blocking"),
+        pytest.param("is_singleton", True, id="singleton"),
+        pytest.param("poll_interval", 0.1, id="poll-interval"),
+        pytest.param("lifetime", 1, id="lifetime"),
+        pytest.param("context_error_policy", "group", id="context-error-policy"),
+        pytest.param("close_error_policy", "raise", id="close-error-policy"),
+        pytest.param("fallback_to_soft", False, id="fallback-to-soft"),
+        pytest.param("preserve_lock_file", True, id="preserve-lock-file"),
+        pytest.param("on_acquired", list[int]().append, id="on-acquired"),
+    ],
+)
+def test_narrow_sync_subclass_rejects_non_default_option(
+    option: str,
+    value: float | str | Callable[[int], None],
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(TypeError, match=option):
+        _sync_constructor()(
+            str(tmp_path / "lock"),
+            **cast("_FileLockOptions", {option: value}),
+        )
+
+
+def test_narrow_sync_subclass_rejects_unknown_option(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="unknown"):
+        _unknown_constructor()(str(tmp_path / "lock"), unknown=True)
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        pytest.param("thread_local", id="thread-local"),
+        pytest.param("loop", id="loop"),
+        pytest.param("run_in_executor", id="run-in-executor"),
+        pytest.param("executor", id="executor"),
+    ],
+)
+def test_narrow_async_subclass_rejects_non_default_option(
+    option: Literal["thread_local", "loop", "run_in_executor", "executor"],
+    tmp_path: Path,
+) -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor, pytest.raises(TypeError, match=option):
+            _async_constructor()(
+                str(tmp_path / "lock"),
+                **_unsupported_async_options(option, loop, executor),
+            )
+    finally:
+        loop.close()
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [pytest.param("sync", id="sync"), pytest.param("async", id="async")],
+)
+def test_narrow_subclass_accepts_explicit_base_defaults(
+    kind: Literal["sync", "async"],
+    tmp_path: Path,
+) -> None:
+    lock_path = str(tmp_path / "lock")
+    assert _build_with_explicit_defaults(kind, lock_path).lock_file == lock_path
+
+
+def test_narrow_subclass_accepts_named_option(tmp_path: Path) -> None:
+    assert _NamedFileLock(str(tmp_path / "lock"), marker=7).marker == 7
+
+
+def test_sync_subclass_forwards_kwargs(tmp_path: Path) -> None:
+    hook: Callable[[int], None] = list[int]().append
+    lock = _ForwardingFileLock(
+        str(tmp_path / "lock"),
+        timeout=2,
+        mode=0o600,
+        thread_local=False,
+        blocking=False,
+        is_singleton=True,
+        poll_interval=0.1,
+        lifetime=3,
+        context_error_policy="group",
+        close_error_policy="suppress",
+        fallback_to_soft=False,
+        preserve_lock_file=True,
+        on_acquired=hook,
+    )
+
+    assert {
+        "timeout": lock.timeout,
+        "mode": lock.mode,
+        "thread_local": lock.is_thread_local(),
+        "blocking": lock.blocking,
+        "is_singleton": lock.is_singleton,
+        "poll_interval": lock.poll_interval,
+        "lifetime": lock.lifetime,
+        "context_error_policy": lock.context_error_policy,
+        "close_error_policy": lock.close_error_policy,
+        "fallback_to_soft": lock.fallback_to_soft,
+        "preserve_lock_file": lock.preserve_lock_file,
+        "on_acquired": lock.on_acquired,
+    } == {
+        "timeout": 2,
+        "mode": 0o600,
+        "thread_local": False,
+        "blocking": False,
+        "is_singleton": True,
+        "poll_interval": 0.1,
+        "lifetime": 3,
+        "context_error_policy": "group",
+        "close_error_policy": "suppress",
+        "fallback_to_soft": False,
+        "preserve_lock_file": True,
+        "on_acquired": hook,
+    }
+
+
+def test_async_subclass_forwards_kwargs(tmp_path: Path) -> None:
+    hook: Callable[[int], None] = list[int]().append
+    loop = asyncio.new_event_loop()
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            lock = _ForwardingAsyncFileLock(
+                str(tmp_path / "lock"),
+                timeout=2,
+                mode=0o600,
+                thread_local=True,
+                blocking=False,
+                is_singleton=True,
+                poll_interval=0.1,
+                lifetime=3,
+                context_error_policy="group",
+                close_error_policy="suppress",
+                fallback_to_soft=False,
+                preserve_lock_file=True,
+                on_acquired=hook,
+                loop=loop,
+                run_in_executor=False,
+                executor=executor,
+            )
+
+            assert {
+                "timeout": lock.timeout,
+                "mode": lock.mode,
+                "thread_local": lock.is_thread_local(),
+                "blocking": lock.blocking,
+                "is_singleton": lock.is_singleton,
+                "poll_interval": lock.poll_interval,
+                "lifetime": lock.lifetime,
+                "context_error_policy": lock.context_error_policy,
+                "close_error_policy": lock.close_error_policy,
+                "fallback_to_soft": lock.fallback_to_soft,
+                "preserve_lock_file": lock.preserve_lock_file,
+                "on_acquired": lock.on_acquired,
+                "loop": lock.loop,
+                "run_in_executor": lock.run_in_executor,
+                "executor": lock.executor,
+            } == {
+                "timeout": 2,
+                "mode": 0o600,
+                "thread_local": True,
+                "blocking": False,
+                "is_singleton": True,
+                "poll_interval": 0.1,
+                "lifetime": 3,
+                "context_error_policy": "group",
+                "close_error_policy": "suppress",
+                "fallback_to_soft": False,
+                "preserve_lock_file": True,
+                "on_acquired": hook,
+                "loop": loop,
+                "run_in_executor": False,
+                "executor": executor,
+            }
+    finally:
+        loop.close()
+
+
+@pytest.mark.parametrize(
+    "option",
+    [pytest.param("hook", id="hook"), pytest.param("policy", id="policy")],
+)
+def test_forwarding_subclass_singleton_rejects_changed_option(
+    option: Literal["hook", "policy"],
+    tmp_path: Path,
+) -> None:
+    hook: Callable[[int], None] = list[int]().append
+    lock_path = str(tmp_path / "lock")
+    first = _ForwardingFileLock(lock_path, is_singleton=True, on_acquired=hook)
+
+    with pytest.raises(ValueError, match="on_acquired" if option == "hook" else "context_error_policy"):
+        _change_singleton_option(option, lock_path, hook)
+    assert first.on_acquired is hook
+
+
+def test_constructor_model_does_not_retain_dynamic_subclass(tmp_path: Path) -> None:
+    lock_type = _dynamic_constructor()
+    class_ref = ref(lock_type)
+    lock_type(str(tmp_path / "lock"))
+    del lock_type
+    gc.collect()
+    assert class_ref() is None
+
+
+def _sync_constructor() -> type[BaseFileLock]:
+    return cast("type[BaseFileLock]", _NarrowFileLock)
+
+
+def _async_constructor() -> type[BaseAsyncFileLock]:
+    return cast("type[BaseAsyncFileLock]", _NarrowAsyncFileLock)
+
+
+def _unknown_constructor() -> _UnknownFileLockConstructor:
+    return cast("_UnknownFileLockConstructor", _NarrowFileLock)
+
+
+def _unsupported_async_options(
+    option: Literal["thread_local", "loop", "run_in_executor", "executor"],
+    loop: asyncio.AbstractEventLoop,
+    executor: Executor,
+) -> _AsyncFileLockOptions:
+    if option == "thread_local":
+        return {"thread_local": True, "run_in_executor": False}
+    if option == "loop":
+        return {"loop": loop}
+    if option == "run_in_executor":
+        return {"run_in_executor": False}
+    return {"executor": executor}
+
+
+def _build_with_explicit_defaults(kind: Literal["sync", "async"], lock_path: str) -> BaseFileLock:
+    if kind == "sync":
+        return _sync_constructor()(
+            lock_path,
+            timeout=-1,
+            mode=-1,
+            thread_local=True,
+            blocking=True,
+            is_singleton=False,
+            poll_interval=0.05,
+            lifetime=None,
+            context_error_policy="chain",
+            close_error_policy="default",
+            fallback_to_soft=True,
+            preserve_lock_file=False,
+            on_acquired=None,
+        )
+    return _async_constructor()(
+        lock_path,
+        timeout=-1,
+        mode=-1,
+        thread_local=False,
+        blocking=True,
+        is_singleton=False,
+        poll_interval=0.05,
+        lifetime=None,
+        context_error_policy="chain",
+        close_error_policy="default",
+        fallback_to_soft=True,
+        preserve_lock_file=False,
+        on_acquired=None,
+        loop=None,
+        run_in_executor=True,
+        executor=None,
+    )
+
+
+def _change_singleton_option(
+    option: Literal["hook", "policy"],
+    lock_path: str,
+    hook: Callable[[int], None],
+) -> BaseFileLock:
+    if option == "hook":
+        return _ForwardingFileLock(lock_path, is_singleton=True, on_acquired=list[int]().append)
+    return _ForwardingFileLock(
+        lock_path,
+        is_singleton=True,
+        context_error_policy="group",
+        on_acquired=hook,
+    )
+
+
+def _dynamic_constructor() -> type[BaseFileLock]:
+    class DynamicFileLock(BaseFileLock):
+        def _acquire(self) -> None:
+            raise NotImplementedError
+
+        def _release(self) -> None:
+            raise NotImplementedError
+
+    return DynamicFileLock
+
+
+class _NarrowFileLock(BaseFileLock):
+    _lifetime_supported = True
+
+    def __init__(self, lock_file: str) -> None:
+        super().__init__(lock_file)
+
+    def _acquire(self) -> None:
+        raise NotImplementedError
+
+    def _release(self) -> None:
+        raise NotImplementedError
+
+
+class _NamedFileLock(BaseFileLock):
+    def __init__(self, lock_file: str, *, marker: int = 0) -> None:
+        super().__init__(lock_file)
+        self.marker = marker
+
+    def _acquire(self) -> None:
+        raise NotImplementedError
+
+    def _release(self) -> None:
+        raise NotImplementedError
+
+
+class _NarrowAsyncFileLock(BaseAsyncFileLock):
+    _lifetime_supported = True
+
+    def __init__(self, lock_file: str) -> None:
+        super().__init__(lock_file)
+
+    def _acquire(self) -> None:
+        raise NotImplementedError
+
+    def _release(self) -> None:
+        raise NotImplementedError
+
+
+class _ForwardingFileLock(BaseFileLock):
+    _lifetime_supported = True
+
+    def __init__(self, lock_file: str, **kwargs: Unpack[_FileLockOptions]) -> None:
+        super().__init__(lock_file, **kwargs)
+
+    def _acquire(self) -> None:
+        raise NotImplementedError
+
+    def _release(self) -> None:
+        raise NotImplementedError
+
+
+class _ForwardingAsyncFileLock(BaseAsyncFileLock):
+    _lifetime_supported = True
+
+    def __init__(self, lock_file: str, **kwargs: Unpack[_AsyncFileLockOptions]) -> None:
+        super().__init__(lock_file, **kwargs)
+
+    def _acquire(self) -> None:
+        raise NotImplementedError
+
+    def _release(self) -> None:
+        raise NotImplementedError
+
+
+class _FileLockOptions(TypedDict, total=False):
+    timeout: float
+    mode: int
+    thread_local: bool
+    blocking: bool
+    is_singleton: bool
+    poll_interval: float
+    lifetime: float | None
+    context_error_policy: ContextErrorPolicy
+    close_error_policy: CloseErrorPolicy
+    fallback_to_soft: bool
+    preserve_lock_file: bool
+    on_acquired: Callable[[int], None] | None
+
+
+class _AsyncFileLockOptions(_FileLockOptions, total=False):
+    loop: asyncio.AbstractEventLoop | None
+    run_in_executor: bool
+    executor: Executor | None
+
+
+class _UnknownFileLockConstructor(Protocol):
+    def __call__(self, lock_file: str, *, unknown: bool) -> BaseFileLock: ...


### PR DESCRIPTION
Filelock discarded non-default safety options when a subclass narrowed its `__init__` signature, and subclasses with `**kwargs` did not receive base lock options. Construction returned an instance whose behavior differed from the requested policy. This closes [issue #628](https://github.com/tox-dev/filelock/issues/628).

Filelock now forwards all options to keyword-capable subclasses and rejects unsupported non-default options for narrow constructors. A weak, locked per-subclass signature cache preserves dynamic class reclamation and cuts repeated construction from 28.3 µs to 2.31 µs on Python 3.14.6.
