### PR TITLE
🐛 fix(descriptor): define unavailable behavior

### DIFF
--- a/docs/changelog/650.bugfix.rst
+++ b/docs/changelog/650.bugfix.rst
@@ -1,0 +1,2 @@
+Raise ``OSError(errno.ENOSYS)`` from descriptor locks when ``fcntl`` is unavailable, and reject invalid blocking poll
+intervals before attempting a lock.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -779,6 +779,11 @@ lock and a ``FileLock`` path lock on the same file contend with each other.
     finally:
         os.close(fd)
 
-Pass ``blocking=False`` for a single attempt that returns ``False`` on contention. There is no async wrapper: run it in
-an executor, or drive ``blocking=False`` from your own polling loop. On Windows *fd* must be a synchronous descriptor.
-For timeout, reentrancy, singleton, lifetime, or stale-break behavior, use :class:`FileLock <filelock.FileLock>`.
+Pass ``blocking=False`` for a single attempt that returns ``False`` on contention and ignores ``poll_interval``.
+Blocking calls require a finite, positive ``poll_interval``. There is no async wrapper. Run it in an executor, or drive
+``blocking=False`` from your own polling loop. On Windows *fd* must be a synchronous descriptor.
+
+Both functions raise ``OSError`` with :data:`errno.ENOSYS` when the Python build lacks the native locking primitive.
+The :class:`FileLock <filelock.FileLock>` and :class:`AsyncFileLock <filelock.AsyncFileLock>` aliases continue to select
+their soft implementations on those builds. For timeout, reentrancy, singleton, lifetime, or stale-break behavior, use
+:class:`FileLock <filelock.FileLock>`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,9 @@ run.concurrency = [
   "thread",
 ]
 run.parallel = true
+run.patch = [
+  "subprocess",
+]
 run.plugins = [
   "covdefaults",
 ]

--- a/src/filelock/_descriptor.py
+++ b/src/filelock/_descriptor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sys
 import time
+from math import isfinite
+from typing import Final
 
 if sys.platform == "win32":  # pragma: win32 cover
     from ._windows import _lock_fd_nonblocking, _unlock_fd
@@ -21,22 +23,28 @@ def lock_descriptor(fd: int, *, blocking: bool = True, poll_interval: float = 0.
     close it. On Windows *fd* must be a synchronous descriptor (its handle not opened with ``FILE_FLAG_OVERLAPPED``).
 
     For timeout, reentrancy, singleton, lifetime, or stale-break behavior, use :class:`FileLock`. There is no async
-    wrapper: run this in an executor, or drive ``blocking=False`` from your own polling loop.
+    wrapper. Run this in an executor, or drive ``blocking=False`` from your own polling loop.
 
     :param fd: an open file descriptor the caller owns.
     :param blocking: when ``True`` (default), retry the nonblocking attempt every *poll_interval* seconds until it
         succeeds; when ``False``, make one attempt.
-    :param poll_interval: seconds between attempts while blocking.
+    :param poll_interval: finite, positive seconds between attempts while blocking; ignored when *blocking* is
+        ``False``.
 
     :returns: ``True`` once the lock is held, or ``False`` on contention when ``blocking`` is ``False``.
 
-    :raises OSError: for a permanent native failure, such as an invalid descriptor. The descriptor is left open.
+    :raises OSError: for a permanent native failure, such as an invalid descriptor, or with ``errno.ENOSYS`` when the
+        Python build lacks the native locking primitive. The descriptor is left open.
+    :raises ValueError: if a blocking call receives a non-finite or non-positive *poll_interval*.
 
     .. versionadded:: 3.30.0
 
     """
     if not blocking:
         return _lock_fd_nonblocking(fd)
+    if not isfinite(poll_interval) or poll_interval <= 0:
+        msg: Final[str] = f"poll_interval must be finite and greater than 0, got {poll_interval}"
+        raise ValueError(msg)
     while not _lock_fd_nonblocking(fd):
         time.sleep(poll_interval)
     return True
@@ -48,7 +56,8 @@ def unlock_descriptor(fd: int) -> None:
 
     :param fd: the descriptor a prior :func:`lock_descriptor` locked; the caller still owns and must close it.
 
-    :raises OSError: if the native unlock fails; the caller may retry on the same descriptor.
+    :raises OSError: if the native unlock fails, including ``errno.ENOSYS`` when the Python build lacks the native
+        locking primitive; the caller may retry on the same descriptor.
 
     .. versionadded:: 3.30.0
 

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -29,28 +29,33 @@ else:  # pragma: win32 no cover
 
         _ = (fcntl.flock, fcntl.LOCK_EX, fcntl.LOCK_NB, fcntl.LOCK_UN)
     except (ImportError, AttributeError):
-        pass
+        _FCNTL_UNAVAILABLE: Final[str] = "fcntl is unavailable"
+
+        def _lock_fd_nonblocking(_fd: int) -> bool:
+            raise OSError(ENOSYS, _FCNTL_UNAVAILABLE)
+
+        def _unlock_fd(_fd: int) -> None:
+            raise OSError(ENOSYS, _FCNTL_UNAVAILABLE)
+
     else:
         has_fcntl = True
+        # Contention errnos for a nonblocking flock. EAGAIN/EWOULDBLOCK are the usual "held elsewhere" codes; some
+        # filesystems report EACCES instead, so treat it as contention too rather than a permanent error.
+        _CONTENTION_ERRNOS: Final[frozenset[int]] = frozenset({EACCES, EAGAIN, EWOULDBLOCK})
 
-    # Contention errnos for a nonblocking flock. EAGAIN/EWOULDBLOCK are the usual "held elsewhere" codes; some
-    # filesystems report EACCES instead, so treat it as contention too rather than a permanent error.
-    _CONTENTION_ERRNOS: Final[frozenset[int]] = frozenset({EACCES, EAGAIN, EWOULDBLOCK})
+        def _lock_fd_nonblocking(fd: int) -> bool:
+            # One nonblocking exclusive flock attempt shared by UnixFileLock and lock_descriptor, so both contend on
+            # the same lock and classify errors identically. The caller owns fd; this never closes it.
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exception:
+                if exception.errno in _CONTENTION_ERRNOS:
+                    return False
+                raise
+            return True
 
-    def _lock_fd_nonblocking(fd: int) -> bool:
-        # One nonblocking exclusive flock attempt shared by UnixFileLock and lock_descriptor, so both contend on the
-        # same lock and classify errors identically. True on acquisition, False on contention, raise otherwise. The
-        # caller owns fd; this never closes it.
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError as exception:
-            if exception.errno in _CONTENTION_ERRNOS:
-                return False
-            raise
-        return True
-
-    def _unlock_fd(fd: int) -> None:
-        fcntl.flock(fd, fcntl.LOCK_UN)
+        def _unlock_fd(fd: int) -> None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
 
     class UnixFileLock(BaseFileLock):
         """
@@ -162,7 +167,7 @@ else:  # pragma: win32 no cover
             self._close_released_fd(fd, default_suppresses=True)
 
 
-__all__ = [
-    "UnixFileLock",
-    "has_fcntl",
-]
+if sys.platform == "win32":  # pragma: win32 cover
+    __all__ = ["UnixFileLock", "has_fcntl"]
+else:  # pragma: win32 no cover
+    __all__ = ["UnixFileLock", "_lock_fd_nonblocking", "_unlock_fd", "has_fcntl"]

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -124,6 +124,13 @@ _WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != 
 _UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     sys.platform == "win32", reason="native flock semantics are Unix-only"
 )
+_INVALID_DESCRIPTOR_POLL_INTERVALS: Final = (
+    pytest.param(0.0, id="zero"),
+    pytest.param(-0.01, id="negative"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="positive-infinity"),
+    pytest.param(float("-inf"), id="negative-infinity"),
+)
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
@@ -1853,6 +1860,28 @@ def test_lock_descriptor_invalid_fd_raises(tmp_path: Path) -> None:
         lock_descriptor(fd, blocking=False)
 
 
+@pytest.mark.parametrize(
+    "poll_interval",
+    _INVALID_DESCRIPTOR_POLL_INTERVALS,
+)
+def test_lock_descriptor_rejects_invalid_blocking_poll_interval(poll_interval: float) -> None:
+    with pytest.raises(ValueError, match="poll_interval must be finite and greater than 0"):
+        lock_descriptor(-1, poll_interval=poll_interval)
+
+
+@pytest.mark.parametrize(
+    "poll_interval",
+    _INVALID_DESCRIPTOR_POLL_INTERVALS,
+)
+def test_lock_descriptor_nonblocking_ignores_poll_interval(tmp_path: Path, poll_interval: float) -> None:
+    fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
+    try:
+        assert lock_descriptor(fd, blocking=False, poll_interval=poll_interval) is True
+        unlock_descriptor(fd)
+    finally:
+        os.close(fd)
+
+
 @pytest.mark.parametrize("direction", ["filelock_first", "descriptor_first"])
 def test_filelock_and_descriptor_contend(tmp_path: Path, direction: str) -> None:
     path = str(tmp_path / "a")
@@ -1928,6 +1957,34 @@ def test_lock_descriptor_blocking_retries_until_free(tmp_path: Path, mocker: Moc
     finally:
         os.close(holder)
         os.close(fd)
+
+
+def test_lock_descriptor_blocking_wait_does_not_spin(tmp_path: Path) -> None:
+    path = str(tmp_path / "a")
+    holder = os.open(path, os.O_RDWR | os.O_CREAT)
+    contender = os.open(path, os.O_RDWR | os.O_CREAT)
+    assert lock_descriptor(holder, blocking=False) is True
+    started = threading.Event()
+
+    def acquire() -> float:
+        started.set()
+        before = time.thread_time()
+        lock_descriptor(contender, poll_interval=0.01)
+        return time.thread_time() - before
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(acquire)
+            try:
+                assert started.wait(timeout=1)
+                time.sleep(0.2)
+            finally:
+                unlock_descriptor(holder)
+            assert future.result(timeout=2) < 0.05
+            unlock_descriptor(contender)
+    finally:
+        os.close(holder)
+        os.close(contender)
 
 
 def test_preserve_lock_file_defaults_off(tmp_path: Path) -> None:

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import os
 import socket
+import subprocess  # noqa: S404  # a clean interpreter isolates the blocked fcntl import
 import sys
 from errno import EIO, ENOSYS
+from textwrap import dedent
 from typing import TYPE_CHECKING, Final
 
 import pytest
@@ -17,6 +19,51 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 _UNIX_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform == "win32", reason="unix-only flock fallback")
+
+
+@_UNIX_ONLY
+def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:
+    script: Final[str] = dedent(
+        """
+        import json
+        import sys
+        import warnings
+        from collections.abc import Callable
+        from errno import ENOSYS
+
+        sys.modules["fcntl"] = None
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            import filelock
+
+        def operation_errno(operation: Callable[[int], bool | None]) -> int | None:
+            try:
+                operation(-1)
+            except OSError as exception:
+                return exception.errno
+            return None
+
+        print(json.dumps({
+            "aliases": [
+                filelock.FileLock is filelock.SoftFileLock,
+                filelock.AsyncFileLock is filelock.AsyncSoftFileLock,
+            ],
+            "errors": [
+                operation_errno(filelock.lock_descriptor) == ENOSYS,
+                operation_errno(filelock.unlock_descriptor) == ENOSYS,
+            ],
+            "warnings": [str(item.message) for item in caught],
+        }, sort_keys=True))
+        """,
+    )
+    result: Final[subprocess.CompletedProcess[str]] = subprocess.run(
+        [sys.executable, "-c", script], check=True, capture_output=True, text=True
+    )
+
+    assert (result.stdout, result.stderr) == (
+        '{"aliases": [true, true], "errors": [true, true], "warnings": ["only soft file lock is available"]}\n',
+        "",
+    )
 
 
 @_UNIX_ONLY


### PR DESCRIPTION
Python builds without `fcntl` selected the soft `FileLock` aliases but left the public caller-owned descriptor helpers bound to an unavailable name. Blocking descriptor calls also accepted non-positive and non-finite polling intervals, so invalid input could spin or fail after a native lock attempt. [Issue #629](https://github.com/tox-dev/filelock/issues/629) records both portability gaps.

When `fcntl` is unavailable, descriptor lock and unlock operations now raise [`OSError(errno.ENOSYS)`](https://docs.python.org/3/library/errno.html#errno.ENOSYS). Blocking calls reject non-finite or non-positive intervals before the first native attempt. Nonblocking calls retain one attempt and ignore the interval; that path skips [`time.sleep()`](https://docs.python.org/3/library/time.html#time.sleep).

Valid intervals keep their current behavior, and `FileLock` plus `AsyncFileLock` continue to select soft implementations on builds without `fcntl`. Closes #629.
