### PR TITLE
🐛 fix(api): detach grouped release errors

### DIFF
--- a/docs/changelog/648.bugfix.rst
+++ b/docs/changelog/648.bugfix.rst
@@ -1,0 +1,1 @@
+Remove the body error from implicit context on the release error before adding both errors to an exception group.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -60,6 +60,8 @@ def _raise_body_and_release(body_error: BaseException, release_error: BaseExcept
     # other's __context__. BaseExceptionGroup returns a plain ExceptionGroup when both leaves subclass Exception, so
     # ``except*`` and ``except Exception`` still catch them; a BaseException leaf (KeyboardInterrupt, CancelledError)
     # keeps the group outside ordinary handlers. ``from None`` stops the group itself gaining a redundant __context__.
+    if release_error.__context__ is body_error:
+        release_error.__context__ = None
     msg = "lock body and release both failed"
     raise _exception_group_cls()(msg, (body_error, release_error)) from None
 
@@ -939,4 +941,8 @@ __all__ = [
     "BaseFileLock",
     "CloseErrorPolicy",
     "ContextErrorPolicy",
+    "FileLockContext",
+    "FileLockMeta",
+    "_canonical",
+    "_raise_body_and_release",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import gc
+import os
 import sys
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from pytest_mock import MockerFixture
+
     from filelock._read_write import _cleanup_connections
 else:
     try:
@@ -25,3 +32,24 @@ def pytest_sessionfinish() -> None:
     if on_pypy:
         gc.collect()
         gc.collect()
+
+
+@pytest.fixture
+def close_failure(
+    mocker: MockerFixture,
+) -> Iterator[tuple[Callable[[int], None], OSError, RuntimeError]]:
+    locked_fd: int | None = None
+    release_error = OSError("release failed")
+    release_cause = RuntimeError("release cause")
+    release_error.__cause__ = release_cause
+    release_error.__suppress_context__ = True
+    real_close = os.close
+
+    def capture(fd: int) -> None:
+        nonlocal locked_fd
+        locked_fd = fd
+        mocker.patch("filelock._api.os.close", side_effect=release_error)
+
+    yield capture, release_error, release_cause
+    if locked_fd is not None:
+        real_close(locked_fd)

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -7,6 +7,7 @@ import os
 import sys
 import threading
 import time
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from errno import EIO, ENOSYS
 from pathlib import Path, PurePath
@@ -22,7 +23,7 @@ else:  # pragma: no cover (<py311)
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
 if TYPE_CHECKING:
-    from contextlib import AbstractAsyncContextManager
+    from collections.abc import Callable
 
     from pytest_mock import MockerFixture
 
@@ -535,64 +536,165 @@ async def test_async_zero_write_rolls_back_acquire(tmp_path: Path, mocker: Mocke
     assert not lock.is_locked
 
 
-async def _acquire_cm(lock: AsyncSoftFileLock, *, use_proxy: bool) -> AbstractAsyncContextManager[BaseAsyncFileLock]:
-    return await lock.acquire() if use_proxy else lock  # proxy exercises AsyncAcquireReturnProxy.__aexit__
-
-
-@pytest.mark.parametrize("use_proxy", [False, True], ids=["direct", "proxy"])
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
 @pytest.mark.asyncio
-async def test_context_group_reports_both_failures(tmp_path: Path, mocker: MockerFixture, use_proxy: bool) -> None:
-    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy="group")
-    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
-    cm = await _acquire_cm(lock, use_proxy=use_proxy)
+async def test_context_group_detaches_release_context(
+    tmp_path: Path,
+    close_failure: tuple[Callable[[int], None], OSError, RuntimeError],
+    *,
+    use_proxy: bool,
+) -> None:
+    capture, release_error, release_cause = close_failure
+    body_error = ValueError("body failed")
+    body_cause = LookupError("body cause")
+    lock = AsyncFileLock(
+        str(tmp_path / "a"),
+        thread_local=False,
+        context_error_policy="group",
+        close_error_policy="raise",
+        on_acquired=capture,
+    )
     with pytest.raises(ExceptionGroup) as info:
-        async with cm:
-            raise ValueError
-    body, release = info.value.exceptions
-    assert isinstance(body, ValueError)
-    assert isinstance(release, OSError)
+        async with await lock.acquire() if use_proxy else lock:
+            raise body_error from body_cause
+    assert (
+        info.value.exceptions,
+        body_error.__context__,
+        release_error.__context__,
+        body_error.__cause__,
+        release_error.__cause__,
+        body_error.__traceback__ is not None,
+        release_error.__traceback__ is not None,
+    ) == ((body_error, release_error), None, None, body_cause, release_cause, True, True)
 
 
-@pytest.mark.parametrize("use_proxy", [False, True], ids=["direct", "proxy"])
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="standard exception-group rendering requires Python 3.11")
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
+@pytest.mark.asyncio
+async def test_context_group_renders_independent_leaves(
+    tmp_path: Path,
+    close_failure: tuple[Callable[[int], None], OSError, RuntimeError],
+    *,
+    use_proxy: bool,
+) -> None:
+    capture, release_error, _ = close_failure
+    release_error.__cause__ = None
+    release_error.__suppress_context__ = False
+    body_error = ValueError("body failed")
+    lock = AsyncFileLock(
+        str(tmp_path / "a"),
+        thread_local=False,
+        context_error_policy="group",
+        close_error_policy="raise",
+        on_acquired=capture,
+    )
+    with pytest.raises(ExceptionGroup) as info:
+        async with await lock.acquire() if use_proxy else lock:
+            raise body_error
+    group_rendering = "".join(traceback.format_exception(info.value))
+    release_rendering = "".join(traceback.format_exception(release_error))
+    assert (
+        group_rendering.count("ValueError: body failed"),
+        release_rendering.count("ValueError: body failed"),
+        release_rendering.count("RuntimeError: release cause"),
+        release_rendering.count("OSError: release failed"),
+    ) == (1, 0, 0, 1)
+
+
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
 @pytest.mark.asyncio
 async def test_context_chain_keeps_release_error_with_body_in_context(
-    tmp_path: Path, mocker: MockerFixture, use_proxy: bool
+    tmp_path: Path,
+    close_failure: tuple[Callable[[int], None], OSError, RuntimeError],
+    *,
+    use_proxy: bool,
 ) -> None:
-    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy="chain")
-    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
-    cm = await _acquire_cm(lock, use_proxy=use_proxy)
+    capture, release_error, _ = close_failure
+    body_error = ValueError("body failed")
+    lock = AsyncFileLock(
+        str(tmp_path / "a"),
+        thread_local=False,
+        context_error_policy="chain",
+        close_error_policy="raise",
+        on_acquired=capture,
+    )
     with pytest.raises(OSError, match="release failed") as info:
-        async with cm:
-            raise ValueError
-    assert isinstance(info.value.__context__, ValueError)
+        async with await lock.acquire() if use_proxy else lock:
+            raise body_error
+    assert (info.value, release_error.__context__) == (release_error, body_error)
 
 
-@pytest.mark.parametrize("policy", ["chain", "group"])
+@pytest.mark.parametrize(
+    "policy",
+    [pytest.param("chain", id="chain"), pytest.param("group", id="group")],
+)
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
 @pytest.mark.asyncio
-async def test_context_body_only_failure_propagates_body(tmp_path: Path, policy: ContextErrorPolicy) -> None:
+async def test_context_body_only_failure_propagates_body(
+    tmp_path: Path, policy: ContextErrorPolicy, *, use_proxy: bool
+) -> None:
     lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy=policy)
     body = ValueError("body failed")
-    with pytest.raises(ValueError, match="body failed"):
-        async with lock:
+    with pytest.raises(ValueError, match="body failed") as info:
+        async with await lock.acquire() if use_proxy else lock:
             raise body
+    assert info.value is body
 
 
-@pytest.mark.parametrize("policy", ["chain", "group"])
+@pytest.mark.parametrize(
+    "policy",
+    [pytest.param("chain", id="chain"), pytest.param("group", id="group")],
+)
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
 @pytest.mark.asyncio
 async def test_context_release_only_failure_propagates_release(
-    tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
+    tmp_path: Path,
+    close_failure: tuple[Callable[[int], None], OSError, RuntimeError],
+    policy: ContextErrorPolicy,
+    *,
+    use_proxy: bool,
 ) -> None:
-    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy=policy)
-    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
-    with pytest.raises(OSError, match="release failed"):
-        async with lock:
+    capture, release_error, release_cause = close_failure
+    lock = AsyncFileLock(
+        str(tmp_path / "a"),
+        thread_local=False,
+        context_error_policy=policy,
+        close_error_policy="raise",
+        on_acquired=capture,
+    )
+    with pytest.raises(OSError, match="release failed") as info:
+        async with await lock.acquire() if use_proxy else lock:
             pass
+    assert (info.value, release_error.__context__, release_error.__cause__) == (release_error, None, release_cause)
 
 
 @pytest.mark.asyncio
-async def test_context_group_base_exception_leaf_is_base_group(tmp_path: Path, mocker: MockerFixture) -> None:
-    lock = AsyncSoftFileLock(str(tmp_path / "a"), context_error_policy="group")
-    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+async def test_context_group_base_exception_leaf_is_base_group(
+    tmp_path: Path, close_failure: tuple[Callable[[int], None], OSError, RuntimeError]
+) -> None:
+    capture, _, _ = close_failure
+    lock = AsyncFileLock(
+        str(tmp_path / "a"),
+        thread_local=False,
+        context_error_policy="group",
+        close_error_policy="raise",
+        on_acquired=capture,
+    )
     with pytest.raises(BaseExceptionGroup) as info:
         async with lock:
             raise KeyboardInterrupt
@@ -700,3 +802,29 @@ async def test_on_acquired_async_failure_releases(tmp_path: Path) -> None:
         await lock.acquire()
     assert not lock.is_locked
     assert lock.lock_counter == 0
+
+
+@pytest.mark.asyncio
+async def test_on_acquired_rollback_group_detaches_release_context(
+    tmp_path: Path, close_failure: tuple[Callable[[int], None], OSError, RuntimeError]
+) -> None:
+    capture, release_error, release_cause = close_failure
+    callback_error = RuntimeError("hook failed")
+    callback_cause = LookupError("hook cause")
+
+    def fail(fd: int) -> None:
+        capture(fd)
+        raise callback_error from callback_cause
+
+    lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, close_error_policy="raise", on_acquired=fail)
+    with pytest.raises(ExceptionGroup) as info:
+        await lock.acquire()
+    assert (
+        info.value.exceptions,
+        callback_error.__context__,
+        release_error.__context__,
+        callback_error.__cause__,
+        release_error.__cause__,
+        callback_error.__traceback__ is not None,
+        release_error.__traceback__ is not None,
+    ) == ((callback_error, release_error), None, None, callback_cause, release_cause, True, True)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -6,6 +6,7 @@ import os
 import sys
 import threading
 import time
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from errno import EAGAIN, EINTR, EIO, ENOSPC, ENOSYS, EWOULDBLOCK
@@ -38,7 +39,6 @@ else:  # pragma: no cover (<py311)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
-    from contextlib import AbstractContextManager
 
     from pytest_mock import MockerFixture
 
@@ -1532,64 +1532,124 @@ def test_windows_delete_in_progress_is_contention_not_denial(tmp_path: Path) -> 
         kernel32.CloseHandle(handle)
 
 
-def _enter_direct(lock: SoftFileLock) -> AbstractContextManager[object]:
-    return lock
-
-
-def _enter_proxy(lock: SoftFileLock) -> AbstractContextManager[object]:
-    return lock.acquire()  # exercises AcquireReturnProxy.__exit__ instead of BaseFileLock.__exit__
-
-
-_CONTEXT_ENTRIES: Final = [pytest.param(_enter_direct, id="direct"), pytest.param(_enter_proxy, id="proxy")]
-
-
-@pytest.mark.parametrize("enter", _CONTEXT_ENTRIES)
-def test_context_group_reports_both_failures(
-    tmp_path: Path, mocker: MockerFixture, enter: Callable[[SoftFileLock], AbstractContextManager[object]]
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
+def test_context_group_detaches_release_context(
+    tmp_path: Path,
+    close_failure: tuple[Callable[[int], None], OSError, RuntimeError],
+    *,
+    use_proxy: bool,
 ) -> None:
-    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy="group")
-    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
-    with pytest.raises(ExceptionGroup) as info, enter(lock):
-        raise ValueError
-    body, release = info.value.exceptions
-    assert isinstance(body, ValueError)
-    assert isinstance(release, OSError)
-    assert body.__traceback__ is not None  # leaves keep their own frames
-    assert release.__traceback__ is not None
+    capture, release_error, release_cause = close_failure
+    body_error = ValueError("body failed")
+    body_cause = LookupError("body cause")
+    lock = FileLock(str(tmp_path / "a"), context_error_policy="group", close_error_policy="raise", on_acquired=capture)
+    with pytest.raises(ExceptionGroup) as info, lock.acquire() if use_proxy else lock:
+        raise body_error from body_cause
+    assert (
+        info.value.exceptions,
+        body_error.__context__,
+        release_error.__context__,
+        body_error.__cause__,
+        release_error.__cause__,
+        body_error.__traceback__ is not None,
+        release_error.__traceback__ is not None,
+    ) == ((body_error, release_error), None, None, body_cause, release_cause, True, True)
 
 
-@pytest.mark.parametrize("enter", _CONTEXT_ENTRIES)
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="standard exception-group rendering requires Python 3.11")
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
+def test_context_group_renders_independent_leaves(
+    tmp_path: Path,
+    close_failure: tuple[Callable[[int], None], OSError, RuntimeError],
+    *,
+    use_proxy: bool,
+) -> None:
+    capture, release_error, _ = close_failure
+    release_error.__cause__ = None
+    release_error.__suppress_context__ = False
+    body_error = ValueError("body failed")
+    lock = FileLock(str(tmp_path / "a"), context_error_policy="group", close_error_policy="raise", on_acquired=capture)
+    with pytest.raises(ExceptionGroup) as info, lock.acquire() if use_proxy else lock:
+        raise body_error
+    group_rendering = "".join(traceback.format_exception(info.value))
+    release_rendering = "".join(traceback.format_exception(release_error))
+    assert (
+        group_rendering.count("ValueError: body failed"),
+        release_rendering.count("ValueError: body failed"),
+        release_rendering.count("RuntimeError: release cause"),
+        release_rendering.count("OSError: release failed"),
+    ) == (1, 0, 0, 1)
+
+
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
 def test_context_chain_keeps_release_error_with_body_in_context(
-    tmp_path: Path, mocker: MockerFixture, enter: Callable[[SoftFileLock], AbstractContextManager[object]]
+    tmp_path: Path,
+    close_failure: tuple[Callable[[int], None], OSError, RuntimeError],
+    *,
+    use_proxy: bool,
 ) -> None:
-    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy="chain")
-    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
-    with pytest.raises(OSError, match="release failed") as info, enter(lock):
-        raise ValueError
-    assert isinstance(info.value.__context__, ValueError)
+    capture, release_error, _ = close_failure
+    body_error = ValueError("body failed")
+    lock = FileLock(str(tmp_path / "a"), context_error_policy="chain", close_error_policy="raise", on_acquired=capture)
+    with pytest.raises(OSError, match="release failed") as info, lock.acquire() if use_proxy else lock:
+        raise body_error
+    assert (info.value, release_error.__context__) == (release_error, body_error)
 
 
-@pytest.mark.parametrize("policy", ["chain", "group"])
-def test_context_body_only_failure_propagates_body(tmp_path: Path, policy: ContextErrorPolicy) -> None:
+@pytest.mark.parametrize(
+    "policy",
+    [pytest.param("chain", id="chain"), pytest.param("group", id="group")],
+)
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
+def test_context_body_only_failure_propagates_body(
+    tmp_path: Path, policy: ContextErrorPolicy, *, use_proxy: bool
+) -> None:
     lock = SoftFileLock(str(tmp_path / "a"), context_error_policy=policy)
     body = ValueError("body failed")
-    with pytest.raises(ValueError, match="body failed"), lock:
+    with pytest.raises(ValueError, match="body failed") as info, lock.acquire() if use_proxy else lock:
         raise body
+    assert info.value is body
 
 
-@pytest.mark.parametrize("policy", ["chain", "group"])
+@pytest.mark.parametrize(
+    "policy",
+    [pytest.param("chain", id="chain"), pytest.param("group", id="group")],
+)
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
 def test_context_release_only_failure_propagates_release(
-    tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
+    tmp_path: Path,
+    close_failure: tuple[Callable[[int], None], OSError, RuntimeError],
+    policy: ContextErrorPolicy,
+    *,
+    use_proxy: bool,
 ) -> None:
-    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy=policy)
-    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
-    with pytest.raises(OSError, match="release failed"), lock:
+    capture, release_error, release_cause = close_failure
+    lock = FileLock(str(tmp_path / "a"), context_error_policy=policy, close_error_policy="raise", on_acquired=capture)
+    with pytest.raises(OSError, match="release failed") as info, lock.acquire() if use_proxy else lock:
         pass
+    assert (info.value, release_error.__context__, release_error.__cause__) == (release_error, None, release_cause)
 
 
-def test_context_group_base_exception_leaf_is_base_group(tmp_path: Path, mocker: MockerFixture) -> None:
-    lock = SoftFileLock(str(tmp_path / "a"), context_error_policy="group")
-    mocker.patch.object(lock, "release", side_effect=OSError("release failed"))
+def test_context_group_base_exception_leaf_is_base_group(
+    tmp_path: Path, close_failure: tuple[Callable[[int], None], OSError, RuntimeError]
+) -> None:
+    capture, _, _ = close_failure
+    lock = FileLock(str(tmp_path / "a"), context_error_policy="group", close_error_policy="raise", on_acquired=capture)
     with pytest.raises(BaseExceptionGroup) as info, lock:
         raise KeyboardInterrupt
     assert not isinstance(info.value, ExceptionGroup)  # a BaseException leaf stays outside except Exception
@@ -2136,6 +2196,31 @@ def test_on_acquired_and_release_failure_group(tmp_path: Path, mocker: MockerFix
     assert lock.is_locked  # the OS unlock failed, so the lock stays held for a retry
     assert lock.lock_counter == 1
     lock.release()  # the second unlock succeeds
+
+
+def test_on_acquired_rollback_group_detaches_release_context(
+    tmp_path: Path, close_failure: tuple[Callable[[int], None], OSError, RuntimeError]
+) -> None:
+    capture, release_error, release_cause = close_failure
+    callback_error = RuntimeError("hook failed")
+    callback_cause = LookupError("hook cause")
+
+    def fail(fd: int) -> None:
+        capture(fd)
+        raise callback_error from callback_cause
+
+    lock = FileLock(str(tmp_path / "a"), close_error_policy="raise", on_acquired=fail)
+    with pytest.raises(ExceptionGroup) as info:
+        lock.acquire()
+    assert (
+        info.value.exceptions,
+        callback_error.__context__,
+        release_error.__context__,
+        callback_error.__cause__,
+        release_error.__cause__,
+        callback_error.__traceback__ is not None,
+        release_error.__traceback__ is not None,
+    ) == ((callback_error, release_error), None, None, callback_cause, release_cause, True, True)
 
 
 @_UNIX_FLOCK_ONLY


### PR DESCRIPTION
Group mode produced two leaves that were not siblings. The release leaf retained the body as implicit context. Extraction exposed the mismatch. Rendering that leaf alone showed the body chain again. This closes [issue #631](https://github.com/tox-dev/filelock/issues/631).

The grouping helper removes the context only when it is the exact body exception. Explicit causes, tracebacks, group order and type, chain mode, single-failure behavior, and callback rollback retain their existing contracts.
