### PR TITLE
🐛 fix(api): retain acquisition path identity

### DIFF
--- a/docs/changelog/647.bugfix.rst
+++ b/docs/changelog/647.bugfix.rst
@@ -1,0 +1,2 @@
+Release now removes the path identity that acquisition recorded instead of resolving a symlinked parent again. When
+acquisition raises, its rollback no longer deletes the holder's deadlock record.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -797,7 +797,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         if self.is_locked:
             self._commit_acquire(canonical)
         else:
-            self._undo_acquire(canonical)
+            self._undo_acquire()
 
     def _invoke_on_acquired(self) -> None:
         # Runs inside the backend _acquire (in the executor for async locks), once the native lock is held and the
@@ -818,20 +818,24 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
                 _raise_body_and_release(callback_error, release_error)
             raise
 
-    def _undo_acquire(self, canonical: str) -> None:
+    def _undo_acquire(self) -> None:
         """Roll back the counter after a failed acquire, dropping the registry entry once nothing holds the path."""
         self._context.lock_counter = max(0, self._context.lock_counter - 1)
         if self._context.lock_counter == 0:
-            _registry.held.pop(canonical, None)
+            self._drop_registry_entry()
 
     def _commit_acquire(self, canonical: str) -> None:
         """Record this instance as the holder once the first acquire succeeds, so peers can detect the deadlock."""
         if self._context.lock_counter == 1:
+            self._context.lock_file_key = canonical
             _registry.held[canonical] = id(self)
 
     def _drop_registry_entry(self) -> None:
-        """Forget this path's holder on release so a later cross-instance acquire is not misread as a deadlock."""
-        _registry.held.pop(_canonical(self.lock_file), None)
+        """Forget the key owned by this hold without resolving a mutable path again."""
+        canonical = self._context.lock_file_key
+        self._context.lock_file_key = None
+        if canonical is not None:
+            _registry.held.pop(canonical, None)
 
     def _commit_release(self) -> None:
         """Record the lock as fully released: reset the recursion counter and drop the deadlock-registry entry."""
@@ -927,6 +931,9 @@ class FileLockContext:
 
     #: Depth of nested acquisitions; the lock is released only when it returns to 0.
     lock_counter: int = 0
+
+    #: Canonical registry key captured when the first physical acquisition commits.
+    lock_file_key: str | None = None
 
 
 class ThreadLocalFileContext(FileLockContext, local):

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -10,7 +10,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from errno import EIO, ENOSYS
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pytest
 
@@ -394,6 +394,20 @@ async def test_non_blocking_gives_timeout_not_deadlock(tmp_path: Path, lock_type
             await lock2.acquire()
 
 
+@pytest.mark.parametrize(
+    "mode",
+    [pytest.param("finite", id="finite"), pytest.param("nonblocking", id="nonblocking")],
+)
+@pytest.mark.asyncio
+async def test_failed_acquire_keeps_holder_registered(tmp_path: Path, mode: Literal["finite", "nonblocking"]) -> None:
+    lock_path = tmp_path / "test.lock"
+    async with AsyncFileLock(lock_path, run_in_executor=False):
+        with pytest.raises(Timeout):
+            await _acquire_for_mode(AsyncFileLock(lock_path, run_in_executor=False), mode)
+        with pytest.raises(RuntimeError, match="Deadlock"):
+            await AsyncFileLock(lock_path, run_in_executor=False).acquire(cancel_check=lambda: True)
+
+
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio
 async def test_different_paths_no_conflict(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
@@ -467,6 +481,46 @@ async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseA
             await lock2.acquire()
 
 
+@_UNIX_FLOCK_ONLY
+@pytest.mark.parametrize(
+    ("depth", "force"),
+    [
+        pytest.param(1, False, id="direct"),
+        pytest.param(2, False, id="nested"),
+        pytest.param(2, True, id="forced"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Path, depth: int, force: bool) -> None:
+    lock_path, original_path, replacement_path = _symlinked_lock_paths(tmp_path)
+    lock = AsyncFileLock(lock_path, run_in_executor=False)
+    for _depth in range(depth):
+        await lock.acquire()
+    _retarget_parent(lock_path, replacement_path)
+
+    if force:
+        await lock.release(force=True)
+    else:
+        for _depth in range(depth):
+            await lock.release()
+
+    async with AsyncFileLock(original_path, run_in_executor=False) as successor:
+        assert successor.is_locked
+
+
+@_UNIX_FLOCK_ONLY
+@pytest.mark.asyncio
+async def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:
+    lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
+    original = AsyncFileLock(lock_path, run_in_executor=False)
+    await original.acquire()
+    _retarget_parent(lock_path, replacement_path)
+    async with AsyncFileLock(replacement_path, run_in_executor=False):
+        await original.release()
+        with pytest.raises(RuntimeError, match="Deadlock"):
+            await AsyncFileLock(replacement_path, run_in_executor=False).acquire(cancel_check=lambda: True)
+
+
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio
 async def test_deadlock_registry_cleanup_on_release(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
@@ -493,6 +547,29 @@ async def test_force_release_clears_registry(tmp_path: Path, lock_type: type[Bas
     lock2 = lock_type(lock_path)
     async with lock2:
         assert lock2.is_locked
+
+
+def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    original = tmp_path / "original"
+    replacement = tmp_path / "replacement"
+    original.mkdir()
+    replacement.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(original, target_is_directory=True)
+    return link / "test.lock", original / "test.lock", replacement / "test.lock"
+
+
+def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:
+    link = lock_path.parent
+    link.unlink()
+    link.symlink_to(replacement_path.parent, target_is_directory=True)
+
+
+async def _acquire_for_mode(lock: BaseAsyncFileLock, mode: Literal["finite", "nonblocking"]) -> None:
+    if mode == "finite":
+        await lock.acquire(timeout=0)
+    else:
+        await lock.acquire(blocking=False)
 
 
 @_UNIX_FLOCK_ONLY

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -13,7 +13,7 @@ from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IMODE, S_IWGRP, S_IWOTH, S_IWUSR, filemode
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, Literal
 from uuid import uuid4
 from weakref import WeakValueDictionary
 
@@ -1248,6 +1248,19 @@ def test_non_blocking_gives_timeout_not_deadlock(tmp_path: Path, lock_type: type
             lock2.acquire()
 
 
+@pytest.mark.parametrize(
+    "mode",
+    [pytest.param("finite", id="finite"), pytest.param("nonblocking", id="nonblocking")],
+)
+def test_failed_acquire_keeps_holder_registered(tmp_path: Path, mode: Literal["finite", "nonblocking"]) -> None:
+    lock_path = tmp_path / "test.lock"
+    with FileLock(lock_path):
+        with pytest.raises(Timeout):
+            _acquire_for_mode(FileLock(lock_path), mode)
+        with pytest.raises(RuntimeError, match="Deadlock"):
+            FileLock(lock_path).acquire(cancel_check=lambda: True)
+
+
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_different_paths_no_conflict(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     lock1 = lock_type(tmp_path / "a.lock")
@@ -1318,6 +1331,44 @@ def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLoc
             lock2.acquire()
 
 
+@_UNIX_FLOCK_ONLY
+@pytest.mark.parametrize(
+    ("depth", "force"),
+    [
+        pytest.param(1, False, id="direct"),
+        pytest.param(2, False, id="nested"),
+        pytest.param(2, True, id="forced"),
+    ],
+)
+def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Path, depth: int, force: bool) -> None:
+    lock_path, original_path, replacement_path = _symlinked_lock_paths(tmp_path)
+    lock = FileLock(lock_path)
+    for _depth in range(depth):
+        lock.acquire()
+    _retarget_parent(lock_path, replacement_path)
+
+    if force:
+        lock.release(force=True)
+    else:
+        for _depth in range(depth):
+            lock.release()
+
+    with FileLock(original_path) as successor:
+        assert successor.is_locked
+
+
+@_UNIX_FLOCK_ONLY
+def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:
+    lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
+    original = FileLock(lock_path)
+    original.acquire()
+    _retarget_parent(lock_path, replacement_path)
+    with FileLock(replacement_path):
+        original.release()
+        with pytest.raises(RuntimeError, match="Deadlock"):
+            FileLock(replacement_path).acquire(cancel_check=lambda: True)
+
+
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_deadlock_registry_cleanup_on_release(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     lock_path = tmp_path / "test.lock"
@@ -1342,6 +1393,29 @@ def test_force_release_cleans_registry(tmp_path: Path, lock_type: type[BaseFileL
     lock2 = lock_type(lock_path)
     with lock2:
         assert lock2.is_locked
+
+
+def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    original = tmp_path / "original"
+    replacement = tmp_path / "replacement"
+    original.mkdir()
+    replacement.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(original, target_is_directory=True)
+    return link / "test.lock", original / "test.lock", replacement / "test.lock"
+
+
+def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:
+    link = lock_path.parent
+    link.unlink()
+    link.symlink_to(replacement_path.parent, target_is_directory=True)
+
+
+def _acquire_for_mode(lock: BaseFileLock, mode: Literal["finite", "nonblocking"]) -> None:
+    if mode == "finite":
+        lock.acquire(timeout=0)
+    else:
+        lock.acquire(blocking=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
Release resolved a mutable parent symlink twice. If its target changed while held, the original registry record remained, and release could delete a live holder's record at the new target. A finite or nonblocking acquisition that raised could also delete its peer's record. This closes [issue #632](https://github.com/tox-dev/filelock/issues/632).

The lock context now stores the path identity owned by the first physical acquisition. Recursive acquisition preserves it, while final release, forced release, and rollback clear only that identity. Backend paths and singleton construction retain their existing behavior, and Unix release avoids a second `realpath()` lookup.
