### PR TITLE
🐛 fix(soft): relinquish fd before close

### DIFF
--- a/docs/changelog/649.bugfix.rst
+++ b/docs/changelog/649.bugfix.rst
@@ -1,0 +1,2 @@
+Relinquish a soft lock's descriptor before one close attempt so a later release cannot close a reused descriptor number,
+and honor ``close_error_policy`` while still attempting marker cleanup.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -666,21 +666,25 @@ When both errors subclass :class:`Exception`, the group is a plain :class:`Excep
  Handle a close failure after unlock
 *****************************************
 
-Native locks close the lock descriptor after the OS unlock has committed. On FUSE and Docker overlay filesystems
-``os.close`` can fail with ``EIO`` even though the lock already released. ``close_error_policy`` decides the outcome:
+Native locks close their descriptor after the OS unlock commits. Soft locks close the marker descriptor after they
+capture its identity for safe cleanup. ``os.close`` can fail even though filelock has relinquished ownership;
+``close_error_policy`` decides the outcome:
 
-- ``"default"`` keeps each platform's historical behavior: Unix drops the error, Windows propagates it.
+- ``"default"`` keeps historical behavior: Unix native locks drop the error, while Windows native and soft locks
+  propagate it.
 - ``"raise"`` always propagates the ``OSError``.
 - ``"suppress"`` always ignores it.
 
 .. code-block:: python
 
-    from filelock import FileLock
+    from filelock import FileLock, SoftFileLock
 
-    lock = FileLock("work.lock", close_error_policy="suppress")
+    native_lock = FileLock("native.lock", close_error_policy="suppress")
+    soft_lock = SoftFileLock("soft.lock", close_error_policy="suppress")
 
-The lock is released in every case; the policy only governs the post-unlock ``os.close``. It does not affect unlock
-failures or lock-file deletion.
+Filelock relinquishes descriptor ownership before applying this policy and never retries the descriptor number. The
+policy does not affect native unlock failures or marker deletion. A soft lock still attempts identity-checked marker
+cleanup after a close error.
 
 ***********************************************
  Fail closed instead of downgrading to soft

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -25,7 +25,7 @@ _UNSET_FILE_MODE: Final[int] = -1
 ContextErrorPolicy = Literal["chain", "group"]
 _CONTEXT_ERROR_POLICIES: Final[frozenset[str]] = frozenset({"chain", "group"})
 
-#: What a native backend does with an ``os.close`` failure after the OS unlock committed (see the property).
+#: What a descriptor-owning backend does with an ``os.close`` failure after relinquishing ownership (see the property).
 CloseErrorPolicy = Literal["default", "raise", "suppress"]
 _CLOSE_ERROR_POLICIES: Final[frozenset[str]] = frozenset({"default", "raise", "suppress"})
 
@@ -56,15 +56,18 @@ def _exception_group_cls() -> type[BaseException]:
     return _Backport  # pragma: no cover (<py311)
 
 
+def _raise_grouped_errors(message: str, first_error: BaseException, second_error: BaseException) -> NoReturn:
+    if second_error.__context__ is first_error:
+        second_error.__context__ = None
+    raise _exception_group_cls()(message, (first_error, second_error)) from None
+
+
 def _raise_body_and_release(body_error: BaseException, release_error: BaseException) -> NoReturn:
     # Group mode: surface the body failure and the release failure as sibling leaves instead of letting one hide in the
     # other's __context__. BaseExceptionGroup returns a plain ExceptionGroup when both leaves subclass Exception, so
     # ``except*`` and ``except Exception`` still catch them; a BaseException leaf (KeyboardInterrupt, CancelledError)
     # keeps the group outside ordinary handlers. ``from None`` stops the group itself gaining a redundant __context__.
-    if release_error.__context__ is body_error:
-        release_error.__context__ = None
-    msg = "lock body and release both failed"
-    raise _exception_group_cls()(msg, (body_error, release_error)) from None
+    _raise_grouped_errors("lock body and release both failed", body_error, release_error)
 
 
 # On Windows os.path.realpath calls CreateFileW with share_mode=0, which blocks concurrent DeleteFileW and causes
@@ -404,11 +407,11 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             releasing on exit. ``"chain"`` (the default) keeps Python's behavior: the release error propagates with the
             body error in its ``__context__``. ``"group"`` raises a :class:`BaseExceptionGroup` holding the body error
             first and the release error second, so neither hides the other.
-        :param close_error_policy: for native locks (:class:`FileLock`), what to do with an ``os.close`` failure after
-            the OS unlock has already committed. ``"default"`` keeps each platform's historical behavior (Unix drops a
-            FUSE/Docker ``EIO``, Windows propagates); ``"raise"`` always propagates the ``OSError``; ``"suppress"``
-            always ignores it. Held state is released either way. It does not affect unlock failures or lock-file
-            deletion.
+        :param close_error_policy: what to do with an ``os.close`` failure after relinquishing descriptor ownership.
+            ``"default"`` keeps each backend's historical behavior (Unix native locks drop a FUSE/Docker ``EIO``;
+            Windows native locks and :class:`SoftFileLock` propagate); ``"raise"`` always propagates the ``OSError``;
+            ``"suppress"`` always ignores it. Held state is released either way. It does not affect unlock failures or
+            lock-file deletion.
         :param fallback_to_soft: for :class:`UnixFileLock`, whether to switch to :class:`SoftFileLock` when the
             filesystem's ``flock`` returns ``ENOSYS``. ``True`` (the default) keeps the historical fallback;
             ``False`` fails closed, letting the ``ENOSYS`` propagate so a caller that needs kernel-enforced
@@ -473,7 +476,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     @property
     def close_error_policy(self) -> CloseErrorPolicy:
         """
-        What a native lock does with an ``os.close`` failure after the OS unlock committed.
+        What a lock does with an ``os.close`` failure after relinquishing descriptor ownership.
 
         .. versionadded:: 3.30.0
 
@@ -481,10 +484,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         return self._close_error_policy
 
     def _close_released_fd(self, fd: int, *, default_suppresses: bool) -> None:
-        # Close the descriptor after the OS unlock has committed. CPython never retries close() after EINTR because the
-        # descriptor number may already be reused, so neither does this. close_error_policy decides the error's fate:
-        # "raise" propagates, "suppress" drops it, "default" keeps the backend's historical behavior (Unix suppresses a
-        # FUSE/Docker EIO, Windows propagates). Held state is already cleared, so the lock stays released either way.
+        # CPython never retries close() after EINTR because the descriptor number may already be reused, so neither does
+        # this. close_error_policy decides the error's fate after the backend relinquishes descriptor ownership.
         try:
             os.close(fd)
         except OSError:
@@ -1000,4 +1001,5 @@ __all__ = [
     "FileLockMeta",
     "_canonical",
     "_raise_body_and_release",
+    "_raise_grouped_errors",
 ]

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -10,7 +10,7 @@ from errno import EACCES, EEXIST, EPERM, ESRCH
 from pathlib import Path
 from typing import Final
 
-from ._api import BaseFileLock
+from ._api import BaseFileLock, _raise_grouped_errors
 from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file, write_all
 
 if sys.platform == "win32":  # pragma: win32 cover
@@ -220,8 +220,25 @@ class SoftFileLock(BaseFileLock):
         identity: tuple[int, int] | None = None
         with suppress(OSError):
             identity = _file_identity(os.fstat(fd))
-        os.close(fd)
+        # A failed close may already have released and recycled the descriptor number. Relinquish it before the one
+        # close attempt so no later release can close an unrelated descriptor that reused the same integer.
         self._context.lock_file_fd = None
+        try:
+            self._close_released_fd(fd, default_suppresses=False)
+        # Marker cleanup must also run for control-flow exceptions, and both failures must remain observable.
+        except BaseException as close_error:
+            try:
+                self._unlink_held_marker(identity)
+            except BaseException as cleanup_error:  # noqa: BLE001  # preserve control-flow cleanup failures
+                _raise_grouped_errors(
+                    "lock descriptor close and marker cleanup both failed",
+                    close_error,
+                    cleanup_error,
+                )
+            raise
+        self._unlink_held_marker(identity)
+
+    def _unlink_held_marker(self, identity: tuple[int, int] | None) -> None:
         if identity is None:
             return
         if sys.platform == "win32":

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -9,13 +9,14 @@ import threading
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
-from errno import EIO, ENOSYS
+from contextlib import contextmanager
+from errno import EINTR, EIO, ENOSYS
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Literal
 
 import pytest
 
-from filelock import AsyncFileLock, AsyncSoftFileLock, BaseAsyncFileLock, ContextErrorPolicy, Timeout
+from filelock import AsyncFileLock, AsyncSoftFileLock, BaseAsyncFileLock, CloseErrorPolicy, ContextErrorPolicy, Timeout
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup, ExceptionGroup
@@ -23,7 +24,7 @@ else:  # pragma: no cover (<py311)
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
     from pytest_mock import MockerFixture
 
@@ -611,6 +612,112 @@ async def test_async_zero_write_rolls_back_acquire(tmp_path: Path, mocker: Mocke
     with pytest.raises(OSError, match="0 bytes"):
         await lock.acquire()
     assert not lock.is_locked
+
+
+@pytest.mark.parametrize(
+    ("policy", "surfaces"),
+    [pytest.param("default", True, id="default"), pytest.param("suppress", False, id="suppress")],
+)
+@pytest.mark.asyncio
+async def test_soft_close_error_policy_cleans_marker(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    policy: CloseErrorPolicy,
+    *,
+    surfaces: bool,
+) -> None:
+    lock_path = tmp_path / "a"
+    lock = AsyncSoftFileLock(lock_path, close_error_policy=policy, run_in_executor=False)
+    await lock.acquire()
+    with _close_after_commit(mocker) as (close_error, attempts):
+        if surfaces:
+            with pytest.raises(OSError, match="close failed") as info:
+                await lock.release()
+            assert info.value is close_error
+        else:
+            await lock.release()
+    assert (len(attempts), lock.is_locked, lock.lock_counter, lock_path.exists()) == (1, False, 0, False)
+
+
+@pytest.mark.parametrize(
+    ("depth", "force"),
+    [pytest.param(2, False, id="nested"), pytest.param(2, True, id="forced")],
+)
+@pytest.mark.asyncio
+async def test_soft_close_error_suppression_releases_once(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    depth: int,
+    *,
+    force: bool,
+) -> None:
+    lock_path = tmp_path / "a"
+    lock = AsyncSoftFileLock(lock_path, close_error_policy="suppress", run_in_executor=False)
+    for _acquisition in range(depth):
+        await lock.acquire()
+    with _close_after_commit(mocker) as (_, attempts):
+        if force:
+            await lock.release(force=True)
+        else:
+            for _release in range(depth):
+                await lock.release()
+    assert (len(attempts), lock.is_locked, lock.lock_counter, lock_path.exists()) == (1, False, 0, False)
+
+
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
+@pytest.mark.asyncio
+async def test_soft_context_surfaces_close_error_after_cleanup(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    *,
+    use_proxy: bool,
+) -> None:
+    lock_path = tmp_path / "a"
+    lock = AsyncSoftFileLock(lock_path, run_in_executor=False)
+    with _close_after_commit(mocker) as (close_error, attempts), pytest.raises(OSError, match="close failed") as info:
+        async with await lock.acquire() if use_proxy else lock:
+            pass
+    assert (info.value, len(attempts), lock.is_locked, lock_path.exists()) == (close_error, 1, False, False)
+
+
+@pytest.mark.asyncio
+async def test_soft_second_release_does_not_close_reused_descriptor(
+    tmp_path: Path,
+    mocker: MockerFixture,
+) -> None:
+    lock = AsyncSoftFileLock(tmp_path / "a", run_in_executor=False)
+    await lock.acquire()
+    with _close_after_commit(mocker) as (close_error, attempts), pytest.raises(OSError, match="close failed") as info:
+        await lock.release()
+    assert info.value is close_error
+    reused_fd = os.open(tmp_path / "reused", os.O_CREAT | os.O_WRONLY)
+    assert reused_fd == attempts[0]
+    try:
+        await lock.release()
+        os.fstat(reused_fd)
+    finally:
+        os.close(reused_fd)
+
+
+@contextmanager
+def _close_after_commit(mocker: MockerFixture) -> Iterator[tuple[OSError, list[int]]]:
+    real_close = os.close
+    close_error = OSError(EINTR, "close failed")
+    attempts: list[int] = []
+
+    def close(fd: int) -> None:
+        real_close(fd)
+        attempts.append(fd)
+        raise close_error
+
+    close_mock = mocker.patch("filelock._soft.os.close", side_effect=close)
+    try:
+        yield close_error, attempts
+    finally:
+        mocker.stop(close_mock)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -3,16 +3,23 @@ from __future__ import annotations
 import os
 import socket
 import sys
-from errno import ENODEV, ENOSPC, EPERM
+from contextlib import contextmanager
+from errno import EINTR, ENODEV, ENOSPC, EPERM
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 import pytest
 
-from filelock import SoftFileLock
+from filelock import CloseErrorPolicy, SoftFileLock
 from filelock._soft import _MAX_LOCK_FILE_SIZE
 
+if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+    from builtins import ExceptionGroup
+else:  # pragma: no cover (<py311)
+    from exceptiongroup import ExceptionGroup
+
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from unittest.mock import MagicMock
 
     from pytest_mock import MockerFixture
@@ -438,3 +445,145 @@ def test_windows_release_spares_a_replacement(lock_path: Path, mocker: MockerFix
     lock.release()
     assert lock_path.exists()
     lock_path.unlink()
+
+
+@pytest.mark.parametrize(
+    ("policy", "surfaces"),
+    [
+        pytest.param("default", True, id="default"),
+        pytest.param("raise", True, id="raise"),
+        pytest.param("suppress", False, id="suppress"),
+    ],
+)
+def test_close_error_policy_cleans_marker(
+    lock_path: Path,
+    mocker: MockerFixture,
+    policy: CloseErrorPolicy,
+    *,
+    surfaces: bool,
+) -> None:
+    lock = SoftFileLock(lock_path, close_error_policy=policy)
+    lock.acquire()
+    with _close_after_commit(mocker) as (close_error, attempts):
+        if surfaces:
+            with pytest.raises(OSError, match="close failed") as info:
+                lock.release()
+            assert info.value is close_error
+        else:
+            lock.release()
+    assert (len(attempts), lock.is_locked, lock.lock_counter, lock_path.exists()) == (1, False, 0, False)
+
+
+@pytest.mark.parametrize(
+    ("depth", "force"),
+    [pytest.param(2, False, id="nested"), pytest.param(2, True, id="forced")],
+)
+def test_close_error_suppression_releases_once(
+    lock_path: Path,
+    mocker: MockerFixture,
+    depth: int,
+    *,
+    force: bool,
+) -> None:
+    lock = SoftFileLock(lock_path, close_error_policy="suppress")
+    for _acquisition in range(depth):
+        lock.acquire()
+    with _close_after_commit(mocker) as (_, attempts):
+        if force:
+            lock.release(force=True)
+        else:
+            for _release in range(depth):
+                lock.release()
+    assert (len(attempts), lock.is_locked, lock.lock_counter, lock_path.exists()) == (1, False, 0, False)
+
+
+@pytest.mark.parametrize(
+    "use_proxy",
+    [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],
+)
+def test_context_surfaces_close_error_after_cleanup(
+    lock_path: Path,
+    mocker: MockerFixture,
+    *,
+    use_proxy: bool,
+) -> None:
+    lock = SoftFileLock(lock_path)
+    with (
+        _close_after_commit(mocker) as (close_error, attempts),
+        pytest.raises(OSError, match="close failed") as info,
+        lock.acquire() if use_proxy else lock,
+    ):
+        pass
+    assert (info.value, len(attempts), lock.is_locked, lock_path.exists()) == (close_error, 1, False, False)
+
+
+def test_second_release_does_not_close_reused_descriptor(
+    lock_path: Path,
+    tmp_path: Path,
+    mocker: MockerFixture,
+) -> None:
+    lock = SoftFileLock(lock_path)
+    lock.acquire()
+    with _close_after_commit(mocker) as (close_error, attempts), pytest.raises(OSError, match="close failed") as info:
+        lock.release()
+    assert info.value is close_error
+    reused_fd = os.open(tmp_path / "reused", os.O_CREAT | os.O_WRONLY)
+    assert reused_fd == attempts[0]
+    try:
+        lock.release()
+        os.fstat(reused_fd)
+    finally:
+        os.close(reused_fd)
+
+
+@_UNIX_ONLY
+def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixture) -> None:
+    holder = SoftFileLock(lock_path)
+    holder.acquire()
+    lock_path.unlink()
+    lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
+    with _close_after_commit(mocker) as (_, _attempts), pytest.raises(OSError, match="close failed"):
+        holder.release()
+    assert lock_path.read_text(encoding="utf-8") == _holder(_DEAD_PID)
+
+
+@_UNIX_ONLY
+def test_close_and_marker_cleanup_failures_are_grouped(lock_path: Path, mocker: MockerFixture) -> None:
+    lock = SoftFileLock(lock_path)
+    lock.acquire()
+    cleanup_error = RuntimeError("cleanup failed")
+    unlink_mock = mocker.patch("filelock._soft.Path.unlink", side_effect=cleanup_error)
+    with _close_after_commit(mocker) as (close_error, _attempts), pytest.raises(ExceptionGroup) as info:
+        lock.release()
+    mocker.stop(unlink_mock)
+    assert (
+        info.value.message,
+        info.value.exceptions,
+        close_error.__context__,
+        cleanup_error.__context__,
+        lock.is_locked,
+    ) == (
+        "lock descriptor close and marker cleanup both failed",
+        (close_error, cleanup_error),
+        None,
+        None,
+        False,
+    )
+
+
+@contextmanager
+def _close_after_commit(mocker: MockerFixture) -> Iterator[tuple[OSError, list[int]]]:
+    real_close = os.close
+    close_error = OSError(EINTR, "close failed")
+    attempts: list[int] = []
+
+    def close(fd: int) -> None:
+        real_close(fd)
+        attempts.append(fd)
+        raise close_error
+
+    close_mock = mocker.patch("filelock._soft.os.close", side_effect=close)
+    try:
+        yield close_error, attempts
+    finally:
+        mocker.stop(close_mock)


### PR DESCRIPTION
`SoftFileLock` left its descriptor recorded as held until `os.close()` returned. A failed close can still retire the descriptor, so a later release could close an unrelated file after the OS reused the integer. [Issue #633](https://github.com/tox-dev/filelock/issues/633) documents this ambiguity; [CPython's `os.close()` implementation](https://github.com/python/cpython/blob/ed716551e13d1e46a5cd17955657d64b8824626a/Modules/posixmodule.c#L11772-L11791) and the [Linux `close(2)` notes](https://man7.org/linux/man-pages/man2/close.2.html) explain why callers must not retry.

The release clears descriptor ownership before one close attempt, captures marker identity first, and performs marker cleanup even when close fails. `close_error_policy` now governs soft-lock close errors while preserving its historical `default` behavior. If close and cleanup both fail, the release keeps them as sibling errors under the grouped-failure contract from [#648](https://github.com/tox-dev/filelock/pull/648).

Existing call signatures and defaults remain compatible. The branch builds on [#648](https://github.com/tox-dev/filelock/pull/648), which should merge first. Closes #633.
