### PR TITLE
🐛 fix(ci): map absolute coverage paths

### DIFF
--- a/docs/changelog/coverage-path-remapping.bugfix.rst
+++ b/docs/changelog/coverage-path-remapping.bugfix.rst
@@ -1,0 +1,1 @@
+Map coverage data from Unix and Windows tox environments to the source tree when jobs run from absolute checkout paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,8 +206,8 @@ paths.other = [
 ]
 paths.source = [
   "src",
-  ".tox/*/lib/*/site-packages",
-  ".tox\\*\\Lib\\site-packages",
+  "*/.tox/*/lib/*/site-packages",
+  "*/.tox/*/Lib/site-packages",
   "**/src",
   "**\\src",
 ]


### PR DESCRIPTION
Combined coverage cannot read artifacts from another runner because the current aliases start at a relative `.tox` directory. The failure affects the [current main workflow](https://github.com/tox-dev/filelock/actions/runs/29305144912) and blocks otherwise successful pull requests.

The aliases now match the tox installation suffix after any absolute checkout root. Coverage maps Unix `lib/<python>/site-packages` and Windows `Lib/site-packages` paths back to `src`, following the [coverage.py path remapping contract](https://coverage.readthedocs.io/en/7.15.1/config.html#paths).
