### PR TITLE
🐛 fix(fork): preserve parent ownership

### DIFF
--- a/docs/changelog/634.bugfix.rst
+++ b/docs/changelog/634.bugfix.rst
@@ -1,0 +1,6 @@
+Preserve parent lock ownership across ``fork()``. A child closes an inherited descriptor only while its identity still
+matches, so it neither unlocks nor unlinks the parent's lock. It clears inherited ownership state and singleton caches,
+then requires a new lock instance before acquiring. Fork-time construction replaces inherited cache mutexes and omits
+an instance whose construction crossed into the child from the cache. If ``fstat()`` cannot establish the identity,
+child cleanup skips the descriptor number because an earlier fork callback may have reused it. Descriptor tracking
+also covers third-party backends that fail after assigning a descriptor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ run.concurrency = [
 ]
 run.parallel = true
 run.patch = [
+  "_exit",
   "subprocess",
 ]
 run.plugins = [

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -10,8 +10,10 @@ import time
 import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import dataclass
-from threading import Lock, local
+from itertools import count, starmap
+from threading import Condition, Lock, RLock, get_ident, local
 from typing import TYPE_CHECKING, Final, Literal, NoReturn, TypeVar, cast
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
@@ -31,11 +33,31 @@ CloseErrorPolicy = Literal["default", "raise", "suppress"]
 _CLOSE_ERROR_POLICIES: Final[frozenset[str]] = frozenset({"default", "raise", "suppress"})
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from types import TracebackType
     from typing import Protocol
 
     from ._read_write import ReadWriteLock
     from ._soft_rw import SoftReadWriteLock
+
+    class _ForkResettable(Protocol):
+        def _reset_after_fork_in_child(self) -> None: ...
+
+    class _ForkDescriptorOwner(Protocol):
+        def _descriptors_for_fork(self) -> tuple[tuple[int, tuple[int, int] | None], ...]: ...
+
+    class _ForkResettableClass(Protocol):
+        @classmethod
+        def _reset_class_after_fork(cls) -> None: ...
+
+    class _RegisterAtFork(Protocol):
+        def __call__(
+            self,
+            *,
+            before: Callable[[], None] | None = None,
+            after_in_parent: Callable[[], None] | None = None,
+            after_in_child: Callable[[], None] | None = None,
+        ) -> None: ...
 
     if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
         from typing import Self
@@ -43,6 +65,8 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 _LOGGER: Final[logging.Logger] = logging.getLogger("filelock")
+_REGISTER_AT_FORK: Final[_RegisterAtFork | None] = cast("_RegisterAtFork | None", getattr(os, "register_at_fork", None))
+_HAS_REGISTER_AT_FORK: Final[bool] = _REGISTER_AT_FORK is not None
 
 _ExtraValue = TypeVar("_ExtraValue")
 _MarkerValue = TypeVar("_MarkerValue")
@@ -243,6 +267,18 @@ def _raise_body_and_release(body_error: BaseException, release_error: BaseExcept
     _raise_grouped_errors("lock body and release both failed", body_error, release_error)
 
 
+def _raise_cleanup_errors(
+    message: str,
+    primary_error: BaseException,
+    *cleanup_errors: BaseException | None,
+) -> NoReturn:
+    _raise_grouped_errors(
+        message,
+        primary_error,
+        *(error for error in cleanup_errors if error is not None),
+    )
+
+
 # On Windows os.path.realpath calls CreateFileW with share_mode=0, which blocks concurrent DeleteFileW and causes
 # livelocks under threaded contention with SoftFileLock. os.path.abspath is purely string-based and avoids this.
 _resolve_dir: Final[Callable[[str], str]] = os.path.abspath if sys.platform == "win32" else os.path.realpath
@@ -277,7 +313,8 @@ _T = TypeVar("_T", bound="BaseFileLock")
 
 class FileLockMeta(ABCMeta):
     _instances: WeakValueDictionary[str, BaseFileLock]
-    _instances_lock: Lock
+    _instances_lock: RLock
+    _instances_under_construction: set[str]
 
     def __call__(  # noqa: PLR0913
         cls: type[_T],
@@ -297,6 +334,7 @@ class FileLockMeta(ABCMeta):
         on_acquired: Callable[[int], None] | None = None,
         **kwargs: _ExtraValue,
     ) -> _T:
+        _ensure_current_process()
         lifetime = _resolve_lifetime(lifetime, supported=cls._lifetime_supported, cls_name=cls.__name__)
         # Validate before building the instance: a raise inside __init__ would leave a half-constructed object whose
         # __del__ then trips over the missing context.
@@ -334,7 +372,19 @@ class FileLockMeta(ABCMeta):
         singleton_key = _canonical(lock_file)
         with cls._instances_lock:
             if (instance := cls._instances.get(singleton_key)) is None:
-                instance = cls._create_instance(lock_file, params)
+                if singleton_key in cls._instances_under_construction:
+                    msg = f"Singleton lock construction is already active for {lock_file!s}"
+                    raise RuntimeError(msg)
+                construction_registry = cls._instances_under_construction
+                construction_pid = os.getpid()
+                construction_registry.add(singleton_key)
+                try:
+                    instance = cls._create_instance(lock_file, params)
+                finally:
+                    construction_registry.discard(singleton_key)
+                if os.getpid() != construction_pid:
+                    msg = "Lock construction cannot continue after fork; construct a new lock in the child"
+                    raise RuntimeError(msg)
                 cls._instances[singleton_key] = instance
                 return instance
 
@@ -393,12 +443,11 @@ class FileLockMeta(ABCMeta):
 
 
 _INIT_PARAMETER_MODELS: Final[WeakKeyDictionary[type[BaseFileLock], _InitParameterModel]] = WeakKeyDictionary()
-_INIT_PARAMETER_MODELS_LOCK: Final[Lock] = Lock()
 
 
 def _init_parameter_model(cls: type[BaseFileLock]) -> _InitParameterModel:
     # A strong cache would keep dynamically created subclasses alive for the process lifetime.
-    with _INIT_PARAMETER_MODELS_LOCK:
+    with _fork_transition(), _FORK_STATE.parameter_models_lock:
         if (model := _INIT_PARAMETER_MODELS.get(cls)) is None:
             parameters = inspect.signature(cls.__init__).parameters.values()
             model = _InitParameterModel(
@@ -512,7 +561,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     """
 
     _instances: WeakValueDictionary[str, BaseFileLock]
-    _instances_lock: Lock
+    _instances_lock: RLock
+    _instances_under_construction: set[str]
 
     #: How the cross-instance deadlock message names the conflicting holder; the async subclass says "task".
     _deadlock_holder_desc: str = "FileLock instance in this thread"
@@ -533,7 +583,15 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         """Give each lock subclass its own singleton registry and lock."""
         super().__init_subclass__(**kwargs)
         cls._instances = WeakValueDictionary()
-        cls._instances_lock = Lock()
+        cls._instances_lock = RLock()
+        cls._instances_under_construction = set()
+        _register_fork_class(cls)
+
+    @classmethod
+    def _reset_class_after_fork(cls) -> None:  # pragma: no cover - exercised in fork children
+        cls._instances = WeakValueDictionary()
+        cls._instances_lock = RLock()
+        cls._instances_under_construction = set()
 
     def __init__(  # noqa: PLR0913
         self,
@@ -605,6 +663,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             and re-raises. :class:`SoftFileLock` rejects the hook.
 
         """
+        self._creator_pid = os.getpid()
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
         self._context_error_policy = context_error_policy  # already validated by the metaclass
@@ -621,6 +680,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             poll_interval=poll_interval,
             lifetime=lifetime,
         )
+        _register_fork_object(self)
 
     def is_thread_local(self) -> bool:
         """:returns: a flag indicating if this lock is thread local or not"""
@@ -819,11 +879,13 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             This was previously a method and is now a property.
 
         """
+        _ensure_current_process()
         return self._context.lock_file_fd is not None
 
     @property
     def lock_counter(self) -> int:
         """The number of times this lock has been acquired (but not yet released)."""
+        _ensure_current_process()
         return self._context.lock_counter
 
     def __enter__(self) -> Self:
@@ -857,6 +919,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
 
     def __del__(self) -> None:
         """Force-release so a dropped reference never leaks a held lock."""
+        if vars(self).get("_creator_pid") != os.getpid():
+            return  # pragma: no cover - exercised in fork children
         self.release(force=True)
 
     def acquire(
@@ -904,6 +968,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             without side effects.
 
         """
+        self._raise_if_inherited()
         if timeout is None:
             timeout = self._context.timeout
 
@@ -946,7 +1011,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         :param force: If true, the lock counter is ignored and the lock is released in every case.
 
         """
-        if not self.is_locked:
+        if self._creator_pid != os.getpid() or not self.is_locked:
             return
         if not force and self._context.lock_counter > 1:
             self._context.lock_counter -= 1
@@ -955,7 +1020,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         lock_id, lock_filename = id(self), self.lock_file
         _LOGGER.debug("Attempting to release lock %s on %s", lock_id, lock_filename)
         try:
-            self._release()
+            self._release_with_fork_tracking()
         except BaseException:
             # A failure after the OS unlock (during close or unlink) still released the lock: the backend cleared
             # its descriptor, so commit the counter and registry to released even as the cleanup error propagates.
@@ -965,6 +1030,44 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             raise
         self._commit_release()
         _LOGGER.debug("Lock %s released on %s", lock_id, lock_filename)
+
+    def _raise_if_inherited(self) -> None:
+        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+            msg = f"{type(self).__name__} on {self.lock_file} was inherited across fork; construct a new instance"
+            raise RuntimeError(msg)
+
+    def _mark_descriptor_owned(self, fd: int, identity: tuple[int, int] | None = None) -> None:
+        self._context.pending_lock_file_fd = None
+        self._context.pending_lock_file_fd_identity = None
+        self._context.lock_file_fd = fd
+        self._context.lock_file_fd_identity = identity
+
+    def _mark_descriptor_pending(self, fd: int, identity: tuple[int, int] | None = None) -> None:
+        self._context.pending_lock_file_fd = fd
+        self._context.pending_lock_file_fd_identity = identity
+
+    def _mark_descriptor_released(self) -> None:
+        self._context.pending_lock_file_fd = None
+        self._context.pending_lock_file_fd_identity = None
+        self._context.lock_file_fd = None
+        self._context.lock_file_fd_identity = None
+
+    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+        self._context.lock_file_fd = None
+        self._context.lock_file_fd_token = None
+        self._context.lock_file_fd_identity = None
+        self._context.pending_lock_file_fd = None
+        self._context.pending_lock_file_fd_identity = None
+        self._context.lock_counter = 0
+        self._context.lock_file_key = None
+
+    def _descriptors_for_fork(self) -> tuple[tuple[int, tuple[int, int] | None], ...]:
+        descriptors: list[tuple[int, tuple[int, int] | None]] = []
+        if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:
+            descriptors.append((self._context.lock_file_fd, self._context.lock_file_fd_identity))
+        if self._context.pending_lock_file_fd is not None:
+            descriptors.append((self._context.pending_lock_file_fd, self._context.pending_lock_file_fd_identity))
+        return tuple(descriptors)
 
     def _raise_if_would_deadlock(self, canonical: str, *, timeout: float, blocking: bool) -> None:
         """
@@ -994,10 +1097,12 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
         lock_id = id(self)
         lock_filename = self.lock_file
         while True:
+            self._raise_if_inherited()
             if not self.is_locked:
                 self._try_break_expired_lock()
                 _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)
-                self._acquire()
+                self._acquire_with_fork_tracking()
+                self._raise_if_inherited()
             if self.is_locked:
                 _LOGGER.debug("Lock %s acquired on %s", lock_id, lock_filename)
                 return
@@ -1024,25 +1129,104 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             self._undo_acquire()
 
     def _invoke_on_acquired(self) -> None:
-        # Runs inside the backend _acquire (in the executor for async locks), once the native lock is held and the
-        # descriptor is set, before acquire() commits the registry. Fires once per physical acquisition; a recursive
-        # acquire never reaches here because the poll loop skips _acquire while the lock is held.
+        # The wrapper runs in the backend executor for async locks, preserving the callback's documented thread.
         if self._on_acquired is None or self._context.lock_counter != 1:
             return
         try:
             self._on_acquired(cast("int", self._context.lock_file_fd))
         except BaseException as callback_error:  # arbitrary caller code; roll back on any failure
             callback_context = callback_error.__context__
-            # Undo the native acquisition so the failed hook does not leave the lock held. Call the backend _release
-            # directly rather than the public release(): the counter and thread-local deadlock registry are reconciled
-            # by acquire() on the owning thread, and the async release() is a coroutine this synchronous path cannot
-            # await. A release that also fails surfaces both errors; is_locked then tells acquire() how to reconcile.
             try:
-                self._release()
+                self._release_with_fork_tracking()
             except BaseException as release_error:  # noqa: BLE001  # both errors surface via the group below
                 _raise_body_and_release(callback_error, release_error)
             callback_error.__context__ = callback_context
             raise
+
+    def _acquire_with_fork_tracking(self) -> None:
+        with _fork_transition(self):
+            try:
+                self._acquire()
+            except BaseException as acquisition_error:
+                self._rollback_failed_acquire(acquisition_error)
+                raise
+            try:
+                self._register_context_descriptor()
+            except BaseException as registration_error:
+                self._rollback_failed_registration(registration_error)
+                raise
+        if self.is_locked:
+            self._invoke_on_acquired()
+
+    def _rollback_failed_acquire(self, acquisition_error: BaseException) -> None:
+        if not self.is_locked:
+            return
+        registration_error: BaseException | None = None
+        tracking_error: BaseException | None = None
+        try:
+            self._register_context_descriptor()
+        except BaseException as error:  # noqa: BLE001  # preserve registration and acquisition failures
+            registration_error = error
+            try:
+                # Rollback may fail too; retain the fd so a child can close it without another identity probe.
+                self._register_unverified_context_descriptor()
+            except BaseException as error:  # noqa: BLE001  # pragma: no cover - allocation/control-flow during fallback
+                tracking_error = error
+        try:
+            self._release_with_fork_tracking()
+        except BaseException as rollback_error:  # noqa: BLE001  # preserve rollback and acquisition failures
+            _raise_cleanup_errors(
+                "lock acquisition cleanup failed",
+                acquisition_error,
+                registration_error,
+                tracking_error,
+                rollback_error,
+            )
+        if registration_error is not None:
+            _raise_cleanup_errors(
+                "lock acquisition cleanup failed", acquisition_error, registration_error, tracking_error
+            )
+
+    def _rollback_failed_registration(self, registration_error: BaseException) -> None:
+        tracking_error: BaseException | None = None
+        try:
+            # Rollback may fail too; retain the fd so a child can close it without another identity probe.
+            self._register_unverified_context_descriptor()
+        except BaseException as error:  # noqa: BLE001  # pragma: no cover - allocation/control-flow during fallback
+            tracking_error = error
+        try:
+            self._release_with_fork_tracking()
+        except BaseException as rollback_error:  # noqa: BLE001  # preserve rollback and registration failures
+            _raise_cleanup_errors(
+                "descriptor registration cleanup failed", registration_error, tracking_error, rollback_error
+            )
+        if tracking_error is not None:  # pragma: no cover - requires failed in-memory fallback
+            _raise_cleanup_errors("descriptor registration cleanup failed", registration_error, tracking_error)
+
+    def _release_with_fork_tracking(self) -> None:
+        with _fork_transition(self):
+            try:
+                self._release()
+            finally:
+                self._unregister_released_descriptor()
+
+    def _register_context_descriptor(self) -> None:
+        if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:
+            self._context.lock_file_fd_token = _register_owned_descriptor(
+                self._context.lock_file_fd,
+                self._context.lock_file_fd_identity,
+            )
+
+    def _register_unverified_context_descriptor(self) -> None:
+        if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:
+            self._context.lock_file_fd_token = _register_unverified_owned_descriptor(self._context.lock_file_fd)
+
+    def _unregister_released_descriptor(self) -> None:
+        if self._context.lock_file_fd is None:
+            if (token := self._context.lock_file_fd_token) is not None:
+                _unregister_owned_descriptor(token)
+            self._context.lock_file_fd_token = None
+            self._context.lock_file_fd_identity = None
 
     def _undo_acquire(self) -> None:
         """Roll back the counter after a failed acquire, dropping the registry entry once nothing holds the path."""
@@ -1155,6 +1339,18 @@ class FileLockContext:
     #: File descriptor from os.open for the lock file; not None while the lock is held.
     lock_file_fd: int | None = None
 
+    #: Registry token for the descriptor owned by this thread's context.
+    lock_file_fd_token: int | None = None
+
+    #: Identity captured by a backend that already inspected the descriptor.
+    lock_file_fd_identity: tuple[int, int] | None = None
+
+    #: Descriptor opened by a backend but not yet committed as the held lock.
+    pending_lock_file_fd: int | None = None
+
+    #: Identity captured for a descriptor whose acquisition has not committed.
+    pending_lock_file_fd_identity: tuple[int, int] | None = None
+
     #: Depth of nested acquisitions; the lock is released only when it returns to 0.
     lock_counter: int = 0
 
@@ -1164,6 +1360,302 @@ class FileLockContext:
 
 class ThreadLocalFileContext(FileLockContext, local):
     """A thread local version of the ``FileLockContext`` class."""
+
+
+@dataclass(frozen=True)
+class _OwnedDescriptor:
+    fd: int
+    creator_pid: int
+    device: int | None
+    inode: int | None
+
+
+class _ForkTransitionContext(local):
+    depth: int = 0
+
+
+class _ForkState:
+    def __init__(self) -> None:
+        self.gate = Condition(Lock())
+        self.registry_lock = RLock()
+        self.parameter_models_lock = RLock()
+        self.transition_context = _ForkTransitionContext()
+        self.transitions: dict[int, dict[int, _ForkDescriptorOwner | None]] = {}
+        self.active_transitions = 0
+        self.admission_closed = False
+        self.fork_owner_depths: dict[int, int] = {}
+        self.pinned_objects: dict[int, list[tuple[_ForkResettable, ...]]] = {}
+        self.pinned_classes: dict[int, list[tuple[type[_ForkResettableClass], ...]]] = {}
+        self.provisional_descriptor_tokens: dict[int, list[tuple[int, ...]]] = {}
+        self.pid = os.getpid()
+
+    def reset_synchronization(self) -> None:  # pragma: no cover - exercised in fork children
+        self.gate = Condition(Lock())
+        self.registry_lock = RLock()
+        self.parameter_models_lock = RLock()
+        self.transition_context = _ForkTransitionContext()
+        self.transitions = {}
+        self.active_transitions = 0
+        self.admission_closed = False
+        self.fork_owner_depths = {}
+        self.pinned_objects = {}
+        self.pinned_classes = {}
+        self.provisional_descriptor_tokens = {}
+
+
+_FORK_OBJECTS: Final[WeakValueDictionary[int, _ForkResettable]] = WeakValueDictionary()
+_FORK_CLASSES: Final[WeakValueDictionary[int, type[_ForkResettableClass]]] = WeakValueDictionary()
+_OWNED_DESCRIPTORS: Final[dict[int, _OwnedDescriptor]] = {}
+_DESCRIPTOR_TOKENS: Final[count[int]] = count()
+_TRANSITION_TOKENS: Final[count[int]] = count()
+_FORK_STATE: Final = _ForkState()
+_FORK_AUDIT_EVENTS: Final[frozenset[str]] = frozenset({"os.fork", "os.forkpty"})
+
+
+def _register_fork_hooks() -> None:
+    if _REGISTER_AT_FORK is None:
+        return  # pragma: no cover - platform without register_at_fork
+    sys.addaudithook(_audit_fork_safety)
+    _REGISTER_AT_FORK(
+        before=_pin_fork_objects,
+        after_in_parent=_resume_parent_after_fork,
+        after_in_child=_reset_child_after_fork,
+    )
+
+
+@contextmanager
+def _fork_transition(descriptor_owner: _ForkDescriptorOwner | None = None) -> Generator[None]:
+    if not _HAS_REGISTER_AT_FORK:
+        yield  # pragma: no cover - platform without register_at_fork
+        return  # pragma: no cover - platform without register_at_fork
+    _ensure_current_process()
+    creator_pid = os.getpid()
+    token = _enter_fork_transition(descriptor_owner)
+    try:
+        yield
+    finally:
+        if os.getpid() == creator_pid:
+            _leave_fork_transition(token)
+
+
+def _register_fork_object(instance: _ForkResettable) -> None:
+    if not _HAS_REGISTER_AT_FORK:
+        return  # pragma: no cover - platform without register_at_fork
+    with _fork_transition(), _FORK_STATE.registry_lock:
+        _FORK_OBJECTS[id(instance)] = instance
+        _refresh_owner_pins()
+
+
+def _register_fork_class(cls: type[_ForkResettableClass]) -> None:
+    if not _HAS_REGISTER_AT_FORK:
+        return  # pragma: no cover - platform without register_at_fork
+    with _fork_transition(), _FORK_STATE.registry_lock:
+        _FORK_CLASSES[id(cls)] = cls
+        _refresh_owner_pins()
+
+
+def _register_owned_descriptor(fd: int, identity: tuple[int, int] | None = None) -> int | None:
+    if not _HAS_REGISTER_AT_FORK:
+        return None  # pragma: no cover - platform without register_at_fork
+    with _fork_transition():
+        if identity is None:
+            stat_result = os.fstat(fd)
+            identity = stat_result.st_dev, stat_result.st_ino
+        return _record_owned_descriptor(fd, identity)
+
+
+def _register_unverified_owned_descriptor(fd: int) -> int | None:
+    if not _HAS_REGISTER_AT_FORK:
+        return None  # pragma: no cover - platform without register_at_fork
+    with _fork_transition():
+        return _record_owned_descriptor(fd, None)
+
+
+def _record_owned_descriptor(fd: int, identity: tuple[int, int] | None) -> int:
+    with _FORK_STATE.registry_lock:
+        token = next(_DESCRIPTOR_TOKENS)
+        _OWNED_DESCRIPTORS[token] = _OwnedDescriptor(
+            fd=fd,
+            creator_pid=os.getpid(),
+            device=None if identity is None else identity[0],
+            inode=None if identity is None else identity[1],
+        )
+    return token
+
+
+def _unregister_owned_descriptor(token: int) -> None:
+    with _fork_transition(), _FORK_STATE.registry_lock:
+        _OWNED_DESCRIPTORS.pop(token, None)
+
+
+def _pin_fork_objects() -> None:
+    _ensure_current_process()
+    thread_id = get_ident()
+    with _FORK_STATE.gate:
+        _FORK_STATE.fork_owner_depths[thread_id] = _FORK_STATE.fork_owner_depths.get(thread_id, 0) + 1
+        _FORK_STATE.admission_closed = True
+        while _FORK_STATE.active_transitions > len(_FORK_STATE.transitions.get(thread_id, ())):
+            _FORK_STATE.gate.wait()
+        transition_owners = tuple(_FORK_STATE.transitions.get(thread_id, {}).values())
+    _verify_unverified_descriptors()
+    owners = {id(owner): owner for owner in transition_owners if owner is not None}
+    provisional_descriptor_tokens = tuple(
+        starmap(
+            _snapshot_descriptor_for_fork,
+            (descriptor for owner in owners.values() for descriptor in owner._descriptors_for_fork()),  # noqa: SLF001
+        )
+    )
+    with _FORK_STATE.registry_lock:
+        _FORK_STATE.provisional_descriptor_tokens.setdefault(thread_id, []).append(provisional_descriptor_tokens)
+        _FORK_STATE.pinned_objects.setdefault(thread_id, []).append(tuple(_FORK_OBJECTS.values()))
+        _FORK_STATE.pinned_classes.setdefault(thread_id, []).append(tuple(_FORK_CLASSES.values()))
+
+
+def _resume_parent_after_fork() -> None:
+    thread_id = get_ident()
+    with _FORK_STATE.registry_lock:
+        for token in _FORK_STATE.provisional_descriptor_tokens[thread_id].pop():
+            _OWNED_DESCRIPTORS.pop(token, None)
+        _FORK_STATE.pinned_objects[thread_id].pop()
+        _FORK_STATE.pinned_classes[thread_id].pop()
+        if not _FORK_STATE.provisional_descriptor_tokens[thread_id]:
+            del _FORK_STATE.provisional_descriptor_tokens[thread_id]
+            del _FORK_STATE.pinned_objects[thread_id]
+            del _FORK_STATE.pinned_classes[thread_id]
+    with _FORK_STATE.gate:
+        if _FORK_STATE.fork_owner_depths[thread_id] == 1:
+            del _FORK_STATE.fork_owner_depths[thread_id]
+        else:  # pragma: no cover - earlier at-fork callbacks may deadlock first
+            _FORK_STATE.fork_owner_depths[thread_id] -= 1
+        _FORK_STATE.admission_closed = bool(_FORK_STATE.fork_owner_depths)
+        _FORK_STATE.gate.notify_all()
+
+
+def _ensure_current_process() -> None:
+    _reset_child_after_fork()
+
+
+def _reset_child_after_fork() -> None:  # pragma: no cover - exercised in fork children
+    if (pid := os.getpid()) == _FORK_STATE.pid:
+        return
+    thread_id = get_ident()
+    pinned_objects = _FORK_STATE.pinned_objects.get(thread_id, [()])[-1]
+    pinned_classes = _FORK_STATE.pinned_classes.get(thread_id, [()])[-1]
+    descriptors: list[_OwnedDescriptor] = []
+    for token, descriptor in tuple(_OWNED_DESCRIPTORS.items()):
+        if descriptor.creator_pid != pid:
+            descriptors.append(_OWNED_DESCRIPTORS.pop(token))
+    _FORK_STATE.reset_synchronization()
+    _FORK_STATE.pid = pid
+    _INIT_PARAMETER_MODELS.clear()
+    _detach_child_state(descriptors, pinned_objects, pinned_classes)
+
+
+def _enter_fork_transition(descriptor_owner: _ForkDescriptorOwner | None) -> int:
+    thread_id = get_ident()
+    with _FORK_STATE.gate:
+        while (
+            _FORK_STATE.admission_closed
+            and thread_id not in _FORK_STATE.fork_owner_depths
+            and thread_id not in _FORK_STATE.transitions
+        ):
+            _FORK_STATE.gate.wait()  # pragma: no cover - exercised in isolated interpreter
+        token = next(_TRANSITION_TOKENS)
+        _FORK_STATE.transitions.setdefault(thread_id, {})[token] = descriptor_owner
+        _FORK_STATE.active_transitions += 1
+    _FORK_STATE.transition_context.depth += 1
+    return token
+
+
+def _leave_fork_transition(token: int) -> None:
+    _FORK_STATE.transition_context.depth -= 1
+    with _FORK_STATE.gate:
+        thread_id = get_ident()
+        del _FORK_STATE.transitions[thread_id][token]
+        if not _FORK_STATE.transitions[thread_id]:
+            del _FORK_STATE.transitions[thread_id]
+        _FORK_STATE.active_transitions -= 1
+        _FORK_STATE.gate.notify_all()
+
+
+def _verify_unverified_descriptors() -> None:
+    with _FORK_STATE.registry_lock:
+        for token, descriptor in tuple(_OWNED_DESCRIPTORS.items()):
+            if descriptor.creator_pid != os.getpid() or descriptor.device is not None:
+                continue
+            try:
+                stat_result = os.fstat(descriptor.fd)
+            except OSError:
+                continue
+            _OWNED_DESCRIPTORS[token] = _OwnedDescriptor(
+                fd=descriptor.fd,
+                creator_pid=descriptor.creator_pid,
+                device=stat_result.st_dev,
+                inode=stat_result.st_ino,
+            )
+
+
+def _snapshot_descriptor_for_fork(fd: int, identity: tuple[int, int] | None) -> int:
+    if identity is None:
+        try:
+            stat_result = os.fstat(fd)
+        except OSError:
+            pass
+        else:
+            identity = stat_result.st_dev, stat_result.st_ino
+    return _record_owned_descriptor(fd, identity)
+
+
+def _detach_child_state(  # pragma: no cover - exercised in fork children
+    descriptors: list[_OwnedDescriptor],
+    pinned_objects: tuple[_ForkResettable, ...],
+    pinned_classes: tuple[type[_ForkResettableClass], ...],
+) -> None:
+    for descriptor in descriptors:
+        if descriptor.device is None:
+            continue
+        try:
+            stat_result = os.fstat(descriptor.fd)
+        except OSError:
+            continue
+        if (stat_result.st_dev, stat_result.st_ino) != (descriptor.device, descriptor.inode):
+            continue
+        with contextlib.suppress(OSError):
+            os.close(descriptor.fd)
+    for instance in pinned_objects:
+        instance._reset_after_fork_in_child()  # noqa: SLF001
+    for cls in pinned_classes:
+        cls._reset_class_after_fork()
+    _registry.held.clear()
+
+
+def _refresh_owner_pins() -> None:
+    with _FORK_STATE.gate:
+        fork_owner_thread_ids = tuple(_FORK_STATE.fork_owner_depths)
+    if get_ident() not in fork_owner_thread_ids:  # pragma: no cover - at-fork callbacks disable tracing
+        return
+    objects = tuple(_FORK_OBJECTS.values())
+    classes = tuple(_FORK_CLASSES.values())
+    for thread_id in fork_owner_thread_ids:
+        if object_snapshots := _FORK_STATE.pinned_objects.get(thread_id):
+            object_snapshots[:] = [objects] * len(object_snapshots)
+            _FORK_STATE.pinned_classes[thread_id][:] = [classes] * len(object_snapshots)
+
+
+# Audit events carry unrelated interpreter-owned values; object is the sole accurate common element type.
+def _audit_fork_safety(  # pragma: no cover - CPython disables tracing while Python audit hooks run
+    event: str, _args: tuple[object, ...]
+) -> None:
+    if event in _FORK_AUDIT_EVENTS:
+        if _FORK_STATE.transition_context.depth or _FORK_STATE.fork_owner_depths:
+            msg = f"{event} is unsafe while filelock is changing descriptor ownership"
+            raise RuntimeError(msg)
+    elif event == "_posixsubprocess.fork_exec" and _FORK_STATE.transition_context.depth:
+        msg = "fork_exec is unsafe while filelock is changing descriptor ownership"
+        raise RuntimeError(msg)
+
+
+_register_fork_hooks()
 
 
 __all__ = [
@@ -1176,8 +1668,15 @@ __all__ = [
     "FileLockMeta",
     "_append_exception_context",
     "_canonical",
+    "_ensure_current_process",
+    "_fork_transition",
     "_grouped_errors",
     "_raise_body_and_release",
     "_raise_chained_errors",
+    "_raise_cleanup_errors",
     "_raise_grouped_errors",
+    "_register_fork_class",
+    "_register_fork_object",
+    "_register_owned_descriptor",
+    "_unregister_owned_descriptor",
 ]

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -80,6 +80,7 @@ class SoftFileLock(BaseFileLock):
                 raise
             self._try_break_stale_lock()
             return
+        self._mark_descriptor_pending(fd)
         self._publish_held_marker(fd)
 
     def _publish_held_marker(self, fd: int) -> None:
@@ -91,12 +92,13 @@ class SoftFileLock(BaseFileLock):
             identity = _file_identity(os.fstat(fd))
             self._write_lock_info(fd)
         except BaseException:
+            self._mark_descriptor_released()
             os.close(fd)
             with suppress(OSError):
                 if identity is not None and _file_identity(os.lstat(self.lock_file)) == identity:
                     Path(self.lock_file).unlink()
             raise
-        self._context.lock_file_fd = fd
+        self._mark_descriptor_owned(fd, identity)
 
     def _try_break_stale_lock(self) -> None:
         with suppress(OSError, ValueError):
@@ -222,7 +224,7 @@ class SoftFileLock(BaseFileLock):
             identity = _file_identity(os.fstat(fd))
         # A failed close may already have released and recycled the descriptor number. Relinquish it before the one
         # close attempt so no later release can close an unrelated descriptor that reused the same integer.
-        self._context.lock_file_fd = None
+        self._mark_descriptor_released()
         try:
             self._close_released_fd(fd, default_suppresses=False)
         # Marker cleanup must also run for control-flow exceptions, and both failures must remain observable.

--- a/src/filelock/_soft_rw/_async.py
+++ b/src/filelock/_soft_rw/_async.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import os
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 from ._sync import SoftReadWriteLock
 
 if TYPE_CHECKING:
-    import os
     from collections.abc import AsyncGenerator, Callable
     from concurrent import futures
     from types import TracebackType
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 class AsyncSoftReadWriteLock:
@@ -51,6 +54,7 @@ class AsyncSoftReadWriteLock:
         loop: asyncio.AbstractEventLoop | None = None,
         executor: futures.Executor | None = None,
     ) -> None:
+        self._creator_pid = os.getpid()
         self._lock = SoftReadWriteLock(
             lock_file,
             timeout,
@@ -143,6 +147,7 @@ class AsyncSoftReadWriteLock:
         :raises Timeout: if the lock cannot be acquired within *timeout* seconds
 
         """
+        self._raise_if_inherited()
         await self._run(self._lock.acquire_read, timeout, blocking=blocking)
         return AsyncAcquireSoftReadWriteReturnProxy(lock=self)
 
@@ -165,6 +170,7 @@ class AsyncSoftReadWriteLock:
         :raises Timeout: if the lock cannot be acquired within *timeout* seconds
 
         """
+        self._raise_if_inherited()
         await self._run(self._lock.acquire_write, timeout, blocking=blocking)
         return AsyncAcquireSoftReadWriteReturnProxy(lock=self)
 
@@ -177,13 +183,20 @@ class AsyncSoftReadWriteLock:
         :raises RuntimeError: if no lock is currently held and *force* is ``False``
 
         """
-        await self._run(self._lock.release, force=force)
+        if self._creator_pid == os.getpid():
+            await self._run(self._lock.release, force=force)
 
     async def close(self) -> None:
         """Release any held lock and release the underlying filesystem resources. Idempotent."""
-        await self._run(self._lock.close)
+        if self._creator_pid == os.getpid():
+            await self._run(self._lock.close)
 
-    async def _run(self, func: Callable[..., object], *args: object, **kwargs: object) -> object:
+    def _raise_if_inherited(self) -> None:
+        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+            msg = f"AsyncSoftReadWriteLock on {self.lock_file} was inherited across fork; construct a new instance"
+            raise RuntimeError(msg)
+
+    async def _run(self, func: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R:
         loop = self._loop or asyncio.get_running_loop()
         return await loop.run_in_executor(self._executor, functools.partial(func, *args, **kwargs))
 

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -19,7 +19,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal
 from weakref import WeakValueDictionary
 
-from filelock._api import AcquireReturnProxy
+from filelock._api import (
+    AcquireReturnProxy,
+    _ensure_current_process,
+    _fork_transition,
+    _raise_grouped_errors,
+    _register_fork_class,
+    _register_fork_object,
+    _register_owned_descriptor,
+    _unregister_owned_descriptor,
+)
 from filelock._error import Timeout
 from filelock._soft import SoftFileLock
 from filelock._util import ensure_directory_exists, write_all
@@ -42,15 +51,14 @@ _SUPPORTS_UTIME_NOFOLLOW: Final[bool] = os.utime in os.supports_follow_symlinks
 # its ``os`` module skips dir_fd support entirely. When disabled, callers fall back to full-path ops.
 _SUPPORTS_DIR_FD: Final[bool] = sys.platform != "win32" and os.open in os.supports_dir_fd
 
-_all_instances: Final[WeakValueDictionary[Path, SoftReadWriteLock]] = WeakValueDictionary()
-_all_instances_lock = threading.Lock()
-_atexit_registered = False
-_fork_registered = False
+_ALL_INSTANCES: Final[WeakValueDictionary[int, SoftReadWriteLock]] = WeakValueDictionary()
+_ALL_INSTANCES_LOCK: threading.Lock = threading.Lock()
+_SINGLETONS_UNDER_CONSTRUCTION: Final[set[Path]] = set()
 
 
 class _SoftRWMeta(type):
     _instances: WeakValueDictionary[Path, SoftReadWriteLock]
-    _instances_lock: threading.Lock
+    _instances_lock: threading.RLock
 
     def __call__(  # noqa: PLR0913
         cls,
@@ -63,6 +71,7 @@ class _SoftRWMeta(type):
         stale_threshold: float | None = None,
         poll_interval: float = 0.25,
     ) -> SoftReadWriteLock:
+        _ensure_current_process()
         if not is_singleton:
             return super().__call__(
                 lock_file,
@@ -78,15 +87,26 @@ class _SoftRWMeta(type):
         with cls._instances_lock:
             instance = cls._instances.get(normalized)
             if instance is None:
-                instance = super().__call__(
-                    lock_file,
-                    timeout,
-                    blocking=blocking,
-                    is_singleton=is_singleton,
-                    heartbeat_interval=heartbeat_interval,
-                    stale_threshold=stale_threshold,
-                    poll_interval=poll_interval,
-                )
+                if normalized in _SINGLETONS_UNDER_CONSTRUCTION:
+                    msg = f"Singleton lock construction is already active for {lock_file!s}"
+                    raise RuntimeError(msg)
+                construction_pid = os.getpid()
+                _SINGLETONS_UNDER_CONSTRUCTION.add(normalized)
+                try:
+                    instance = super().__call__(
+                        lock_file,
+                        timeout,
+                        blocking=blocking,
+                        is_singleton=is_singleton,
+                        heartbeat_interval=heartbeat_interval,
+                        stale_threshold=stale_threshold,
+                        poll_interval=poll_interval,
+                    )
+                finally:
+                    _SINGLETONS_UNDER_CONSTRUCTION.discard(normalized)
+                if os.getpid() != construction_pid:
+                    msg = "Lock construction cannot continue after fork; construct a new lock in the child"
+                    raise RuntimeError(msg)
                 cls._instances[normalized] = instance
             elif instance.timeout != timeout or instance.blocking != blocking:
                 msg = (
@@ -122,9 +142,8 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
     Reentrancy, upgrade/downgrade rules, thread pinning, and singleton caching by resolved path match
     :class:`~filelock.ReadWriteLock`.
 
-    Forking while holding a lock invalidates the inherited instance in the child so the child cannot
-    double-own the lock with its parent; ``release()`` on a fork-invalidated instance is a no-op, and
-    the child must re-acquire if it needs a lock.
+    Forking invalidates the inherited instance in the child so the child cannot double-own the lock with its parent;
+    ``release()`` on that instance is a no-op, and the child must construct a new instance if it needs a lock.
 
     Trust boundary: protects against same-UID non-cooperating processes (one host or cross-host) and
     same-host different-UID users via ``0o600`` / ``0o700`` permissions. Does not protect against root
@@ -145,7 +164,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
     """
 
     _instances: WeakValueDictionary[Path, SoftReadWriteLock] = WeakValueDictionary()
-    _instances_lock = threading.Lock()
+    _instances_lock = threading.RLock()
 
     def __init__(  # noqa: PLR0913
         self,
@@ -158,6 +177,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         stale_threshold: float | None = None,
         poll_interval: float = 0.25,
     ) -> None:
+        self._creator_pid = os.getpid()
         if heartbeat_interval <= 0:
             msg = f"heartbeat_interval must be positive, got {heartbeat_interval}"
             raise ValueError(msg)
@@ -189,13 +209,21 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             state=SoftFileLock(self._paths.state, timeout=-1),
         )
         self._readers_dir_fd: int | None = None
+        self._readers_dir_fd_token: int | None = None
         self._hold: _Hold | None = None
-        self._fork_invalidated: bool = False
         self._closed: bool = False
 
-        with _all_instances_lock:
-            _all_instances[Path(self.lock_file).resolve()] = self
-            _register_hooks()
+        with _ALL_INSTANCES_LOCK:
+            _ALL_INSTANCES[id(self)] = self
+        _register_fork_object(self)
+
+    @classmethod
+    def _reset_class_after_fork(cls) -> None:  # pragma: no cover - exercised in fork children
+        global _ALL_INSTANCES_LOCK  # noqa: PLW0603
+        _ALL_INSTANCES_LOCK = threading.Lock()
+        cls._instances = WeakValueDictionary()
+        cls._instances_lock = threading.RLock()
+        _SINGLETONS_UNDER_CONSTRUCTION.clear()
 
     @contextmanager
     def read_lock(self, timeout: float | None = None, *, blocking: bool | None = None) -> Generator[None]:
@@ -316,15 +344,21 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         Idempotent. After calling this method the instance can no longer acquire locks — subsequent acquires raise
         :class:`RuntimeError`. A fork-invalidated instance is closed without raising.
         """
+        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+            return
         self.release(force=True)
         with self._locks.internal:
             if self._closed:
                 return
             self._closed = True
             if self._readers_dir_fd is not None:
-                with suppress(OSError):
-                    os.close(self._readers_dir_fd)
-                self._readers_dir_fd = None
+                with _fork_transition():
+                    if self._readers_dir_fd_token is not None:
+                        _unregister_owned_descriptor(self._readers_dir_fd_token)
+                    self._readers_dir_fd_token = None
+                    fd, self._readers_dir_fd = self._readers_dir_fd, None
+                    with suppress(OSError):
+                        os.close(fd)
 
     def release(self, *, force: bool = False) -> None:
         """
@@ -339,11 +373,9 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         :raises RuntimeError: if no lock is currently held and *force* is ``False``
 
         """
+        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+            return
         with self._locks.internal:
-            if self._fork_invalidated:
-                # Inherited state from the parent is meaningless in the child; clear any counters and return.
-                self._hold = None
-                return
             hold = self._hold
             if hold is None:
                 if force:
@@ -389,13 +421,13 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         *,
         blocking: bool | None,
     ) -> AcquireReturnProxy:
+        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+            msg = f"SoftReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
+            raise RuntimeError(msg)
         timeout = self.timeout if timeout is None else timeout
         blocking = self.blocking if blocking is None else blocking
 
         with self._locks.internal:
-            if self._fork_invalidated:
-                msg = f"SoftReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
-                raise RuntimeError(msg)
             if self._closed:
                 msg = f"SoftReadWriteLock on {self.lock_file} has been closed"
                 raise RuntimeError(msg)
@@ -491,15 +523,8 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
 
         def readers_drained_touching() -> bool:
             with self._locks.state:
-                # Refresh our writer marker every scan iteration so phase 2 does not exceed
-                # ``stale_threshold`` under contention and get evicted. The refresh only happens while
-                # the marker is still ours: if we were paused past ``stale_threshold`` a peer can evict
-                # the stale marker and reclaim ``.write`` with its own token, and touching that path
-                # blindly would keep the peer's live marker alive and let this acquire finish as though
-                # we still held the slot, admitting a second writer. When the claim is no longer ours we
-                # re-claim the slot here (waiting behind the peer if it currently holds it) rather than
-                # trusting the foreign marker, mirroring the token re-check the stale-break and release
-                # paths already rely on.
+                # A peer may replace an expired marker while this process pauses. Refresh only our token; touching a
+                # successor's marker would let this acquisition proceed without owning the writer slot.
                 if not self._touch_writer_marker_if_ours(token) and not self._claim_writer_marker(token):
                     return False
                 self._break_stale_readers(time.time())
@@ -606,9 +631,22 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             msg = f"{self._paths.readers} exists but is not a directory or is a symlink; refusing to use it"
             raise RuntimeError(msg)
         if self._readers_dir_fd is None and _SUPPORTS_DIR_FD:
-            self._readers_dir_fd = os.open(
-                self._paths.readers, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
-            )
+            with _fork_transition():
+                fd = os.open(self._paths.readers, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW)
+                try:
+                    token = _register_owned_descriptor(fd)
+                except BaseException as registration_error:
+                    try:
+                        os.close(fd)
+                    except BaseException as close_error:  # noqa: BLE001  # both errors surface via the group below
+                        _raise_grouped_errors(
+                            "reader directory registration and descriptor close both failed",
+                            registration_error,
+                            close_error,
+                        )
+                    raise
+                self._readers_dir_fd = fd
+                self._readers_dir_fd_token = token
 
     def _any_readers(self) -> bool:
         for _ in self._iter_reader_entries():
@@ -680,18 +718,15 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         finally:
             os.close(fd)
 
-    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - fork child not tracked
-        # Replace every lock this instance owns with a fresh one; the inherited locks may still be held
-        # by threads that no longer exist in the child. The readers dirfd and the SoftFileLock state
-        # mutex both get dropped for the same reason — the child re-creates them on its next acquire.
+    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
         self._locks = _Locks(
             internal=threading.Lock(),
             transaction=threading.Lock(),
-            state=SoftFileLock(self._paths.state, timeout=-1),
+            state=self._locks.state,
         )
         self._hold = None
         self._readers_dir_fd = None
-        self._fork_invalidated = True
+        self._readers_dir_fd_token = None
 
 
 class _HeartbeatThread(threading.Thread):
@@ -918,31 +953,14 @@ class _Hold:
     heartbeat_stop: threading.Event
 
 
-def _register_hooks() -> None:
-    global _atexit_registered, _fork_registered  # noqa: PLW0603
-    if not _atexit_registered:
-        atexit.register(_cleanup_all_instances)
-        _atexit_registered = True
-    # after_in_child replaces inherited state so the child cannot double-own any lock the parent held.
-    if not _fork_registered and hasattr(os, "register_at_fork"):
-        os.register_at_fork(after_in_child=_reset_all_after_fork)
-        _fork_registered = True
-
-
 def _cleanup_all_instances() -> None:  # pragma: no cover - runs from atexit at interpreter shutdown
-    for instance in list(_all_instances.values()):
+    for instance in list(_ALL_INSTANCES.values()):
         with suppress(Exception):
             instance.release(force=True)
 
 
-def _reset_all_after_fork() -> None:  # pragma: no cover - fork child, not tracked by coverage
-    global _all_instances_lock  # noqa: PLW0603
-    # User-created threading locks do not auto-reset across fork: any lock held by a parent thread stays
-    # locked in the child with no owner to release it. Replace the module-level lock and every instance's
-    # locks with fresh ones; the child is single-threaded at this point so no synchronization is needed.
-    _all_instances_lock = threading.Lock()
-    for instance in list(_all_instances.values()):
-        instance._reset_after_fork_in_child()  # noqa: SLF001
+atexit.register(_cleanup_all_instances)
+_register_fork_class(SoftReadWriteLock)
 
 
 __all__ = [

--- a/src/filelock/_unix.py
+++ b/src/filelock/_unix.py
@@ -67,6 +67,11 @@ else:  # pragma: win32 no cover
         """
 
         def _acquire(self) -> None:
+            missing_flock = self._acquire_native()
+            if missing_flock is not None:
+                self._switch_to_soft_lock(*missing_flock)
+
+        def _acquire_native(self) -> tuple[int, OSError] | None:
             ensure_directory_exists(self.lock_file)
             # Open without O_TRUNC and defer truncation and fchmod until after flock succeeds: a contender that loses
             # the lock must not truncate the holder's file (erasing caller diagnostics) or change its mode. The winner
@@ -83,7 +88,7 @@ else:  # pragma: win32 no cover
                 # delete the file between them. For a valid path, treat ENOENT as transient contention. For an
                 # invalid path (e.g. empty string), re-raise to avoid an infinite retry loop.
                 if self.lock_file and Path(self.lock_file).parent.exists():
-                    return
+                    return None
                 raise
             except PermissionError:
                 # Sticky-bit dirs (e.g. /tmp): O_CREAT fails if the file is owned by another user (#317).
@@ -93,19 +98,22 @@ else:  # pragma: win32 no cover
                 try:
                     fd = os.open(self.lock_file, open_flags & ~os.O_CREAT, open_mode)
                 except FileNotFoundError:
-                    return
+                    return None
+            self._mark_descriptor_pending(fd)
             try:
                 locked = _lock_fd_nonblocking(fd)
             except OSError as exception:
                 if exception.errno != ENOSYS:
+                    self._mark_descriptor_released()
                     os.close(fd)
                     raise  # contention returns False from _lock_fd_nonblocking, so any raise here is a real failure
-                self._switch_to_soft_lock(fd, exception)
-                return
+                return fd, exception
             if locked:
                 self._finalize_locked_fd(fd)
             else:
+                self._mark_descriptor_released()
                 os.close(fd)  # contention; let the retry loop try again
+            return None
 
         def _switch_to_soft_lock(self, fd: int, missing_flock: OSError) -> None:
             # The filesystem does not implement flock. Capture the opened file's identity before closing so the cleanup
@@ -113,6 +121,7 @@ else:  # pragma: win32 no cover
             identity: tuple[int, int] | None = None
             with suppress(OSError):
                 identity = (fstat := os.fstat(fd)).st_dev, fstat.st_ino
+            self._mark_descriptor_released()
             os.close(fd)
             if not self._fallback_to_soft or self._preserve_lock_file or self._on_acquired is not None:
                 # Fail closed: the caller opted out of existence-lock semantics (#603), asked to preserve the pathname
@@ -131,17 +140,19 @@ else:  # pragma: win32 no cover
             # flock() (st_nlink 0), leaving a useless dead-inode lock; drop it and let the retry loop start fresh.
             keep = False
             try:
-                if os.fstat(fd).st_nlink != 0:
+                stat_result = os.fstat(fd)
+                if stat_result.st_nlink != 0:
                     os.ftruncate(fd, 0)
                     self._apply_explicit_mode(fd)
                     keep = True
             except OSError:
+                self._mark_descriptor_released()
                 os.close(fd)
                 raise
             if keep:
-                self._context.lock_file_fd = fd  # the lock is held; run the hook now that truncation and mode are set
-                self._invoke_on_acquired()
+                self._mark_descriptor_owned(fd, (stat_result.st_dev, stat_result.st_ino))
             else:
+                self._mark_descriptor_released()
                 os.close(fd)
 
         def _apply_explicit_mode(self, fd: int) -> None:
@@ -163,7 +174,7 @@ else:  # pragma: win32 no cover
             # must keep reporting held for a retry. Once flock commits, clear held state and close as post-unlock
             # cleanup; a close failure (EIO on FUSE/Docker bind mounts) does not make the kernel lock held again.
             _unlock_fd(fd)
-            self._context.lock_file_fd = None
+            self._mark_descriptor_released()
             self._close_released_fd(fd, default_suppresses=True)
 
 

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -185,13 +185,12 @@ if sys.platform == "win32":  # pragma: win32 cover
                 return  # open contention (share conflict or a name pending deletion); let the retry loop try again
             try:
                 locked = _lock_fd_nonblocking(fd)
+                if locked:
+                    self._mark_descriptor_owned(fd)
             except BaseException:
                 os.close(fd)
                 raise
-            if locked:
-                self._context.lock_file_fd = fd
-                self._invoke_on_acquired()
-            else:
+            if not locked:
                 os.close(fd)  # another holder owns the byte-range lock; let the retry loop try again
 
         def _release(self) -> None:
@@ -200,7 +199,7 @@ if sys.platform == "win32":  # pragma: win32 cover
             # held, so is_locked must keep reporting held rather than losing the fd. Only after the unlock commits do
             # close and unlink run as post-unlock cleanup; their failure cannot make the lock held again.
             _unlock_fd(fd)
-            self._context.lock_file_fd = None
+            self._mark_descriptor_released()
             self._close_released_fd(fd, default_suppresses=False)
             if not self._preserve_lock_file:  # preserve_lock_file keeps a stable file identity for the caller (#605)
                 with suppress(OSError):

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -21,10 +21,13 @@ from ._api import (
     FileLockMeta,
     _append_exception_context,
     _canonical,
+    _fork_transition,
     _grouped_errors,
     _raise_body_and_release,
     _raise_chained_errors,
+    _raise_cleanup_errors,
     _raise_grouped_errors,
+    _register_fork_object,
 )
 from ._async import (
     _AsyncTransitionGate,
@@ -43,7 +46,7 @@ from ._windows import WindowsFileLock
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Callable, Coroutine
+    from collections.abc import Awaitable, Callable, Coroutine
     from concurrent import futures
     from types import TracebackType
 
@@ -186,6 +189,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         :param executor: The executor to use. If not specified, the default executor will be used.
 
         """
+        self._creator_pid = os.getpid()
         self._is_thread_local = thread_local
         self._is_singleton = is_singleton
         self._context_error_policy = context_error_policy  # already validated by the metaclass
@@ -206,6 +210,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             run_in_executor=run_in_executor,
             executor=executor,
         )
+        _register_fork_object(self)
 
     @property
     def run_in_executor(self) -> bool:
@@ -271,6 +276,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 lock.release()
 
         """
+        self._raise_if_inherited()
         if timeout is None:
             timeout = self._context.timeout
 
@@ -337,10 +343,12 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         lock_id = id(self)
         lock_filename = self.lock_file
         while True:
+            self._raise_if_inherited()
             if not self.is_locked:
                 self._try_break_expired_lock()
                 _LOGGER.debug("Attempting to acquire lock %s on %s", lock_id, lock_filename)
                 await self._run_acquire_attempt()
+                self._raise_if_inherited()
             if self.is_locked:
                 _LOGGER.debug("Lock %s acquired on %s", lock_id, lock_filename)
                 return
@@ -357,7 +365,11 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             await asyncio.sleep(poll_interval)
 
     async def _run_acquire_attempt(self) -> None:
-        acquire_future = self._start_internal_method(self._acquire)
+        acquire_future = self._start_internal_method(
+            self._acquire_with_fork_tracking_async
+            if iscoroutinefunction(self._acquire)
+            else self._acquire_with_fork_tracking
+        )
         try:
             await _wait_until_done(acquire_future)
         except asyncio.CancelledError as cancellation:
@@ -370,7 +382,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             rollback_error: BaseException | None = None
             if self.is_locked:
                 try:
-                    await _drain_future(self._start_internal_method(self._release))
+                    await _drain_future(self._start_tracked_release())
                 except BaseException as error:  # noqa: BLE001  # reported with the cancellation below
                     rollback_error = error
 
@@ -398,7 +410,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     async def _rollback_backend_cancelled_acquire(self, acquire_error: asyncio.CancelledError) -> NoReturn:
         if self.is_locked:
             try:
-                await _drain_future(self._start_internal_method(self._release))
+                await _drain_future(self._start_tracked_release())
             except BaseException as rollback_error:  # noqa: BLE001  # both backend errors must surface
                 self._raise_acquire_rollback_errors(acquire_error, rollback_error)
         raise acquire_error
@@ -439,7 +451,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         :param force: If true, the lock counter is ignored and the lock is released in every case.
 
         """
-        if not self.is_locked:
+        if self._creator_pid != os.getpid() or not self.is_locked:
             return
         async with self._transition_gate.hold():
             await self._release_serialized(force=force)
@@ -453,7 +465,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
 
         lock_id, lock_filename = id(self), self.lock_file
         _LOGGER.debug("Attempting to release lock %s on %s", lock_id, lock_filename)
-        release_future = self._start_internal_method(self._release)
+        release_future = self._start_tracked_release()
         try:
             await _wait_until_done(release_future)
         except asyncio.CancelledError as cancellation:
@@ -490,6 +502,96 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         future: asyncio.Future[_BackendOutcome[None]] = loop.create_future()
         future.set_result(_capture_call(sync_method))
         return future
+
+    def _start_tracked_release(self) -> asyncio.Future[_BackendOutcome[None]]:
+        return self._start_internal_method(
+            self._release_with_fork_tracking_async
+            if iscoroutinefunction(self._release)
+            else self._release_with_fork_tracking
+        )
+
+    async def _acquire_with_fork_tracking_async(self) -> None:
+        with _fork_transition(self):
+            try:
+                await cast("Callable[[], Awaitable[None]]", self._acquire)()
+            except BaseException as acquisition_error:
+                await self._rollback_failed_acquire_async(acquisition_error)
+                raise
+            try:
+                self._register_context_descriptor()
+            except BaseException as registration_error:  # cancellation must roll back the descriptor
+                await self._rollback_failed_registration_async(registration_error)
+                raise
+        if self.is_locked:
+            await self._invoke_on_acquired_async()
+
+    async def _rollback_failed_acquire_async(self, acquisition_error: BaseException) -> None:
+        if not self.is_locked:
+            return
+        registration_error: BaseException | None = None
+        tracking_error: BaseException | None = None
+        try:
+            self._register_context_descriptor()
+        except BaseException as error:  # noqa: BLE001  # preserve registration and acquisition failures
+            registration_error = error
+            try:
+                # Rollback may fail too; retain the fd so a child can close it without another identity probe.
+                self._register_unverified_context_descriptor()
+            except BaseException as error:  # noqa: BLE001  # pragma: no cover - allocation/control-flow during fallback
+                tracking_error = error
+        try:
+            await _drain_future(self._start_tracked_release())
+        except BaseException as rollback_error:  # noqa: BLE001  # preserve rollback and acquisition failures
+            if registration_error is None and tracking_error is None:
+                self._raise_acquire_rollback_errors(acquisition_error, rollback_error)
+            _raise_cleanup_errors(
+                "lock acquisition cleanup failed",
+                acquisition_error,
+                registration_error,
+                tracking_error,
+                rollback_error,
+            )
+        if registration_error is not None:
+            _raise_cleanup_errors(
+                "lock acquisition cleanup failed", acquisition_error, registration_error, tracking_error
+            )
+
+    async def _rollback_failed_registration_async(self, registration_error: BaseException) -> None:
+        tracking_error: BaseException | None = None
+        try:
+            # Rollback may fail too; retain the fd so a child can close it without another identity probe.
+            self._register_unverified_context_descriptor()
+        except BaseException as error:  # noqa: BLE001  # pragma: no cover - allocation/control-flow during fallback
+            tracking_error = error
+        try:
+            await _drain_future(self._start_tracked_release())
+        except BaseException as rollback_error:  # noqa: BLE001  # preserve rollback and registration failures
+            _raise_cleanup_errors(
+                "descriptor registration cleanup failed", registration_error, tracking_error, rollback_error
+            )
+        if tracking_error is not None:  # pragma: no cover - requires failed in-memory fallback
+            _raise_cleanup_errors("descriptor registration cleanup failed", registration_error, tracking_error)
+
+    async def _invoke_on_acquired_async(self) -> None:
+        if self._on_acquired is None or self._context.lock_counter != 1:
+            return
+        try:
+            self._on_acquired(cast("int", self._context.lock_file_fd))
+        except BaseException as callback_error:  # caller control-flow errors must release the lock
+            callback_context = callback_error.__context__
+            try:
+                await _drain_future(self._start_tracked_release())
+            except BaseException as release_error:  # noqa: BLE001  # both errors surface via the group below
+                _raise_body_and_release(callback_error, release_error)
+            callback_error.__context__ = callback_context
+            raise
+
+    async def _release_with_fork_tracking_async(self) -> None:
+        with _fork_transition(self):
+            try:
+                await cast("Callable[[], Awaitable[None]]", self._release)()
+            finally:
+                self._unregister_released_descriptor()
 
     def __enter__(self) -> NoReturn:
         """Sync context manager entry is not supported because lock acquisition is a coroutine."""
@@ -558,6 +660,8 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
 
     def __del__(self) -> None:
         """Release on deletion; safe to call during GC even when no event loop is running."""
+        if vars(self).get("_creator_pid") != os.getpid():
+            return  # pragma: no cover - exercised in fork children
         with contextlib.suppress(Exception):
             try:
                 loop = asyncio.get_running_loop()

--- a/tests/fork_helpers.py
+++ b/tests/fork_helpers.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Final, NoReturn, cast
+
+from coverage import Coverage, process_startup
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Protocol
+
+    class _RegisterAtFork(Protocol):
+        def __call__(self, *, after_in_child: Callable[[], None] | None = None) -> None: ...
+
+
+_FORK: Final[Callable[[], int] | None] = cast(
+    "Callable[[], int] | None",
+    getattr(os, "fork", None),  # fork is absent from Windows at runtime and in its type interface
+)
+_REGISTER_AT_FORK: Final[_RegisterAtFork | None] = cast(
+    "_RegisterAtFork | None",
+    getattr(  # register_at_fork is absent from Windows at runtime and in its type interface
+        os,
+        "register_at_fork",
+        None,
+    ),
+)
+
+
+def fork_process(child: Callable[[], NoReturn] | None = None) -> int:
+    if _FORK is None:  # pragma: no cover - platform without os.fork
+        msg = "os.fork is unavailable"
+        raise RuntimeError(msg)
+    child_pid = _FORK()
+    if child_pid == 0 and child is not None:
+        child()  # pragma: no cover - child coverage starts after fork returns to this frame
+    return child_pid
+
+
+def exit_child(status: int) -> NoReturn:
+    try:
+        if (coverage := Coverage.current()) is not None:
+            coverage.save()
+    finally:
+        # A coverage write failure must not return the fork child to pytest.
+        os._exit(status)
+
+
+def _restart_coverage_after_fork() -> None:
+    if (coverage := Coverage.current()) is not None:
+        coverage.stop()
+    process_startup(force=True, slug="fork")  # pragma: no cover - coverage is stopped until this call returns
+
+
+if _REGISTER_AT_FORK is not None:
+    _REGISTER_AT_FORK(after_in_child=_restart_coverage_after_fork)
+
+
+__all__ = ["exit_child", "fork_process"]

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess  # noqa: S404  # isolated interpreter controls child callback registration order
+import sys
+from errno import EBADF
+from typing import TYPE_CHECKING, Final, NoReturn, cast
+
+import pytest
+from fork_helpers import exit_child, fork_process
+
+from filelock import BaseAsyncFileLock, BaseFileLock
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup
+else:  # pragma: no cover (<py311)
+    from exceptiongroup import BaseExceptionGroup
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
+
+
+class _DescriptorLock(BaseFileLock):
+    acquire_error: BaseException | None = None
+    descriptor: int | None = None
+    fail_release: bool = False
+
+    def _acquire(self) -> None:
+        self.descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+        if self.acquire_error is not None:
+            raise self.acquire_error
+
+    def _release(self) -> None:
+        if self.fail_release:
+            msg = "unlock failed"
+            raise RuntimeError(msg)
+        os.close(cast("int", self._context.lock_file_fd))
+        self._context.lock_file_fd = None
+
+
+class _CoroutineDescriptorLock(BaseAsyncFileLock):
+    acquire_error: BaseException | None = None
+    acquire_error_before_descriptor: BaseException | None = None
+    descriptor: int | None = None
+    release_error: BaseException | None = None
+    release_error_before_close: BaseException | None = None
+
+    async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]  # coroutine backends are supported
+        if self.acquire_error_before_descriptor is not None:
+            raise self.acquire_error_before_descriptor
+        self.descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+        if self.acquire_error is not None:
+            raise self.acquire_error
+
+    async def _release(self) -> None:  # ty: ignore[invalid-method-override]  # coroutine backends are supported
+        if self.release_error_before_close is not None:
+            raise self.release_error_before_close
+        os.close(cast("int", self._context.lock_file_fd))
+        self._context.lock_file_fd = None
+        if self.release_error is not None:
+            raise self.release_error
+
+
+@_REQUIRES_FORK
+def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:
+    descriptors: list[int] = []
+    lock = _DescriptorLock(str(tmp_path / "third-party.lock"), is_singleton=False, on_acquired=descriptors.append)
+    lock.acquire()
+
+    child_pid = _fork_descriptor_probe(descriptors[0], os.fstat)
+    _, status = os.waitpid(child_pid, 0)
+    lock.release()
+
+    assert os.waitstatus_to_exitcode(status) == 0
+
+
+@_REQUIRES_FORK
+def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:
+    descriptors: list[int] = []
+    lock = _DescriptorLock(str(tmp_path / "retry.lock"), is_singleton=False, on_acquired=descriptors.append)
+    lock.acquire()
+    lock.fail_release = True
+    with pytest.raises(RuntimeError, match="unlock failed"):
+        lock.release()
+
+    child_pid = _fork_descriptor_probe(descriptors[0], os.fstat)
+    _, status = os.waitpid(child_pid, 0)
+    lock.fail_release = False
+    lock.release()
+
+    assert os.waitstatus_to_exitcode(status) == 0
+
+
+@_REQUIRES_FORK
+def test_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path: Path) -> None:
+    lock = _DescriptorLock(str(tmp_path / "partial.lock"), is_singleton=False)
+    lock.acquire_error = RuntimeError("acquire failed")
+    lock.fail_release = True
+    with pytest.raises(BaseExceptionGroup) as info:
+        lock.acquire(timeout=0)
+    child_pid = _fork_descriptor_probe(cast("int", lock.descriptor), os.fstat)
+    _, status = os.waitpid(child_pid, 0)
+    lock.acquire_error = None
+    lock.fail_release = False
+    lock.release()
+
+    assert (
+        _error_details(info.value),
+        os.waitstatus_to_exitcode(status),
+    ) == (
+        [(RuntimeError, "acquire failed"), (RuntimeError, "unlock failed")],
+        0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("fail_release", "expected"),
+    [
+        pytest.param(
+            False,
+            [(RuntimeError, "acquire failed"), (OSError, "registration failed")],
+            id="rollback-succeeds",
+        ),
+        pytest.param(
+            True,
+            [
+                (RuntimeError, "acquire failed"),
+                (OSError, "registration failed"),
+                (RuntimeError, "unlock failed"),
+            ],
+            id="rollback-fails",
+        ),
+    ],
+)
+@_REQUIRES_FORK
+def test_acquisition_and_registration_errors_are_grouped(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    *,
+    fail_release: bool,
+    expected: list[tuple[type[BaseException], str]],
+) -> None:
+    lock = _DescriptorLock(str(tmp_path / "registration.lock"), is_singleton=False)
+    lock.acquire_error = RuntimeError("acquire failed")
+    lock.fail_release = fail_release
+    real_fstat = os.fstat
+
+    def fail_registration(fd: int) -> os.stat_result:
+        assert fd == lock.descriptor
+        msg = "registration failed"
+        raise OSError(msg)
+
+    fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
+    with pytest.raises(BaseExceptionGroup) as info:
+        lock.acquire(timeout=0)
+    descriptor = cast("int", lock.descriptor)
+    mocker.stop(fstat_mock)
+
+    child_pid = _fork_descriptor_probe(descriptor, real_fstat)
+    _, status = os.waitpid(child_pid, 0)
+    lock.acquire_error = None
+    lock.fail_release = False
+    lock.release(force=True)
+
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+        real_fstat(descriptor)
+    assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
+
+
+@_REQUIRES_FORK
+def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = _DescriptorLock(str(tmp_path / "group.lock"), is_singleton=False)
+    lock.fail_release = True
+    real_fstat = os.fstat
+
+    def fail_registration(fd: int) -> os.stat_result:
+        assert fd == lock.descriptor
+        msg = "registration failed"
+        raise OSError(msg)
+
+    fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
+    with pytest.raises(BaseExceptionGroup) as info:
+        lock.acquire(timeout=0)
+    descriptor = cast("int", lock.descriptor)
+    mocker.stop(fstat_mock)
+
+    child_pid = _fork_descriptor_probe(descriptor, real_fstat)
+    _, status = os.waitpid(child_pid, 0)
+    lock.fail_release = False
+    lock.release()
+
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+        real_fstat(descriptor)
+    assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (
+        [(OSError, "registration failed"), (RuntimeError, "unlock failed")],
+        0,
+    )
+
+
+@_REQUIRES_FORK
+def test_unverified_descriptor_does_not_close_reused_child_fd(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup
+else:
+    from exceptiongroup import BaseExceptionGroup
+
+descriptor = -1
+replacement_descriptor = -1
+real_fstat = os.fstat
+
+def replace_descriptor_in_child() -> None:
+    global replacement_descriptor
+    os.close(descriptor)
+    replacement_descriptor = os.open(sys.argv[2], os.O_CREAT | os.O_RDWR, 0o600)
+
+os.register_at_fork(after_in_child=replace_descriptor_in_child)
+
+from filelock import BaseFileLock
+
+class FailingRollbackLock(BaseFileLock):
+    fail_release = True
+
+    def _acquire(self) -> None:
+        global descriptor
+        descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+
+    def _release(self) -> None:
+        if self.fail_release:
+            raise RuntimeError("rollback failed")
+        os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+        self._context.lock_file_fd = None
+
+def fail_descriptor_probe(fd: int) -> os.stat_result:
+    if fd == descriptor:
+        raise OSError("registration failed")
+    return real_fstat(fd)
+
+os.fstat = fail_descriptor_probe
+lock = FailingRollbackLock(sys.argv[1], is_singleton=False)
+try:
+    lock.acquire(timeout=0)
+except BaseExceptionGroup:
+    pass
+else:
+    raise SystemExit(2)
+
+child_pid = os.fork()
+if child_pid == 0:
+    try:
+        real_fstat(replacement_descriptor)
+    except OSError:
+        os._exit(1)
+    os._exit(0 if replacement_descriptor == descriptor else 2)
+
+_, status = os.waitpid(child_pid, 0)
+os.fstat = real_fstat
+lock.fail_release = False
+lock.release()
+raise SystemExit(os.waitstatus_to_exitcode(status))
+"""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(tmp_path / "lock"),
+            str(tmp_path / "replacement"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+def test_control_flow_registration_error_rolls_back_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
+    descriptors: list[int] = []
+
+    class StopAcquire(BaseException):
+        pass
+
+    class CapturingLock(_DescriptorLock):
+        def _acquire(self) -> None:
+            super()._acquire()
+            descriptors.append(cast("int", self._context.lock_file_fd))
+
+    real_fstat = os.fstat
+
+    def interrupt_registration(fd: int) -> os.stat_result:
+        assert fd == descriptors[0]
+        raise StopAcquire
+
+    mocker.patch("os.fstat", side_effect=interrupt_registration)
+    with pytest.raises(StopAcquire):
+        CapturingLock(str(tmp_path / "interrupt.lock"), is_singleton=False).acquire(timeout=0)
+
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+        real_fstat(descriptors[0])
+
+
+@pytest.mark.asyncio
+@_REQUIRES_FORK
+async def test_coroutine_registration_error_rolls_back_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
+    descriptors: list[int] = []
+    real_fstat = os.fstat
+
+    def fail_registration(fd: int) -> os.stat_result:
+        descriptors.append(fd)
+        msg = "registration failed"
+        raise OSError(msg)
+
+    mocker.patch("os.fstat", side_effect=fail_registration)
+    with pytest.raises(OSError, match="registration failed"):
+        await _CoroutineDescriptorLock(str(tmp_path / "coroutine.lock"), is_singleton=False).acquire(timeout=0)
+
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+        real_fstat(descriptors[0])
+
+
+@pytest.mark.asyncio
+async def test_coroutine_acquisition_failure_before_descriptor_propagates(tmp_path: Path) -> None:
+    acquisition_error = RuntimeError("acquire failed")
+    lock = _CoroutineDescriptorLock(str(tmp_path / "coroutine-empty.lock"), is_singleton=False)
+    lock.acquire_error_before_descriptor = acquisition_error
+
+    with pytest.raises(RuntimeError, match="acquire failed") as info:
+        await lock.acquire(timeout=0)
+
+    assert (info.value is acquisition_error, lock.is_locked) == (True, False)
+
+
+@_REQUIRES_FORK
+@pytest.mark.asyncio
+async def test_coroutine_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path: Path) -> None:
+    lock = _CoroutineDescriptorLock(
+        str(tmp_path / "coroutine-partial.lock"), is_singleton=False, context_error_policy="group"
+    )
+    lock.acquire_error = RuntimeError("acquire failed")
+    lock.release_error = RuntimeError("release failed")
+    with pytest.raises(BaseExceptionGroup) as info:
+        await lock.acquire(timeout=0)
+    descriptor = cast("int", lock.descriptor)
+
+    child_pid = _fork_descriptor_probe(descriptor, os.fstat)
+    _, status = await asyncio.to_thread(os.waitpid, child_pid, 0)
+    lock.acquire_error = None
+    lock.release_error = None
+    await lock.release()
+
+    assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (
+        [(RuntimeError, "acquire failed"), (RuntimeError, "release failed")],
+        0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("release_error", "expected"),
+    [
+        pytest.param(
+            None,
+            [(RuntimeError, "acquire failed"), (OSError, "registration failed")],
+            id="rollback-succeeds",
+        ),
+        pytest.param(
+            RuntimeError("release failed"),
+            [
+                (RuntimeError, "acquire failed"),
+                (OSError, "registration failed"),
+                (RuntimeError, "release failed"),
+            ],
+            id="rollback-fails",
+        ),
+    ],
+)
+@_REQUIRES_FORK
+@pytest.mark.asyncio
+async def test_coroutine_acquisition_and_registration_errors_are_grouped(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    release_error: BaseException | None,
+    expected: list[tuple[type[BaseException], str]],
+) -> None:
+    lock = _CoroutineDescriptorLock(str(tmp_path / "coroutine-registration.lock"), is_singleton=False)
+    lock.acquire_error = RuntimeError("acquire failed")
+    lock.release_error = release_error
+    real_fstat = os.fstat
+
+    def fail_registration(fd: int) -> os.stat_result:
+        assert fd == lock.descriptor
+        msg = "registration failed"
+        raise OSError(msg)
+
+    fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
+    with pytest.raises(BaseExceptionGroup) as info:
+        await lock.acquire(timeout=0)
+    descriptor = cast("int", lock.descriptor)
+    mocker.stop(fstat_mock)
+
+    child_pid = _fork_descriptor_probe(descriptor, real_fstat)
+    _, status = await asyncio.to_thread(os.waitpid, child_pid, 0)
+    lock.acquire_error = None
+    lock.release_error = None
+    await lock.release(force=True)
+
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+        real_fstat(descriptor)
+    assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
+
+
+@_REQUIRES_FORK
+@pytest.mark.asyncio
+async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fails(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    lock = _CoroutineDescriptorLock(str(tmp_path / "coroutine-group.lock"), is_singleton=False)
+    lock.release_error_before_close = RuntimeError("rollback failed")
+    real_fstat = os.fstat
+
+    def fail_registration(fd: int) -> os.stat_result:
+        assert fd == lock.descriptor
+        msg = "registration failed"
+        raise OSError(msg)
+
+    fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
+    with pytest.raises(BaseExceptionGroup) as info:
+        await lock.acquire(timeout=0)
+    descriptor = cast("int", lock.descriptor)
+    mocker.stop(fstat_mock)
+
+    child_pid = _fork_descriptor_probe(descriptor, real_fstat)
+    _, status = await asyncio.to_thread(os.waitpid, child_pid, 0)
+    lock.release_error_before_close = None
+    await lock.release()
+
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+        real_fstat(descriptor)
+    assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (
+        [(OSError, "registration failed"), (RuntimeError, "rollback failed")],
+        0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_coroutine_on_acquired_error_preserves_context(tmp_path: Path) -> None:
+    callback_error = RuntimeError("hook failed")
+    prior_context = LookupError("prior callback failure")
+    callback_error.__context__ = prior_context
+
+    def fail_callback(_fd: int) -> None:
+        raise callback_error
+
+    lock = _CoroutineDescriptorLock(
+        str(tmp_path / "coroutine-hook-context.lock"), is_singleton=False, on_acquired=fail_callback
+    )
+    with pytest.raises(RuntimeError, match="hook failed") as info:
+        await lock.acquire(timeout=0)
+
+    assert (info.value is callback_error, callback_error.__context__, lock.is_locked) == (True, prior_context, False)
+
+
+@pytest.mark.asyncio
+async def test_coroutine_on_acquired_and_rollback_errors_are_grouped(tmp_path: Path) -> None:
+    callback_error = RuntimeError("hook failed")
+
+    def fail_callback(_fd: int) -> None:
+        raise callback_error
+
+    lock = _CoroutineDescriptorLock(
+        str(tmp_path / "coroutine-hook.lock"), is_singleton=False, on_acquired=fail_callback
+    )
+    lock.release_error = RuntimeError("release failed")
+    with pytest.raises(BaseExceptionGroup) as info:
+        await lock.acquire(timeout=0)
+
+    assert _error_details(info.value) == [
+        (RuntimeError, "hook failed"),
+        (RuntimeError, "release failed"),
+    ]
+
+
+def _error_details(group: BaseExceptionGroup) -> list[tuple[type[BaseException], str]]:
+    return [(type(error), str(error)) for error in group.exceptions]
+
+
+def _fork_descriptor_probe(descriptor: int, stat_descriptor: Callable[[int], os.stat_result]) -> int:
+    def probe_child() -> NoReturn:
+        with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+            stat_descriptor(descriptor)
+        exit_child(0)
+
+    return fork_process(probe_child)

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -1,0 +1,1103 @@
+from __future__ import annotations
+
+import os
+import subprocess  # noqa: S404  # isolated interpreters control at-fork registration order
+import sys
+import threading
+from typing import TYPE_CHECKING, Final, Literal
+
+import pytest
+from fork_helpers import exit_child, fork_process
+
+from filelock import BaseFileLock, Timeout, has_fcntl
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
+_FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
+    "ignore:.*multi-threaded, use of fork.*:DeprecationWarning"
+)
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_callbacks_registered_before_filelock_can_use_locks(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+
+callback_lock = None
+child_ok = False
+parent_callback_ran = False
+
+def before() -> None:
+    global callback_lock
+    callback_lock = FileLock(sys.argv[2], is_singleton=True)
+    callback_lock.acquire()
+
+def parent() -> None:
+    global parent_callback_ran
+    if callback_lock is None or not callback_lock.is_locked:
+        return
+    callback_lock.release()
+    parent_callback_ran = True
+
+def child() -> None:
+    global child_ok
+    if callback_lock is None:
+        return
+    child_singleton = FileLock(sys.argv[1], is_singleton=True)
+    child_ok = (
+        not callback_lock.is_locked
+        and callback_lock.lock_counter == 0
+        and child_singleton is not parent_singleton
+    )
+
+os.register_at_fork(before=before, after_in_parent=parent, after_in_child=child)
+
+from filelock import FileLock
+
+parent_singleton = FileLock(sys.argv[1], is_singleton=True)
+child_pid = os.fork()
+if child_pid == 0:
+    os._exit(0 if child_ok else 1)
+_, status = os.waitpid(child_pid, 0)
+if (
+    os.waitstatus_to_exitcode(status) != 0
+    or not parent_callback_ran
+    or callback_lock is None
+    or callback_lock.is_locked
+):
+    sys.exit(2)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "singleton.lock"), str(tmp_path / "callback.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.parametrize(
+    "audit_mode",
+    [pytest.param("installed", id="audit-installed"), pytest.param("rejected", id="audit-rejected")],
+)
+def test_concurrent_fork_after_first_snapshot_does_not_deadlock(
+    tmp_path: Path, audit_mode: Literal["installed", "rejected"]
+) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from queue import Queue
+
+entered = threading.Event()
+release = threading.Event()
+statuses: Queue[int] = Queue()
+
+def block_before_fork() -> None:
+    if threading.current_thread().name == "fork-owner":
+        entered.set()
+        if not release.wait(timeout=5):
+            raise RuntimeError("fork owner was not released")
+
+os.register_at_fork(before=block_before_fork)
+
+if sys.argv[2] == "rejected":
+    # Audit arguments mix interpreter-owned types; object is their only accurate common type.
+    def reject_add_hook(event: str, _args: tuple[object, ...]) -> None:
+        if event == "sys.addaudithook":
+            raise RuntimeError
+
+    sys.addaudithook(reject_add_hook)
+
+from filelock import FileLock
+
+FileLock(sys.argv[1], is_singleton=False)
+
+def fork_once() -> None:
+    child_pid = os.fork()
+    if child_pid == 0:
+        os._exit(0)
+    _, status = os.waitpid(child_pid, 0)
+    statuses.put(os.waitstatus_to_exitcode(status))
+
+owner = threading.Thread(target=fork_once, name="fork-owner")
+owner.start()
+if not entered.wait(timeout=5):
+    sys.exit(1)
+try:
+    child_pid = os.fork()
+except RuntimeError as exception:
+    second_status = 0 if "unsafe while filelock is changing descriptor ownership" in str(exception) else 1
+else:
+    if child_pid == 0:
+        os._exit(0)
+    _, status = os.waitpid(child_pid, 0)
+    second_status = os.waitstatus_to_exitcode(status)
+release.set()
+owner.join(timeout=5)
+if second_status != 0 or owner.is_alive() or statuses.get(timeout=1) != 0:
+    sys.exit(2)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "parent.lock"), audit_mode],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@_REQUIRES_FORK
+@pytest.mark.parametrize(
+    "event",
+    [
+        pytest.param("os.fork", id="fork"),
+        pytest.param("os.forkpty", id="forkpty"),
+        pytest.param("_posixsubprocess.fork_exec", id="fork-exec"),
+    ],
+)
+def test_audit_rejects_process_creation_inside_descriptor_transition(
+    tmp_path: Path,
+    event: Literal["os.fork", "os.forkpty", "_posixsubprocess.fork_exec"],
+) -> None:
+    class AuditedLock(BaseFileLock):
+        def _acquire(self) -> None:
+            self._context.lock_file_fd = None
+            if event == "_posixsubprocess.fork_exec":
+                sys.audit(event, (), (), None)
+            else:
+                sys.audit(event)
+
+        _release = _acquire
+
+    with pytest.raises(RuntimeError, match="unsafe while filelock is changing descriptor ownership"):
+        AuditedLock(str(tmp_path / "audit.lock"), is_singleton=False).acquire(timeout=0)
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.parametrize(
+    "fork_mode",
+    [
+        pytest.param("rejected-audit", id="rejected-audit-hook"),
+        pytest.param(
+            "fork1",
+            marks=pytest.mark.skipif(not hasattr(os, "fork1"), reason="os.fork1 required"),
+            id="fork1",
+        ),
+    ],
+)
+def test_fork_without_audit_guard_snapshots_current_transition(
+    tmp_path: Path, fork_mode: Literal["rejected-audit", "fork1"]
+) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+from errno import EBADF
+
+if sys.argv[1] == "rejected-audit":
+    # Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
+    def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+        if event == "sys.addaudithook":
+            raise RuntimeError
+
+    sys.addaudithook(reject_filelock_hook)
+
+from filelock import BaseFileLock
+
+fork = os.fork if sys.argv[1] == "rejected-audit" else os.fork1
+
+class ForkingLock(BaseFileLock):
+    child_status = -1
+
+    def _acquire(self) -> None:
+        descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+        child_pid = fork()
+        if child_pid == 0:
+            try:
+                os.fstat(descriptor)
+            except OSError as exception:
+                os._exit(0 if exception.errno == EBADF else 1)
+            os._exit(1)
+        _, status = os.waitpid(child_pid, 0)
+        self.child_status = os.waitstatus_to_exitcode(status)
+
+    def _release(self) -> None:
+        os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+        self._context.lock_file_fd = None
+
+lock = ForkingLock(sys.argv[2], is_singleton=False)
+lock.acquire()
+lock.release()
+raise SystemExit(lock.child_status)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, fork_mode, str(tmp_path / "transition.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.skipif(not has_fcntl, reason="fcntl.flock required")
+@pytest.mark.skipif(sys.implementation.name != "cpython", reason="CPython fcntl audit event required")
+@pytest.mark.parametrize(
+    "fork_mode",
+    [
+        pytest.param("rejected-audit", id="rejected-audit-hook"),
+        pytest.param(
+            "fork1",
+            marks=pytest.mark.skipif(not hasattr(os, "fork1"), reason="os.fork1 required"),
+            id="fork1",
+        ),
+    ],
+)
+def test_native_descriptor_is_visible_during_flock_audit(
+    tmp_path: Path, fork_mode: Literal["rejected-audit", "fork1"]
+) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+from errno import EBADF
+
+child_status = -1
+forked = False
+
+# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
+def audit_hook(event: str, args: tuple[object, ...]) -> None:
+    global child_status, forked
+    if event == "sys.addaudithook" and sys.argv[1] == "rejected-audit":
+        raise RuntimeError
+    if event != "fcntl.flock" or forked:
+        return
+    forked = True
+    descriptor = args[0]
+    child_pid = (os.fork if sys.argv[1] == "rejected-audit" else os.fork1)()
+    if child_pid == 0:
+        try:
+            os.fstat(descriptor)
+        except OSError as exception:
+            os._exit(0 if exception.errno == EBADF else 1)
+        os._exit(1)
+    _, status = os.waitpid(child_pid, 0)
+    child_status = os.waitstatus_to_exitcode(status)
+
+sys.addaudithook(audit_hook)
+
+from filelock import FileLock
+
+lock = FileLock(sys.argv[2], is_singleton=False)
+lock.acquire()
+lock.release()
+raise SystemExit(child_status)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, fork_mode, str(tmp_path / "native.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_child_unwinds_pre_fork_transition_before_new_acquire(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+from errno import EBADF
+
+# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
+def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+    if event == "sys.addaudithook":
+        raise RuntimeError
+
+sys.addaudithook(reject_filelock_hook)
+
+from filelock import BaseFileLock
+
+class ForkingLock(BaseFileLock):
+    child_pid = -1
+
+    def _acquire(self) -> None:
+        self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+        self.child_pid = os.fork()
+
+    def _release(self) -> None:
+        os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+        self._context.lock_file_fd = None
+
+first = ForkingLock(sys.argv[1], is_singleton=False)
+try:
+    first.acquire()
+except RuntimeError as exception:
+    if first.child_pid != 0 or "inherited across fork" not in str(exception):
+        raise
+
+    class ProbeLock(BaseFileLock):
+        child_status = -1
+
+        def _acquire(self) -> None:
+            descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+            child_pid = os.fork()
+            if child_pid == 0:
+                try:
+                    os.fstat(descriptor)
+                except OSError as error:
+                    os._exit(0 if error.errno == EBADF else 1)
+                os._exit(1)
+            _, status = os.waitpid(child_pid, 0)
+            self.child_status = os.waitstatus_to_exitcode(status)
+
+        def _release(self) -> None:
+            os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+            self._context.lock_file_fd = None
+
+    probe = ProbeLock(sys.argv[2], is_singleton=False)
+    probe.acquire()
+    probe.release()
+    os._exit(probe.child_status)
+
+_, status = os.waitpid(first.child_pid, 0)
+first.release()
+raise SystemExit(os.waitstatus_to_exitcode(status))
+"""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(tmp_path / "first.lock"),
+            str(tmp_path / "probe.lock"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_overlapping_coroutine_transitions_close_every_pending_descriptor(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from errno import EBADF
+
+# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
+def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+    if event == "sys.addaudithook":
+        raise RuntimeError
+
+sys.addaudithook(reject_filelock_hook)
+
+from filelock import BaseAsyncFileLock
+
+both_pending = asyncio.Event()
+allow_return = asyncio.Event()
+descriptors: list[int] = []
+child_status = -1
+
+class OverlapLock(BaseAsyncFileLock):
+    async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]  # coroutine backends are supported
+        global child_status
+        descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+        descriptors.append(descriptor)
+        if len(descriptors) == 2:
+            both_pending.set()
+        await both_pending.wait()
+        if self.lock_file != sys.argv[1]:
+            await allow_return.wait()
+            return
+        child_pid = os.fork()
+        if child_pid == 0:
+            for inherited in descriptors:
+                try:
+                    os.fstat(inherited)
+                except OSError as exception:
+                    if exception.errno == EBADF:
+                        continue
+                os._exit(1)
+            os._exit(0)
+        _, status = os.waitpid(child_pid, 0)
+        child_status = os.waitstatus_to_exitcode(status)
+        allow_return.set()
+
+    async def _release(self) -> None:  # ty: ignore[invalid-method-override]  # coroutine backends are supported
+        os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+        self._context.lock_file_fd = None
+
+async def main() -> None:
+    first = OverlapLock(sys.argv[1], thread_local=False, is_singleton=False, run_in_executor=False)
+    second = OverlapLock(sys.argv[2], thread_local=False, is_singleton=False, run_in_executor=False)
+    await asyncio.gather(first.acquire(timeout=0), second.acquire(timeout=0))
+    await asyncio.gather(first.release(), second.release())
+    raise SystemExit(child_status)
+
+asyncio.run(main())
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "first.lock"), str(tmp_path / "second.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_pending_descriptor_with_unknown_identity_is_preserved_in_child(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+
+# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
+def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+    if event == "sys.addaudithook":
+        raise RuntimeError
+
+sys.addaudithook(reject_filelock_hook)
+
+from filelock import BaseFileLock
+
+real_fstat = os.fstat
+
+class PendingLock(BaseFileLock):
+    child_status = -1
+
+    def _acquire(self) -> None:
+        descriptor = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+        self._context.pending_lock_file_fd = descriptor
+
+        def fail_pending_identity(fd: int) -> os.stat_result:
+            if fd == descriptor:
+                raise OSError("identity unavailable")
+            return real_fstat(fd)
+
+        os.fstat = fail_pending_identity
+        child_pid = os.fork()
+        os.fstat = real_fstat
+        if child_pid == 0:
+            real_fstat(descriptor)
+            raise SystemExit(0)
+        _, status = os.waitpid(child_pid, 0)
+        self.child_status = os.waitstatus_to_exitcode(status)
+        stat_result = real_fstat(descriptor)
+        self._context.pending_lock_file_fd = None
+        self._context.lock_file_fd = descriptor
+        self._context.lock_file_fd_identity = stat_result.st_dev, stat_result.st_ino
+
+    def _release(self) -> None:
+        os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+        self._context.lock_file_fd = None
+
+lock = PendingLock(sys.argv[1], is_singleton=False)
+lock.acquire(timeout=0)
+lock.release()
+raise SystemExit(lock.child_status)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "pending.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_child_replaces_parameter_model_mutex_held_during_construction(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import threading
+import warnings
+from collections.abc import Callable
+from queue import Queue
+
+warnings.filterwarnings("ignore", message=".*multi-threaded, use of fork.*", category=DeprecationWarning)
+
+# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
+def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+    if event == "sys.addaudithook":
+        raise RuntimeError
+
+sys.addaudithook(reject_filelock_hook)
+
+from filelock import BaseFileLock
+
+parent_pid = os.getpid()
+forked = False
+paused = threading.Event()
+release = threading.Event()
+children: Queue[int] = Queue()
+real_signature = inspect.signature
+
+class BlockingLock(BaseFileLock):
+    def _acquire(self) -> None:
+        self._context.lock_file_fd = None
+
+    def _release(self) -> None:
+        self._context.lock_file_fd = None
+
+class ChildLock(BaseFileLock):
+    def _acquire(self) -> None:
+        self._context.lock_file_fd = None
+
+    def _release(self) -> None:
+        self._context.lock_file_fd = None
+
+def blocking_signature(target: Callable[..., BaseFileLock | None]) -> inspect.Signature:
+    global forked
+    if target is BlockingLock.__init__ and not forked:
+        forked = True
+        child_pid = os.fork()
+        if child_pid == 0:
+            ChildLock(sys.argv[2], is_singleton=False)
+            os._exit(0)
+        children.put(child_pid)
+        paused.set()
+        if not release.wait(timeout=5):
+            raise RuntimeError("parent construction was not released")
+    return real_signature(target)
+
+inspect.signature = blocking_signature
+
+def construct() -> None:
+    BlockingLock(sys.argv[1], is_singleton=False)
+
+worker = threading.Thread(target=construct)
+worker.start()
+if not paused.wait(timeout=5):
+    sys.exit(1)
+child_pid = children.get(timeout=1)
+_, status = os.waitpid(child_pid, 0)
+release.set()
+worker.join(timeout=5)
+if os.waitstatus_to_exitcode(status) != 0 or worker.is_alive() or os.getpid() != parent_pid:
+    sys.exit(2)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "parent.lock"), str(tmp_path / "child.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_registration_transition_completes_after_fork_closes_admission(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import warnings
+from queue import Queue
+
+warnings.filterwarnings("ignore", message=".*multi-threaded, use of fork.*", category=DeprecationWarning)
+
+admission_waiting = threading.Event()
+real_condition_wait = threading.Condition.wait
+
+def observed_wait(condition: threading.Condition, timeout: float | None = None) -> bool:
+    if threading.current_thread().name == "forker":
+        admission_waiting.set()
+    return real_condition_wait(condition, timeout)
+
+threading.Condition.wait = observed_wait
+
+from filelock import BaseFileLock
+
+entered = threading.Event()
+release = threading.Event()
+failures: Queue[str] = Queue()
+fork_status: Queue[int] = Queue()
+
+class BlockingLock(BaseFileLock):
+    def _acquire(self) -> None:
+        self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+        entered.set()
+        if not release.wait(timeout=5):
+            raise RuntimeError("backend acquisition was not released")
+
+    def _release(self) -> None:
+        os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+        self._context.lock_file_fd = None
+
+lock = BlockingLock(sys.argv[1], is_singleton=False)
+
+def acquire() -> None:
+    try:
+        lock.acquire(timeout=0)
+    except BaseException as exception:
+        failures.put(f"acquire: {exception!r}")
+
+def fork() -> None:
+    try:
+        child_pid = os.fork()
+        if child_pid == 0:
+            os._exit(0)
+        _, status = os.waitpid(child_pid, 0)
+        fork_status.put(os.waitstatus_to_exitcode(status))
+    except BaseException as exception:
+        failures.put(f"fork: {exception!r}")
+
+worker = threading.Thread(target=acquire, name="acquirer")
+worker.start()
+if not entered.wait(timeout=5):
+    sys.exit(1)
+forker = threading.Thread(target=fork, name="forker")
+forker.start()
+if not admission_waiting.wait(timeout=5):
+    sys.exit(2)
+release.set()
+worker.join(timeout=5)
+forker.join(timeout=5)
+if worker.is_alive() or forker.is_alive() or not failures.empty() or fork_status.get(timeout=1) != 0:
+    sys.exit(3)
+lock.release()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "admission.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.skipif(not has_fcntl, reason="fcntl.flock required")
+def test_cancelled_async_acquire_unregisters_reused_descriptor(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import threading
+import warnings
+
+from filelock import AsyncFileLock
+
+warnings.filterwarnings("ignore", message=".*multi-threaded, use of fork.*", category=DeprecationWarning)
+
+async def main() -> int:
+    callback_started = asyncio.Event()
+    finish_callback = threading.Event()
+    loop = asyncio.get_running_loop()
+    descriptor = -1
+    identity = (-1, -1)
+
+    def block_after_acquire(fd: int) -> None:
+        nonlocal descriptor, identity
+        descriptor = fd
+        stat_result = os.fstat(fd)
+        identity = stat_result.st_dev, stat_result.st_ino
+        loop.call_soon_threadsafe(callback_started.set)
+        if not finish_callback.wait(timeout=5):
+            raise RuntimeError("acquisition callback was not released")
+
+    lock = AsyncFileLock(sys.argv[1], on_acquired=block_after_acquire)
+    acquire_task = asyncio.create_task(lock.acquire())
+    await asyncio.wait_for(callback_started.wait(), timeout=5)
+    acquire_task.cancel()
+    finish_callback.set()
+    try:
+        await acquire_task
+    except asyncio.CancelledError:
+        pass
+    else:
+        return 1
+    if lock.is_locked or lock.lock_counter != 0:
+        return 2
+
+    path_stat = os.stat(sys.argv[1])
+    if (path_stat.st_dev, path_stat.st_ino) != identity:
+        return 3
+
+    occupant = os.open(os.devnull, os.O_RDONLY)
+    if occupant != descriptor:
+        os.dup2(occupant, descriptor)
+    source = os.open(sys.argv[1], os.O_RDWR)
+    if source == descriptor:
+        return 4
+    if (source_stat := os.fstat(source)).st_dev != identity[0] or source_stat.st_ino != identity[1]:
+        return 5
+    os.dup2(source, descriptor)
+    os.close(source)
+    if occupant != descriptor:
+        os.close(occupant)
+
+    child_pid = os.fork()
+    if child_pid == 0:
+        try:
+            replacement_stat = os.fstat(descriptor)
+        except OSError:
+            os._exit(1)
+        os._exit(0 if (replacement_stat.st_dev, replacement_stat.st_ino) == identity else 2)
+    _, status = os.waitpid(child_pid, 0)
+    os.close(descriptor)
+    return os.waitstatus_to_exitcode(status)
+
+raise SystemExit(asyncio.run(main()))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "canceled.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_parent_callback_rejects_reentrant_singleton_construction(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+
+active_constructor: Callable[[], BaseFileLock | SoftReadWriteLock] | None = None
+callback_errors: list[str] = []
+callback_instances: list[BaseFileLock | SoftReadWriteLock] = []
+
+def construct_in_parent_callback() -> None:
+    if active_constructor is None:
+        return
+    try:
+        callback_instances.append(active_constructor())
+    except RuntimeError as exception:
+        callback_errors.append(str(exception))
+
+os.register_at_fork(after_in_parent=construct_in_parent_callback)
+
+from filelock import BaseFileLock, SoftReadWriteLock
+
+fork_in_progress = False
+children: list[int] = []
+
+def fork_once() -> None:
+    global fork_in_progress
+    if fork_in_progress:
+        return
+    fork_in_progress = True
+    child_pid = os.fork()
+    if child_pid == 0:
+        os._exit(0)
+    children.append(child_pid)
+    fork_in_progress = False
+
+class ForkingFileLock(BaseFileLock):
+    def __init__(
+        self, lock_file: str, timeout: float = -1, thread_local: bool = True, *, is_singleton: bool = False
+    ) -> None:
+        fork_once()
+        super().__init__(lock_file, timeout, thread_local=thread_local, is_singleton=is_singleton)
+
+    def _acquire(self) -> None:
+        self._context.lock_file_fd = None
+
+    def _release(self) -> None:
+        self._context.lock_file_fd = None
+
+class ForkingSoftReadWriteLock(SoftReadWriteLock):
+    def __init__(
+        self,
+        lock_file: str,
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+        is_singleton: bool = True,
+        heartbeat_interval: float = 30.0,
+        stale_threshold: float | None = None,
+        poll_interval: float = 0.25,
+    ) -> None:
+        fork_once()
+        super().__init__(
+            lock_file,
+            timeout,
+            blocking=blocking,
+            is_singleton=is_singleton,
+            heartbeat_interval=heartbeat_interval,
+            stale_threshold=stale_threshold,
+            poll_interval=poll_interval,
+        )
+
+file_path, read_write_path = sys.argv[1:]
+active_constructor = lambda: ForkingFileLock(file_path, thread_local=False, is_singleton=True)
+file_lock = ForkingFileLock(file_path, thread_local=False, is_singleton=True)
+active_constructor = lambda: ForkingSoftReadWriteLock(read_write_path, is_singleton=True)
+read_write_lock = ForkingSoftReadWriteLock(read_write_path, is_singleton=True)
+active_constructor = None
+
+statuses = [os.waitstatus_to_exitcode(os.waitpid(child_pid, 0)[1]) for child_pid in children]
+if (
+    statuses != [0, 0]
+    or callback_instances
+    or len(callback_errors) != 2
+    or not all("Singleton lock construction is already active" in error for error in callback_errors)
+    or ForkingFileLock(file_path, thread_local=False, is_singleton=True) is not file_lock
+    or ForkingSoftReadWriteLock(read_write_path, is_singleton=True) is not read_write_lock
+):
+    sys.exit(1)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "file.lock"), str(tmp_path / "read-write.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_singleton_construction_crossing_fork_does_not_poison_child_cache(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+
+from filelock import BaseFileLock
+
+parent_pid = os.getpid()
+forked = False
+children: list[int] = []
+
+class ForkingLock(BaseFileLock):
+    def __init__(self, lock_file: str, thread_local: bool = True, *, is_singleton: bool = False) -> None:
+        global forked
+        if not forked:
+            forked = True
+            child_pid = os.fork()
+            if child_pid != 0:
+                children.append(child_pid)
+        super().__init__(lock_file, thread_local=thread_local, is_singleton=is_singleton)
+
+    def _acquire(self) -> None:
+        self._context.lock_file_fd = None
+
+    def _release(self) -> None:
+        self._context.lock_file_fd = None
+
+try:
+    parent_lock = ForkingLock(sys.argv[1], thread_local=False, is_singleton=True)
+except RuntimeError as exception:
+    if os.getpid() == parent_pid or "Lock construction cannot continue after fork" not in str(exception):
+        raise
+    child_lock = ForkingLock(sys.argv[1], thread_local=False, is_singleton=True)
+    raise SystemExit(0 if ForkingLock(sys.argv[1], thread_local=False, is_singleton=True) is child_lock else 1)
+
+_, status = os.waitpid(children[0], 0)
+if (
+    os.waitstatus_to_exitcode(status) != 0
+    or ForkingLock(sys.argv[1], thread_local=False, is_singleton=True) is not parent_lock
+):
+    sys.exit(2)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "singleton.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_soft_read_write_construction_crossing_fork_does_not_poison_child_cache(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+
+from filelock import SoftReadWriteLock
+
+parent_pid = os.getpid()
+forked = False
+children: list[int] = []
+
+class ForkingLock(SoftReadWriteLock):
+    def __init__(
+        self,
+        lock_file: str,
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+        is_singleton: bool = True,
+        heartbeat_interval: float = 30.0,
+        stale_threshold: float | None = None,
+        poll_interval: float = 0.25,
+    ) -> None:
+        global forked
+        if not forked:
+            forked = True
+            child_pid = os.fork()
+            if child_pid != 0:
+                children.append(child_pid)
+        super().__init__(
+            lock_file,
+            timeout,
+            blocking=blocking,
+            is_singleton=is_singleton,
+            heartbeat_interval=heartbeat_interval,
+            stale_threshold=stale_threshold,
+            poll_interval=poll_interval,
+        )
+
+try:
+    parent_lock = ForkingLock(sys.argv[1], is_singleton=True)
+except RuntimeError as exception:
+    if os.getpid() == parent_pid or "Lock construction cannot continue after fork" not in str(exception):
+        raise
+    child_lock = ForkingLock(sys.argv[1], is_singleton=True)
+    child_cached = ForkingLock(sys.argv[1], is_singleton=True)
+    child_lock.close()
+    raise SystemExit(0 if child_cached is child_lock else 1)
+
+_, status = os.waitpid(children[0], 0)
+parent_cached = ForkingLock(sys.argv[1], is_singleton=True)
+parent_lock.close()
+if os.waitstatus_to_exitcode(status) != 0 or parent_cached is not parent_lock:
+    sys.exit(2)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "singleton.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+def test_fork_exec_from_another_thread_remains_available(tmp_path: Path) -> None:
+    entered, release, finished = threading.Event(), threading.Event(), threading.Event()
+
+    class BlockingTransitionLock(BaseFileLock):
+        def _acquire(self) -> None:
+            entered.set()
+            release.wait(timeout=5)
+            self._context.lock_file_fd = None
+
+        _release = _acquire
+
+    def acquire() -> None:
+        try:
+            BlockingTransitionLock(str(tmp_path / "transition.lock"), is_singleton=False).acquire(timeout=0)
+        except Timeout:
+            finished.set()
+
+    worker = threading.Thread(target=acquire)
+    worker.start()
+    assert entered.wait(timeout=5)
+    sys.audit("_posixsubprocess.fork_exec", (), (), None)
+    result = subprocess.run([sys.executable, "-c", ""], check=False, timeout=5)
+    release.set()
+    worker.join(timeout=5)
+
+    assert (result.returncode, finished.is_set(), worker.is_alive()) == (0, True, False)
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) -> None:
+    entered, release = threading.Event(), threading.Event()
+    parent_pid = os.getpid()
+
+    class BlockingLock(BaseFileLock):
+        def __init__(self, lock_file: str, *, is_singleton: bool = False) -> None:
+            if os.getpid() == parent_pid:
+                entered.set()
+                release.wait(timeout=5)
+            super().__init__(lock_file, thread_local=False, is_singleton=is_singleton)
+
+        def _acquire(self) -> None:
+            self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+
+        def _release(self) -> None:
+            os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+            self._context.lock_file_fd = None
+
+    worker = threading.Thread(target=BlockingLock, args=(str(tmp_path / "mutex.lock"),), kwargs={"is_singleton": True})
+    worker.start()
+    assert entered.wait(timeout=5)
+
+    if (child_pid := fork_process()) == 0:
+        child_lock = BlockingLock(str(tmp_path / "mutex.lock"), is_singleton=True)
+        child_lock.acquire(timeout=0)
+        child_lock.release()
+        exit_child(0)
+    _, status = os.waitpid(child_pid, 0)
+    release.set()
+    worker.join(timeout=5)
+
+    assert (os.waitstatus_to_exitcode(status), worker.is_alive()) == (0, False)

--- a/tests/test_fork_ownership.py
+++ b/tests/test_fork_ownership.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+import os
+import subprocess  # noqa: S404  # fresh interpreter must register the callback before importing filelock
+import sys
+import threading
+from errno import EBADF
+from queue import Queue
+from stat import S_ISDIR
+from typing import TYPE_CHECKING, Final, Literal, NoReturn
+
+import pytest
+from fork_helpers import exit_child, fork_process
+
+from filelock import (
+    AcquireReturnProxy,
+    AsyncFileLock,
+    AsyncSoftFileLock,
+    BaseAsyncFileLock,
+    BaseFileLock,
+    FileLock,
+    SoftFileLock,
+    SoftReadWriteLock,
+    Timeout,
+)
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup
+else:  # pragma: no cover (<py311)
+    from exceptiongroup import BaseExceptionGroup
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
+_FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
+    "ignore:.*multi-threaded, use of fork.*:DeprecationWarning"
+)
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.parametrize(
+    ("lock_type", "action"),
+    [
+        pytest.param(FileLock, "release", id="native-release"),
+        pytest.param(FileLock, "context", id="native-context"),
+        pytest.param(FileLock, "collect", id="native-collect"),
+        pytest.param(SoftFileLock, "release", id="soft-release"),
+        pytest.param(SoftFileLock, "context", id="soft-context"),
+        pytest.param(SoftFileLock, "collect", id="soft-collect"),
+    ],
+)
+def test_child_cleanup_preserves_parent_lock(
+    tmp_path: Path,
+    lock_type: type[BaseFileLock],
+    action: Literal["release", "context", "collect"],
+) -> None:
+    path = str(tmp_path / "parent.lock")
+    lock = lock_type(path, thread_local=False, is_singleton=False)
+    proxy = lock.acquire()
+
+    def cleanup_child() -> NoReturn:
+        _run_child_cleanup(lock, proxy, action)
+
+    child_pid = fork_process(cleanup_child)
+    _, status = os.waitpid(child_pid, 0)
+
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert not _probe_lock(lock_type, path)
+    lock.release()
+    assert _probe_lock(lock_type, path)
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.parametrize(
+    ("async_lock_type", "sync_lock_type"),
+    [
+        pytest.param(AsyncFileLock, FileLock, id="native"),
+        pytest.param(AsyncSoftFileLock, SoftFileLock, id="soft"),
+    ],
+)
+def test_async_child_release_preserves_parent_lock(
+    tmp_path: Path,
+    async_lock_type: type[BaseAsyncFileLock],
+    sync_lock_type: type[BaseFileLock],
+) -> None:
+    path = str(tmp_path / "parent.lock")
+    lock = async_lock_type(path, thread_local=False, is_singleton=False)
+    asyncio.run(lock.acquire())
+
+    def release_child() -> NoReturn:
+        state = lock.is_locked, lock.lock_counter
+        asyncio.run(lock.release(force=True))
+        exit_child(0 if state == (False, 0) else 1)
+
+    child_pid = fork_process(release_child)
+    _, status = os.waitpid(child_pid, 0)
+
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert not _probe_lock(sync_lock_type, path)
+    asyncio.run(lock.release())
+    assert _probe_lock(sync_lock_type, path)
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None:
+    path = str(tmp_path / "parent.lock")
+    older = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
+    newer = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
+    del newer
+    gc.collect()
+    older.acquire_write()
+
+    def inherited_child() -> NoReturn:
+        with pytest.raises(RuntimeError, match="invalidated by fork"):
+            older.acquire_read(timeout=0)
+        older.release()
+        exit_child(0)
+
+    child_pid = fork_process(inherited_child)
+    _, status = os.waitpid(child_pid, 0)
+
+    assert os.waitstatus_to_exitcode(status) == 0
+    contender = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
+    with pytest.raises(Timeout):
+        contender.acquire_write(timeout=0)
+    contender.close()
+    older.release()
+    older.close()
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None:
+    path = str(tmp_path / "parent.lock")
+    descriptor: Queue[int] = Queue()
+    acquired, release = threading.Event(), threading.Event()
+
+    def hold_lock() -> None:
+        lock = FileLock(path, thread_local=True, is_singleton=False, on_acquired=descriptor.put)
+        with lock:
+            acquired.set()
+            release.wait()
+
+    worker = threading.Thread(target=hold_lock)
+    worker.start()
+    assert acquired.wait(timeout=5)
+    fd = descriptor.get(timeout=5)
+
+    def descriptor_child() -> NoReturn:
+        _assert_descriptor_closed(fd)
+
+    child_pid = fork_process(descriptor_child)
+    _, status = os.waitpid(child_pid, 0)
+    release.set()
+    worker.join(timeout=5)
+
+    assert (os.waitstatus_to_exitcode(status), worker.is_alive()) == (0, False)
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFixture) -> None:
+    path = str(tmp_path / "parent.lock")
+    lock = FileLock(path, thread_local=False, is_singleton=False)
+    entered, proceed, acquired = threading.Event(), threading.Event(), threading.Event()
+    descriptors: list[int] = []
+    real_fstat = os.fstat
+
+    def delayed_fstat(fd: int) -> os.stat_result:
+        if threading.current_thread() is worker and not entered.is_set():
+            descriptors.append(fd)
+            entered.set()
+            proceed.wait()
+        return real_fstat(fd)
+
+    mocker.patch("os.fstat", side_effect=delayed_fstat)
+
+    def acquire_lock() -> None:
+        lock.acquire()
+        acquired.set()
+
+    worker = threading.Thread(target=acquire_lock)
+    worker.start()
+    assert entered.wait(timeout=5)
+    timer = threading.Timer(0.05, proceed.set)
+    timer.start()
+
+    def descriptor_child() -> NoReturn:
+        _assert_descriptor_closed(descriptors[0])
+
+    child_pid = fork_process(descriptor_child)
+    _, status = os.waitpid(child_pid, 0)
+    timer.join(timeout=5)
+    worker.join(timeout=5)
+
+    assert (os.waitstatus_to_exitcode(status), acquired.is_set(), worker.is_alive()) == (0, True, False)
+    lock.release()
+
+
+@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="fork transition gate requires register_at_fork")
+def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(tmp_path: Path, mocker: MockerFixture) -> None:
+    boundary = threading.Barrier(3, timeout=5)
+    real_fstat = os.fstat
+
+    def wait_at_boundary(fd: int) -> os.stat_result:
+        if threading.current_thread().name.startswith("concurrent-acquire-"):
+            boundary.wait()
+        return real_fstat(fd)
+
+    mocker.patch("os.fstat", side_effect=wait_at_boundary)
+
+    def acquire_lock(path: str) -> None:
+        with FileLock(path, is_singleton=False):
+            pass
+
+    workers = [
+        threading.Thread(
+            target=acquire_lock,
+            args=(str(tmp_path / f"{index}.lock"),),
+            name=f"concurrent-acquire-{index}",
+        )
+        for index in range(2)
+    ]
+    for worker in workers:
+        worker.start()
+    try:
+        boundary.wait()
+    finally:
+        for worker in workers:
+            worker.join(timeout=5)
+
+    assert [worker.is_alive() for worker in workers] == [False, False]
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.parametrize("lock_type", [pytest.param(FileLock, id="native"), pytest.param(SoftFileLock, id="soft")])
+def test_child_singleton_registry_drops_parent_instance(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
+    path = str(tmp_path / "parent.lock")
+    parent_lock = lock_type(path, is_singleton=True)
+
+    def singleton_child() -> NoReturn:
+        child_lock = lock_type(path, is_singleton=True)
+        exit_child(0 if child_lock is not parent_lock else 1)
+
+    child_pid = fork_process(singleton_child)
+    _, status = os.waitpid(child_pid, 0)
+
+    assert os.waitstatus_to_exitcode(status) == 0
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.parametrize("lock_type", [pytest.param(FileLock, id="native"), pytest.param(SoftFileLock, id="soft")])
+def test_inherited_idle_lock_rejects_acquire(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
+    lock = lock_type(str(tmp_path / "parent.lock"), is_singleton=False)
+
+    def inherited_child() -> NoReturn:
+        try:
+            lock.acquire(timeout=0)
+        except RuntimeError as exception:
+            exit_child(0 if "inherited across fork" in str(exception) else 1)
+        exit_child(1)
+
+    child_pid = fork_process(inherited_child)
+    _, status = os.waitpid(child_pid, 0)
+
+    assert os.waitstatus_to_exitcode(status) == 0
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.parametrize(
+    "lock_type", [pytest.param(AsyncFileLock, id="native"), pytest.param(AsyncSoftFileLock, id="soft")]
+)
+def test_inherited_idle_async_lock_rejects_acquire(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
+    lock = lock_type(str(tmp_path / "parent.lock"), is_singleton=False)
+
+    def inherited_child() -> NoReturn:
+        try:
+            asyncio.run(lock.acquire(timeout=0))
+        except RuntimeError as exception:
+            exit_child(0 if "inherited across fork" in str(exception) else 1)
+        exit_child(1)
+
+    child_pid = fork_process(inherited_child)
+    _, status = os.waitpid(child_pid, 0)
+
+    assert os.waitstatus_to_exitcode(status) == 0
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None:
+    path = str(tmp_path / "parent.lock")
+    fork_result = -1
+    lock: FileLock
+
+    def inherited_child() -> NoReturn:
+        try:
+            lock.acquire(timeout=0)
+        except RuntimeError as exception:
+            exit_child(0 if "inherited across fork" in str(exception) else 1)
+        exit_child(1)
+
+    def fork_from_hook(_fd: int) -> None:
+        nonlocal fork_result
+        fork_result = fork_process(inherited_child)
+
+    lock = FileLock(path, thread_local=False, is_singleton=False, on_acquired=fork_from_hook)
+    lock.acquire()
+    _, status = os.waitpid(fork_result, 0)
+    assert (os.waitstatus_to_exitcode(status), _probe_lock(FileLock, path)) == (0, False)
+    lock.release()
+
+
+@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="descriptor registry requires register_at_fork")
+def test_reader_directory_registration_failure_closes_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = SoftReadWriteLock(
+        str(tmp_path / "parent.lock"),
+        is_singleton=False,
+        heartbeat_interval=0.1,
+        stale_threshold=0.5,
+    )
+    real_fstat = os.fstat
+    directory_fds: list[int] = []
+
+    def fail_directory_fstat(fd: int) -> os.stat_result:
+        stat_result = real_fstat(fd)
+        assert S_ISDIR(stat_result.st_mode)
+        directory_fds.append(fd)
+        msg = "directory identity unavailable"
+        raise OSError(msg)
+
+    mocker.patch("os.fstat", side_effect=fail_directory_fstat)
+    with pytest.raises(OSError, match="directory identity unavailable"):
+        lock.acquire_read()
+
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+        real_fstat(directory_fds[0])
+    lock.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="descriptor registry requires register_at_fork")
+def test_reader_directory_registration_and_close_errors_are_grouped(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = SoftReadWriteLock(
+        str(tmp_path / "parent.lock"),
+        is_singleton=False,
+        heartbeat_interval=0.1,
+        stale_threshold=0.5,
+    )
+    real_close, real_fstat = os.close, os.fstat
+    directory_fds: list[int] = []
+
+    def fail_directory_fstat(fd: int) -> os.stat_result:
+        stat_result = real_fstat(fd)
+        assert S_ISDIR(stat_result.st_mode)
+        directory_fds.append(fd)
+        msg = "directory identity unavailable"
+        raise OSError(msg)
+
+    def fail_directory_close(fd: int) -> None:
+        assert fd == directory_fds[0]
+        msg = "directory close failed"
+        raise OSError(msg)
+
+    mocker.patch("os.fstat", side_effect=fail_directory_fstat)
+    mocker.patch("os.close", side_effect=fail_directory_close)
+    with pytest.raises(BaseExceptionGroup) as info:
+        lock.acquire_read()
+    real_close(directory_fds[0])
+    lock.close()
+
+    assert [(type(error), str(error)) for error in info.value.exceptions] == [
+        (OSError, "directory identity unavailable"),
+        (OSError, "directory close failed"),
+    ]
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+def test_child_callback_registered_before_filelock_can_acquire(tmp_path: Path) -> None:
+    script = """
+import os
+import sys
+
+parent_path, child_path = sys.argv[1:]
+callback_succeeded = False
+
+def acquire_in_early_child_callback() -> None:
+    global callback_succeeded
+    with FileLock(child_path, is_singleton=False):
+        pass
+    callback_succeeded = True
+
+os.register_at_fork(after_in_child=acquire_in_early_child_callback)
+
+from filelock import FileLock, Timeout
+
+parent = FileLock(parent_path, is_singleton=False)
+parent.acquire()
+child_pid = os.fork()
+if child_pid == 0:
+    os._exit(0 if callback_succeeded else 3)
+_, status = os.waitpid(child_pid, 0)
+if os.waitstatus_to_exitcode(status) != 0:
+    sys.exit(1)
+
+contender = FileLock(parent_path, is_singleton=False)
+try:
+    contender.acquire(timeout=0)
+except Timeout:
+    pass
+else:
+    sys.exit(2)
+parent.release()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "parent.lock"), str(tmp_path / "child.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@_REQUIRES_FORK
+@_FORK_WARNING
+@pytest.mark.parametrize(
+    "kind",
+    [
+        pytest.param("native", id="native"),
+        pytest.param("soft", id="soft"),
+        pytest.param("soft-rw", id="soft-read-write"),
+    ],
+)
+def test_child_interpreter_exit_preserves_parent_lock(
+    tmp_path: Path, kind: Literal["native", "soft", "soft-rw"]
+) -> None:
+    script = """
+from __future__ import annotations
+
+import os
+import sys
+
+from filelock import BaseFileLock, FileLock, SoftFileLock, SoftReadWriteLock, Timeout
+
+def acquire(lock: BaseFileLock | SoftReadWriteLock, timeout: float = -1) -> None:
+    if isinstance(lock, SoftReadWriteLock):
+        lock.acquire_write(timeout=timeout)
+    else:
+        lock.acquire(timeout=timeout)
+
+def release(lock: BaseFileLock | SoftReadWriteLock) -> None:
+    if isinstance(lock, SoftReadWriteLock):
+        lock.release()
+        lock.close()
+    else:
+        lock.release()
+
+kind, path = sys.argv[1:]
+lock: BaseFileLock | SoftReadWriteLock
+if kind == "soft-rw":
+    lock = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=30)
+elif kind == "soft":
+    lock = SoftFileLock(path, is_singleton=False)
+else:
+    lock = FileLock(path, is_singleton=False)
+acquire(lock)
+
+child_pid = os.fork()
+if child_pid == 0:
+    sys.exit(0)
+_, status = os.waitpid(child_pid, 0)
+if os.waitstatus_to_exitcode(status) != 0:
+    sys.exit(1)
+
+contender_pid = os.fork()
+if contender_pid == 0:
+    contender: BaseFileLock | SoftReadWriteLock
+    if kind == "soft-rw":
+        contender = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=30)
+    elif kind == "soft":
+        contender = SoftFileLock(path, is_singleton=False)
+    else:
+        contender = FileLock(path, is_singleton=False)
+    try:
+        acquire(contender, timeout=0)
+    except Timeout:
+        os._exit(0)
+    release(contender)
+    os._exit(2)
+_, status = os.waitpid(contender_pid, 0)
+release(lock)
+sys.exit(os.waitstatus_to_exitcode(status))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, kind, str(tmp_path / "parent.lock")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def _run_child_cleanup(
+    lock: BaseFileLock,
+    proxy: AcquireReturnProxy,
+    action: Literal["release", "context", "collect"],
+) -> NoReturn:
+    assert (lock.is_locked, lock.lock_counter) == (False, 0)
+    if action == "release":
+        lock.release(force=True)
+    elif action == "context":
+        proxy.__exit__(None, None, None)
+    else:
+        del proxy
+        del lock
+        gc.collect()
+    exit_child(0)
+
+
+def _probe_lock(lock_type: type[BaseFileLock], path: str) -> bool:
+    read_fd, write_fd = os.pipe()
+
+    def probe_child() -> NoReturn:
+        os.close(read_fd)
+        candidate = lock_type(path, is_singleton=False)
+        try:
+            candidate.acquire(timeout=0)
+        except Timeout:
+            acquired = False
+        else:
+            acquired = True
+            candidate.release()
+        os.write(write_fd, b"1" if acquired else b"0")
+        os.close(write_fd)
+        exit_child(0)
+
+    child_pid = fork_process(probe_child)
+    os.close(write_fd)
+    result = os.read(read_fd, 1)
+    os.close(read_fd)
+    _, status = os.waitpid(child_pid, 0)
+    assert os.waitstatus_to_exitcode(status) == 0
+    return result == b"1"
+
+
+def _assert_descriptor_closed(fd: int) -> NoReturn:
+    try:
+        os.fstat(fd)
+    except OSError as exception:
+        exit_child(0 if exception.errno == EBADF else 1)
+    exit_child(1)

--- a/tests/test_fork_registries.py
+++ b/tests/test_fork_registries.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import gc
+import os
+import subprocess  # noqa: S404  # interpreter exit exercises the atexit registry
+import sys
+import weakref
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final, NoReturn
+
+import pytest
+from fork_helpers import exit_child, fork_process
+
+from filelock import BaseFileLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
+
+
+@_REQUIRES_FORK
+def test_equal_unhashable_locks_reset_independently(tmp_path: Path) -> None:
+    @dataclass(eq=True, init=False)
+    class EqualLock(BaseFileLock):
+        def _acquire(self) -> None:
+            self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+
+        def _release(self) -> None:
+            os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
+            self._context.lock_file_fd = None
+
+    first = EqualLock(str(tmp_path / "first.lock"), is_singleton=False)
+    second = EqualLock(str(tmp_path / "second.lock"), is_singleton=False)
+    first.acquire()
+    second.acquire()
+
+    def reset_child() -> NoReturn:
+        state = first.is_locked, first.lock_counter, second.is_locked, second.lock_counter
+        exit_child(0 if state == (False, 0, False, 0) else 1)
+
+    child_pid = fork_process(reset_child)
+    _, status = os.waitpid(child_pid, 0)
+    first.release()
+    second.release()
+
+    assert os.waitstatus_to_exitcode(status) == 0
+
+
+def test_equal_unhashable_soft_read_write_locks_survive_atexit_registry(tmp_path: Path) -> None:
+    script = """
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+from filelock import SoftReadWriteLock
+
+@dataclass(eq=True, init=False)
+class EqualLock(SoftReadWriteLock):
+    pass
+
+locks = [EqualLock(path, is_singleton=False, heartbeat_interval=1, stale_threshold=30) for path in sys.argv[1:]]
+for lock in locks:
+    lock.acquire_write()
+"""
+    paths = [tmp_path / "first.lock", tmp_path / "second.lock"]
+    result = subprocess.run(
+        [sys.executable, "-c", script, *(str(path) for path in paths)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, [path.with_name(f"{path.name}.write").exists() for path in paths]) == (0, [False, False])
+
+
+def test_dynamic_lock_class_can_be_collected() -> None:
+    class EphemeralLock(BaseFileLock):
+        _acquire = _release = BaseFileLock._acquire
+
+    class_ref = weakref.ref(EphemeralLock)
+    del EphemeralLock
+    gc.collect()
+
+    assert class_ref() is None

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -155,6 +155,24 @@ def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) 
     assert not lock.is_locked
 
 
+@_UNIX_ONLY
+def test_acquire_flock_error_clears_pending_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = UnixFileLock(tmp_path / "test.lock")
+    mocker.patch(
+        "filelock._unix.fcntl.flock",
+        side_effect=[OSError(EIO, "Input/output error"), None, None],
+    )
+
+    with pytest.raises(OSError, match="Input/output error"):
+        lock.acquire(timeout=0)
+    assert not lock.is_locked
+
+    lock.acquire(timeout=0)
+    assert lock.is_locked
+    lock.release()
+    assert not lock.is_locked
+
+
 @pytest.fixture
 def unsupported_flock(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "Function not implemented"))


### PR DESCRIPTION
A forked child inherits a parent's descriptors and Python lock state. Releasing an inherited native lock can unlock the
shared open-file description, while releasing a soft lock can unlink the parent's marker. Same-path non-singleton soft
read/write locks could also disappear from the fork registry before child cleanup. This caused the ownership violation
reported in [#634](https://github.com/tox-dev/filelock/issues/634).

Track held and provisional descriptors by object identity and creator PID. The child checks the descriptor identity
before closing it, without issuing an OS unlock or removing a marker, then clears the inherited in-memory lock state. An
unavailable identity leaves the descriptor untouched because an earlier child callback may have reused its number.

Coordinate descriptor transitions with fork callbacks across threads and concurrent coroutine tasks. Registration and
rollback failures remain observable, including cancellation paths inherited from
[#652](https://github.com/tox-dev/filelock/pull/652). Reentrant singleton construction during a parent callback reports
a `RuntimeError`. Child cache insertion rejects an instance whose construction crossed the fork boundary.

This branch depends on #652 so fork tracking can wrap its cancellation-safe async transitions. Rebase it onto `main`
after merging #652.

Fixes #634.
