### PR TITLE
🐛 fix(sqlite): isolate forked connections

### DIFF
--- a/docs/changelog/635.bugfix.rst
+++ b/docs/changelog/635.bugfix.rst
@@ -1,5 +1,3 @@
-Keep SQLite read-write locks held by a parent after a forked child exits. Open a connection for each outer transaction,
-close it on final release, and reject inherited databases in the child until ``exec()`` when the fork copied an active
-connection. Exit a child forked from a SQLite call boundary when an earlier audit hook blocks filelock's
-guard. Reject read-write locks in a PyPy fork child after the parent used SQLite because closed connections can leave
-process-wide state unsafe there.
+Open a SQLite connection per outer acquisition and close it on final release, so a forked child can no longer close its
+parent's handle. A child rejects inherited databases until ``exec()``, and a PyPy child rejects read-write locks once the
+parent has used SQLite.

--- a/docs/changelog/635.bugfix.rst
+++ b/docs/changelog/635.bugfix.rst
@@ -1,0 +1,5 @@
+Keep SQLite read-write locks held by a parent after a forked child exits. Open a connection for each outer transaction,
+close it on final release, and reject inherited databases in the child until ``exec()`` when the fork copied an active
+connection. Exit a child forked from a SQLite call boundary when an earlier audit hook blocks filelock's
+guard. Reject read-write locks in a PyPy fork child after the parent used SQLite because closed connections can leave
+process-wide state unsafe there.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -297,7 +297,9 @@ But upgrading from read to write (or downgrading) raises an error:
         with rw.write_lock():  # RuntimeError
             pass
 
-When you're done with a ``ReadWriteLock``, close it to release the underlying SQLite connection:
+``ReadWriteLock`` opens a SQLite connection for an outer acquisition and closes it after the final matching
+``release()``. Reentrant acquisitions share that transaction. Call ``close()`` to release a held lock and invalidate the
+instance:
 
 .. code-block:: python
 
@@ -306,7 +308,40 @@ When you're done with a ``ReadWriteLock``, close it to release the underlying SQ
         with rw.read_lock():
             data = get_shared_data()
     finally:
-        rw.close()  # releases any held lock and closes the SQLite connection
+        rw.close()
+
+SQLite prohibits using or closing a database connection inherited across ``fork()``. filelock invalidates an
+inherited ``ReadWriteLock`` or ``AsyncReadWriteLock`` in the child. Acquisition raises ``RuntimeError``; ``release()``
+and ``close()`` do nothing so context-manager cleanup cannot release the parent's transaction. On CPython, if no
+SQLite connection was active at the fork, construct a new lock in the child before acquiring:
+
+.. code-block:: python
+
+    child_rw = ReadWriteLock("data.db")
+    with child_rw.read_lock():
+        data = get_shared_data()
+
+See SQLite's `fork guidance`_.
+PyPy can leave process-wide SQLite state unsafe after a fork even when every known connection was closed. If the parent
+used SQLite after importing filelock, a PyPy child therefore rejects every ``ReadWriteLock`` and
+``AsyncReadWriteLock`` until ``exec()`` or exit. Importing filelock only in the child cannot detect SQLite use that
+happened in the parent.
+
+If a connection was active, filelock rejects every lock for the same path or database inode in the child. In the normal
+path, an outer acquisition owns this connection; failed cleanup can also retain one. The child must call ``exec()`` or
+exit before using that database. filelock abandons each inherited active handle until OS process exit, consuming one
+descriptor and its SQLite memory per active lock. CPython 3.10 and 3.11 need an extra raw reference to stop their base
+deallocator from closing the handle; later versions suppress finalization through the connection subclass. Both paths
+avoid the ``sqlite3_close()`` call that SQLite forbids after a fork.
+
+filelock normally rejects ``fork()`` from a callback that runs during a SQLite operation. If another audit hook blocks
+that guard from registering, a child created at this boundary exits with status 70 before it can touch the inherited
+connection; the parent operation continues.
+
+A native or signal callback that forks while its thread is executing inside SQLite can resume in inherited C state;
+filelock cannot make that operation safe.
+
+.. _fork guidance: https://www.sqlite.org/howtocorrupt.html#_carrying_an_open_database_connection_across_a_fork_
 
 ***************************************************
  Use read/write locks on network filesystems (NFS)
@@ -315,8 +350,9 @@ When you're done with a ``ReadWriteLock``, close it to release the underlying SQ
 :class:`ReadWriteLock <filelock.ReadWriteLock>` is SQLite-backed and requires a local filesystem: SQLite's own
 docs warn against running on NFS because POSIX ``fcntl`` locks are unreliable there. For HPC clusters, slurm
 deployments, or any multi-host shared storage, use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>`
-instead. It is built on :class:`SoftFileLock <filelock.SoftFileLock>` primitives (atomic ``O_CREAT | O_EXCL | O_NOFOLLOW``) and runs a
-daemon heartbeat thread that refreshes each held marker's ``mtime`` so any host on any node can evict a stale
+instead. It is built on :class:`SoftFileLock <filelock.SoftFileLock>` primitives (atomic
+``O_CREAT | O_EXCL | O_NOFOLLOW``) and runs a daemon heartbeat thread that refreshes each held marker's ``mtime`` so any
+host on any node can evict a stale
 marker when the holder crashes.
 
 .. code-block:: python
@@ -352,8 +388,8 @@ Writer acquisition is two-phase and writer-preferring: phase one claims the writ
 new reader), phase two waits for existing readers to drain. This rules out writer starvation under read-heavy
 workloads. See :doc:`concepts` for the full model.
 
-**Fork caveat.** A process that forks while holding a ``SoftReadWriteLock`` loses the lock in the child. filelock marks the
-inherited instance fork-invalidated; ``release()`` on it becomes a no-op, and the child must call
+**Fork caveat.** A process that forks while holding a ``SoftReadWriteLock`` loses the lock in the child. filelock marks
+the inherited instance fork-invalidated; ``release()`` on it becomes a no-op, and the child must call
 ``SoftReadWriteLock(path)`` again to get a fresh instance before acquiring. Matches the semantics of
 :class:`threading.Lock` and PyMongo's connection pools.
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import count, starmap
-from threading import Condition, Lock, RLock, get_ident, local
+from threading import Condition, RLock, get_ident, local
 from typing import TYPE_CHECKING, Final, Literal, NoReturn, TypeVar, cast
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
@@ -1376,7 +1376,7 @@ class _ForkTransitionContext(local):
 
 class _ForkState:
     def __init__(self) -> None:
-        self.gate = Condition(Lock())
+        self.gate = Condition(RLock())
         self.registry_lock = RLock()
         self.parameter_models_lock = RLock()
         self.transition_context = _ForkTransitionContext()
@@ -1390,7 +1390,7 @@ class _ForkState:
         self.pid = os.getpid()
 
     def reset_synchronization(self) -> None:  # pragma: no cover - exercised in fork children
-        self.gate = Condition(Lock())
+        self.gate = Condition(RLock())
         self.registry_lock = RLock()
         self.parameter_models_lock = RLock()
         self.transition_context = _ForkTransitionContext()

--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -4,16 +4,23 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import os
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
-from ._api import _append_exception_context, _raise_chained_errors
+from ._api import (
+    _append_exception_context,
+    _ensure_current_process,
+    _fork_transition,
+    _raise_chained_errors,
+    _register_fork_object,
+)
 from ._async import _BackendOutcome, _capture_call, _drain_future, _future_result, _wait_until_done
 from ._read_write import ReadWriteLock
 
 if TYPE_CHECKING:
-    import os
     from collections.abc import AsyncGenerator, Callable
     from concurrent import futures
     from types import TracebackType
@@ -57,10 +64,19 @@ class AsyncReadWriteLock:
         loop: asyncio.AbstractEventLoop | None = None,
         executor: futures.Executor | None = None,
     ) -> None:
-        self._lock = ReadWriteLock(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
-        self._loop = loop
-        self._owns_executor = executor is None
-        self._executor = executor or ThreadPoolExecutor(max_workers=1)
+        creator_pid = os.getpid()
+        self._creator_pid = creator_pid
+        self._fork_invalidated = False
+        self._closed = False
+        _register_fork_object(self)
+        with _fork_transition():
+            self._lock = ReadWriteLock(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
+            self._loop = loop
+            self._owns_executor = executor is None
+            self._executor = executor or ThreadPoolExecutor(max_workers=1)
+            if os.getpid() != creator_pid:  # pragma: no cover - exercised only in a forked constructor callback
+                msg = "AsyncReadWriteLock construction cannot continue after fork"
+                raise RuntimeError(msg)
 
     @property
     def lock_file(self) -> str:
@@ -159,10 +175,8 @@ class AsyncReadWriteLock:
         :raises RuntimeError: if a write lock is already held on this instance
         :raises Timeout: if the lock cannot be acquired within *timeout* seconds
 
-        If rollback fails, peers may remain blocked. A later acquisition first retries that cleanup;
-        ``release(force=True)`` retries it without acquiring.
-
         """
+        self._raise_if_unusable()
         await self._run_acquire(functools.partial(self._lock.acquire_read, timeout, blocking=blocking))
         return AsyncAcquireReadWriteReturnProxy(lock=self)
 
@@ -180,10 +194,8 @@ class AsyncReadWriteLock:
         :raises RuntimeError: if a read lock is already held, or a write lock is held by a different thread
         :raises Timeout: if the lock cannot be acquired within *timeout* seconds
 
-        If rollback fails, peers may remain blocked. A later acquisition first retries that cleanup;
-        ``release(force=True)`` retries it without acquiring.
-
         """
+        self._raise_if_unusable()
         await self._run_acquire(functools.partial(self._lock.acquire_write, timeout, blocking=blocking))
         return AsyncAcquireReadWriteReturnProxy(lock=self)
 
@@ -193,12 +205,14 @@ class AsyncReadWriteLock:
 
         See :meth:`ReadWriteLock.release` for full semantics.
 
-        :param force: if ``True``, release the lock completely regardless of the current lock level and retry cleanup
-            from a failed acquisition
+        :param force: if ``True``, release the lock completely regardless of the current lock level
 
         :raises RuntimeError: if no lock is currently held and *force* is ``False``
 
         """
+        _ensure_current_process()
+        if self._inherited:
+            return
         await self._run(self._lock.release, force=force)
 
     async def close(self) -> None:
@@ -208,6 +222,11 @@ class AsyncReadWriteLock:
         After calling this method, the lock instance is no longer usable.
 
         """
+        _ensure_current_process()
+        if self._inherited:
+            return
+        if self._closed:
+            return
         close_future = self._submit(self._lock.close)
         try:
             await _wait_until_done(close_future)
@@ -216,9 +235,11 @@ class AsyncReadWriteLock:
                 await _drain_future(close_future)
             except BaseException as error:  # noqa: BLE001  # reported with the cancellation below
                 self._raise_cancelled_error(cancellation, error)
+            self._closed = True
             self._shutdown_owned_executor()
             raise
         _future_result(close_future)
+        self._closed = True
         self._shutdown_owned_executor()
 
     async def _run_acquire(self, acquire: Callable[[], AcquireReturnProxy]) -> None:
@@ -273,10 +294,26 @@ class AsyncReadWriteLock:
         if self._owns_executor:
             self._executor.shutdown(wait=False)
 
+    @property
+    def _inherited(self) -> bool:
+        return self._fork_invalidated or os.getpid() != self._creator_pid
+
+    def _raise_if_unusable(self) -> None:
+        _ensure_current_process()
+        if self._inherited:
+            msg = f"AsyncReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
+            raise RuntimeError(msg)
+        if self._closed:
+            msg = "Cannot operate on a closed database."
+            raise sqlite3.ProgrammingError(msg)
+
+    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+        self._fork_invalidated = True
+
     def __del__(self) -> None:
         # Safety net when close() was never called: shut down the executor we own so its worker thread does not
         # outlive the lock. shutdown(wait=False) never blocks.
-        if getattr(self, "_owns_executor", False):
+        if os.getpid() == getattr(self, "_creator_pid", None) and getattr(self, "_owns_executor", False):
             self._executor.shutdown(wait=False)
 
 

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -1,40 +1,176 @@
 from __future__ import annotations
 
-import atexit
 import logging
 import os
 import pathlib
 import sqlite3
+import sys
 import threading
 import time
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Final, Literal
+from typing import TYPE_CHECKING, ClassVar, Final, Literal, TypeAlias, cast
 from weakref import WeakValueDictionary
 
-from ._api import AcquireReturnProxy, _raise_chained_errors
+from ._api import (
+    AcquireReturnProxy,
+    _ensure_current_process,
+    _fork_transition,
+    _raise_chained_errors,
+    _register_fork_class,
+    _register_fork_object,
+)
 from ._error import Timeout
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 _LOGGER: Final[logging.Logger] = logging.getLogger("filelock")
-
-_all_connections: Final[set[sqlite3.Connection]] = set()
-_all_connections_lock: Final[threading.Lock] = threading.Lock()
-
-
-def _cleanup_connections() -> None:
-    with _all_connections_lock:
-        for con in list(_all_connections):
-            with suppress(Exception):
-                con.close()
-        _all_connections.clear()
-
-
-atexit.register(_cleanup_connections)
+_GETPID: Final[Callable[[], int]] = os.getpid
+_IS_PYPY: Final[bool] = sys.implementation.name == "pypy"
+_NEEDS_CONNECTION_ESCROW: Final[bool] = (
+    hasattr(os, "register_at_fork") and sys.implementation.name == "cpython" and sys.version_info < (3, 12)
+)
+_ConnectionParameter: TypeAlias = (
+    str | bytes | os.PathLike[str] | os.PathLike[bytes] | float | int | type[sqlite3.Connection] | None
+)
+_DatabaseIdentity: TypeAlias = tuple[int, int]
 
 # sqlite3_busy_timeout() accepts a C int, max 2_147_483_647 on 32-bit. Use a lower value to be safe (~23 days).
 _MAX_SQLITE_TIMEOUT_MS: Final[int] = 2_000_000_000 - 1
+_UNSAFE_FORK_EXIT_STATUS: Final[int] = 70
+
+
+class _SQLiteTransitionContext(threading.local):
+    depth: int = 0
+
+
+_SQLITE_TRANSITION_CONTEXT: Final = _SQLiteTransitionContext()
+
+
+class _ConnectionEscrow:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._functions: tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None = None
+
+    def functions(
+        self,
+    ) -> tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None:
+        if not _NEEDS_CONNECTION_ESCROW:
+            return None
+        with self._lock:
+            if self._functions is None:
+                import ctypes  # noqa: PLC0415  # keep optional ctypes and its audited dlsym out of ordinary imports
+
+                function_type = ctypes.PYFUNCTYPE(None, ctypes.py_object)
+                increment_address = ctypes.cast(ctypes.pythonapi.Py_IncRef, ctypes.c_void_p).value
+                decrement_address = ctypes.cast(ctypes.pythonapi.Py_DecRef, ctypes.c_void_p).value
+                if increment_address is None or decrement_address is None:  # pragma: no cover - resolved CPython API
+                    msg = "CPython reference functions have no address"
+                    raise RuntimeError(msg)
+                self._functions = (
+                    cast("Callable[[sqlite3.Connection], None]", function_type(increment_address)),
+                    cast("Callable[[sqlite3.Connection], None]", function_type(decrement_address)),
+                )
+            return self._functions
+
+    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+        self._lock = threading.RLock()
+
+
+_CONNECTION_ESCROW: Final = _ConnectionEscrow()
+
+
+class _ForkedDatabaseRegistry:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._paths: set[pathlib.Path] = set()
+        self._identities: set[_DatabaseIdentity] = set()
+        self._sqlite_used = False
+        self._all_paths_poisoned = False
+
+    def raise_if_poisoned(self, path: pathlib.Path) -> None:
+        identity = self.identity(path)
+        with self._lock:
+            all_paths_poisoned = self._all_paths_poisoned
+            poisoned = (
+                all_paths_poisoned or path in self._paths or (identity is not None and identity in self._identities)
+            )
+        if poisoned:
+            msg = (
+                "ReadWriteLock is unavailable in a PyPy fork child; exec or exit before using it"
+                if all_paths_poisoned
+                else f"SQLite database {path!s} was active across fork(); exec or exit before using it in the child"
+            )
+            raise RuntimeError(msg)
+
+    def poison_after_fork(self, path: pathlib.Path, identity: _DatabaseIdentity | None) -> None:
+        self._paths.add(path)
+        if identity is not None:
+            self._identities.add(identity)
+
+    def note_sqlite_use(self) -> None:
+        if _IS_PYPY:
+            with self._lock:
+                self._sqlite_used = True
+
+    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+        self._lock = threading.RLock()
+        self._all_paths_poisoned = self._all_paths_poisoned or (_IS_PYPY and self._sqlite_used)
+        self._sqlite_used = False
+
+    @staticmethod
+    def identity(path: pathlib.Path) -> _DatabaseIdentity | None:
+        try:
+            stat_result = path.stat()
+        except OSError:
+            return None
+        return stat_result.st_dev, stat_result.st_ino
+
+
+_FORKED_DATABASES: Final = _ForkedDatabaseRegistry()
+
+
+class _ForkSafeConnection(sqlite3.Connection):
+    _creator_pid: int
+    _decrement_escrow: Callable[[sqlite3.Connection], None] | None
+
+    def __new__(
+        cls,
+        *_args: _ConnectionParameter,
+        **_kwargs: _ConnectionParameter,
+    ) -> Self:
+        connection = super().__new__(cls)
+        connection._creator_pid = _GETPID()
+        connection._decrement_escrow = None
+        return connection
+
+    def close(self) -> None:
+        with _sqlite_transition():
+            if _GETPID() != self._creator_pid:
+                return
+            with _fork_transition():
+                sqlite3.Connection.close(self)
+                if (decrement := self._decrement_escrow) is not None:
+                    self._decrement_escrow = None
+                    decrement(self)
+
+    def acquire_escrow(
+        self,
+        functions: tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None,
+    ) -> None:
+        if functions is not None:
+            increment, decrement = functions
+            increment(self)
+            self._decrement_escrow = decrement
+
+    def __del__(self) -> None:
+        with suppress(sqlite3.Error, RuntimeError):
+            self.close()
 
 
 class _ReadWriteLockMeta(type):
@@ -47,7 +183,9 @@ class _ReadWriteLockMeta(type):
     """
 
     _instances: WeakValueDictionary[pathlib.Path, ReadWriteLock]
-    _instances_lock: threading.Lock
+    _instances_lock: threading.RLock
+    _instances_pid: int
+    _instances_under_construction: set[pathlib.Path]
 
     def __call__(
         cls,
@@ -57,13 +195,33 @@ class _ReadWriteLockMeta(type):
         blocking: bool = True,
         is_singleton: bool = True,
     ) -> ReadWriteLock:
+        _ensure_current_process()
+        if cls._instances_pid != _GETPID():
+            cls._reset_class_after_fork()
+        construction_pid = _GETPID()
         if not is_singleton:
-            return super().__call__(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
+            instance = super().__call__(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
+            if _GETPID() != construction_pid:  # pragma: no cover - exercised only in a forked constructor callback
+                msg = "ReadWriteLock construction cannot continue after fork"
+                raise RuntimeError(msg)
+            return instance
 
         normalized = pathlib.Path(lock_file).resolve()
         with cls._instances_lock:
             if normalized not in cls._instances:
-                instance = super().__call__(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
+                if normalized in cls._instances_under_construction:  # pragma: no cover - exercised in an audit callback
+                    msg = f"Singleton lock construction is already active for {lock_file!s}"
+                    raise RuntimeError(msg)
+                construction_registry = cls._instances_under_construction
+                construction_registry.add(normalized)
+                try:
+                    instance = super().__call__(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
+                finally:
+                    if _GETPID() == construction_pid:
+                        construction_registry.discard(normalized)
+                if _GETPID() != construction_pid:
+                    msg = "ReadWriteLock construction cannot continue after fork"
+                    raise RuntimeError(msg)
                 cls._instances[normalized] = instance
             else:
                 instance = cls._instances[normalized]
@@ -75,6 +233,12 @@ class _ReadWriteLockMeta(type):
                 )
                 raise ValueError(msg)
             return instance
+
+    def _reset_class_after_fork(cls) -> None:  # pragma: no cover - exercised in fork children
+        cls._instances = WeakValueDictionary()
+        cls._instances_lock = threading.RLock()
+        cls._instances_pid = _GETPID()
+        cls._instances_under_construction = set()
 
 
 class ReadWriteLock(metaclass=_ReadWriteLockMeta):
@@ -99,7 +263,17 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
     """
 
     _instances: WeakValueDictionary[pathlib.Path, ReadWriteLock] = WeakValueDictionary()
-    _instances_lock = threading.Lock()
+    _instances_lock = threading.RLock()
+    _instances_pid = _GETPID()
+    _instances_under_construction: ClassVar[set[pathlib.Path]] = set()
+
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        cls._instances = WeakValueDictionary()
+        cls._instances_lock = threading.RLock()
+        cls._instances_pid = _GETPID()
+        cls._instances_under_construction = set()
+        _register_fork_class(cls)
 
     @classmethod
     def get_lock(
@@ -128,6 +302,8 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         is_singleton: bool = True,  # noqa: ARG002  # consumed by _ReadWriteLockMeta.__call__
     ) -> None:
         self.lock_file = os.fspath(lock_file)
+        self._canonical_path = pathlib.Path(lock_file).resolve()
+        _FORKED_DATABASES.raise_if_poisoned(self._canonical_path)
         self.timeout = timeout
         self.blocking = blocking
         self._transaction_lock = threading.Lock()  # serializes the (possibly blocking) SQLite transaction work
@@ -135,9 +311,17 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         self._lock_level = 0
         self._current_mode: Literal["read", "write"] | None = None
         self._write_thread_id: int | None = None
-        self._con = sqlite3.connect(self.lock_file, check_same_thread=False)
-        with _all_connections_lock:
-            _all_connections.add(self._con)
+        self._acquisition_thread_ids: set[int] = set()
+        self._con: _ForkSafeConnection | None = None
+        self._connection_transaction_released = True
+        self._connection_identity: _DatabaseIdentity | None = None
+        self._closed = False
+        self._creator_pid = _GETPID()
+        self._fork_invalidated = False
+        _register_fork_object(self)
+        with _fork_transition(), _sqlite_transition():
+            validation_connection = self._open_connection(sqlite_timeout=5.0)
+            validation_connection.close()
 
     def acquire_read(self, timeout: float = -1, *, blocking: bool = True) -> AcquireReturnProxy:
         """
@@ -153,10 +337,6 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
         :raises RuntimeError: if a write lock is already held on this instance
         :raises Timeout: if the lock cannot be acquired within *timeout* seconds
-
-        If cleanup from a previous failed acquisition also failed, this method retries that rollback before starting a
-        new transaction. Until cleanup succeeds, other processes may remain blocked. :meth:`release` with ``force=True``
-        retries the same cleanup without acquiring.
 
         """
         return self._acquire("read", timeout, blocking=blocking)
@@ -177,10 +357,6 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
         :raises RuntimeError: if a read lock is already held, or a write lock is held by a different thread
         :raises Timeout: if the lock cannot be acquired within *timeout* seconds
-
-        If cleanup from a previous failed acquisition also failed, this method retries that rollback before starting a
-        new transaction. Until cleanup succeeds, other processes may remain blocked. :meth:`release` with ``force=True``
-        retries the same cleanup without acquiring.
 
         """
         return self._acquire("write", timeout, blocking=blocking)
@@ -233,34 +409,17 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
         When the lock level reaches zero the underlying SQLite transaction is rolled back, releasing the database lock.
 
-        :param force: if ``True``, release the lock completely regardless of the current lock level and retry cleanup
-            from a failed acquisition
+        :param force: if ``True``, release the lock completely regardless of the current lock level
 
         :raises RuntimeError: if no lock is currently held and *force* is ``False``
 
         """
-        with self._transaction_lock, self._internal_lock:
-            if self._lock_level == 0:
-                if force and not self._con.in_transaction:
-                    return
-                if not force:
-                    msg = f"Cannot release a lock on {self.lock_file} (lock id: {id(self)}) that is not held"
-                    raise RuntimeError(msg)
-            if not force and self._lock_level > 1:
-                self._lock_level -= 1
+        with _fork_transition():
+            _ensure_current_process()
+            if self._inherited:
                 return
-            try:
-                self._con.rollback()
-            except sqlite3.Error:
-                if not self._con.in_transaction:
-                    self._clear_lock_state()
-                raise
-            self._clear_lock_state()
-
-    def _clear_lock_state(self) -> None:
-        self._lock_level = 0
-        self._current_mode = None
-        self._write_thread_id = None
+            self._raise_if_acquiring("release")
+            self._release(force=force, close=False)
 
     def close(self) -> None:
         """
@@ -269,22 +428,100 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         After calling this method, the lock instance is no longer usable.
 
         """
-        self.release(force=True)
-        self._con.close()
-        with _all_connections_lock:
-            _all_connections.discard(self._con)
+        with _fork_transition():
+            _ensure_current_process()
+            if self._inherited:
+                return
+            self._raise_if_acquiring("close")
+            self._release(force=True, close=True)
+
+    def _release(self, *, force: bool, close: bool) -> None:
+        with self._transaction_lock, self._internal_lock:
+            if self._lock_level == 0:
+                if force and self._con is None:
+                    if close:
+                        self._closed = True
+                    return
+                if not force:
+                    msg = f"Cannot release a lock on {self.lock_file} (lock id: {id(self)}) that is not held"
+                    raise RuntimeError(msg)
+            if not force and self._lock_level > 1:
+                self._lock_level -= 1
+                return
+            try:
+                self._finish_connection()
+            except sqlite3.Error:
+                if self._connection_transaction_released:
+                    self._clear_lock_state()
+                raise
+            self._clear_lock_state()
+            if close:
+                self._closed = True
+
+    def _clear_lock_state(self) -> None:
+        self._lock_level = 0
+        self._current_mode = None
+        self._write_thread_id = None
+
+    def __del__(self) -> None:
+        if _GETPID() == getattr(self, "_creator_pid", None) and (connection := getattr(self, "_con", None)) is not None:
+            with suppress(sqlite3.Error, RuntimeError):
+                connection.close()
+
+    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+        if self._con is not None:
+            _FORKED_DATABASES.poison_after_fork(self._canonical_path, self._connection_identity)
+        self._con = None
+        self._connection_transaction_released = True
+        self._connection_identity = None
+        self._transaction_lock = threading.Lock()
+        self._internal_lock = threading.Lock()
+        self._clear_lock_state()
+        self._acquisition_thread_ids = set()
+        self._fork_invalidated = True
+
+    @property
+    def _inherited(self) -> bool:
+        return self._fork_invalidated or _GETPID() != self._creator_pid
+
+    def _raise_if_unusable(self) -> None:
+        _ensure_current_process()
+        if self._inherited:
+            msg = f"ReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
+            raise RuntimeError(msg)
+        if self._closed:
+            msg = "Cannot operate on a closed database."
+            raise sqlite3.ProgrammingError(msg)
 
     def _acquire(self, mode: Literal["read", "write"], timeout: float, *, blocking: bool) -> AcquireReturnProxy:
-        with self._internal_lock:
-            if self._lock_level > 0:
-                return self._validate_reentrant(mode)
-
-        start_time = time.perf_counter()
-        self._acquire_transaction_lock(blocking=blocking, timeout=timeout)
-        try:
-            return self._do_acquire_inner(mode, timeout, blocking=blocking, start_time=start_time)
-        finally:
-            self._transaction_lock.release()
+        with _fork_transition():
+            self._raise_if_unusable()
+            operation_pid = _GETPID()
+            thread_id = threading.get_ident()
+            with self._internal_lock:
+                if self._lock_level > 0:
+                    return self._validate_reentrant(mode)
+                if thread_id in self._acquisition_thread_ids:  # pragma: no cover - exercised in an audit callback
+                    msg = f"Cannot acquire ReadWriteLock on {self.lock_file} while acquisition is active in this thread"
+                    raise RuntimeError(msg)
+                self._acquisition_thread_ids.add(thread_id)
+            try:
+                start_time = time.perf_counter()
+                self._acquire_transaction_lock(blocking=blocking, timeout=timeout)
+                try:
+                    self._raise_if_unusable()
+                    return self._do_acquire_inner(
+                        mode,
+                        timeout,
+                        blocking=blocking,
+                        operation_pid=operation_pid,
+                        start_time=start_time,
+                    )
+                finally:
+                    self._transaction_lock.release()
+            finally:
+                with self._internal_lock:
+                    self._acquisition_thread_ids.discard(thread_id)
 
     def _do_acquire_inner(
         self,
@@ -292,60 +529,152 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         timeout: float,
         *,
         blocking: bool,
+        operation_pid: int,
         start_time: float,
     ) -> AcquireReturnProxy:
         # Double-check: another thread may have acquired the lock while we waited on _transaction_lock.
         with self._internal_lock:
             if self._lock_level > 0:
                 return self._validate_reentrant(mode)
-        if self._con.in_transaction:
-            self._con.rollback()
+        if self._con is not None:
+            self._finish_connection()
         try:
-            self._configure_and_begin(mode, timeout, blocking=blocking, start_time=start_time)
-        except sqlite3.Error as error:
+            self._open_for_acquisition(
+                timeout,
+                blocking=blocking,
+                operation_pid=operation_pid,
+                start_time=start_time,
+            )
+            self._configure_and_begin(
+                mode,
+                timeout,
+                blocking=blocking,
+                operation=(operation_pid, start_time),
+            )
+            self._raise_if_process_changed(operation_pid)
+        except BaseException as error:
             acquisition_error: BaseException
             if isinstance(error, sqlite3.OperationalError) and "database is locked" in str(error):
                 acquisition_error = Timeout(self.lock_file)
             else:
                 acquisition_error = error
-            if self._con.in_transaction:
-                try:
-                    self._con.rollback()
-                except sqlite3.Error as rollback_error:
-                    _raise_chained_errors(acquisition_error, rollback_error)
+            try:
+                self._finish_connection()
+            except sqlite3.Error as cleanup_error:
+                _raise_chained_errors(acquisition_error, cleanup_error)
             if acquisition_error is not error:
                 raise acquisition_error from None
             raise
         with self._internal_lock:
+            self._raise_if_process_changed(operation_pid)
             self._current_mode = mode
             self._lock_level = 1
             if mode == "write":
                 self._write_thread_id = threading.get_ident()
         return AcquireReturnProxy(lock=self)
 
+    def _open_for_acquisition(self, timeout: float, *, blocking: bool, operation_pid: int, start_time: float) -> None:
+        with _sqlite_transition():
+            sqlite_timeout = (
+                timeout_for_sqlite(
+                    timeout,
+                    blocking=blocking,
+                    already_waited=time.perf_counter() - start_time,
+                )
+                / 1000
+            )
+            connection = self._open_connection(sqlite_timeout=sqlite_timeout)
+            self._con, self._connection_transaction_released, self._connection_identity = (
+                connection,
+                False,
+                _FORKED_DATABASES.identity(self._canonical_path),
+            )
+            self._raise_if_process_changed(operation_pid)
+
     def _configure_and_begin(
-        self, mode: Literal["read", "write"], timeout: float, *, blocking: bool, start_time: float
+        self,
+        mode: Literal["read", "write"],
+        timeout: float,
+        *,
+        blocking: bool,
+        operation: tuple[int, float],
     ) -> None:
-        waited = time.perf_counter() - start_time
-        timeout_ms = timeout_for_sqlite(timeout, blocking=blocking, already_waited=waited)
-        self._con.execute(f"PRAGMA busy_timeout={timeout_ms};").close()
-        # Use legacy journal mode (not WAL) because WAL does not block readers while a concurrent EXCLUSIVE
-        # write transaction is active, which makes read-write locking impossible without modifying table data.
-        # MEMORY is safe here since no writes happen, so a crash cannot corrupt the DB.
-        # See https://sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
-        #
-        # Set here (not in __init__) because this pragma may block on a locked database, so it must run after
-        # busy_timeout is configured above.
-        self._con.execute("PRAGMA journal_mode=MEMORY;").close()
-        # Recompute the remaining timeout after the blocking journal_mode pragma.
-        waited = time.perf_counter() - start_time
-        if (recomputed := timeout_for_sqlite(timeout, blocking=blocking, already_waited=waited)) != timeout_ms:
-            self._con.execute(f"PRAGMA busy_timeout={recomputed};").close()
-        self._con.execute("BEGIN EXCLUSIVE TRANSACTION;" if mode == "write" else "BEGIN TRANSACTION;").close()
-        if mode == "read":
-            # SQLite takes the SHARED lock only when a statement reads; BEGIN alone stays deferred.
-            # https://www.sqlite.org/lockingv3.html#transaction_control
-            self._con.execute("SELECT name FROM sqlite_schema LIMIT 1;").close()
+        with _sqlite_transition():
+            operation_pid, start_time = operation
+            connection = cast("_ForkSafeConnection", self._con)
+            waited = time.perf_counter() - start_time
+            timeout_ms = timeout_for_sqlite(timeout, blocking=blocking, already_waited=waited)
+            self._raise_if_process_changed(operation_pid)
+            connection.executescript(f"PRAGMA busy_timeout={timeout_ms}; PRAGMA journal_mode=MEMORY;").close()
+            # Use legacy journal mode (not WAL) because WAL does not block readers while a concurrent EXCLUSIVE
+            # write transaction is active, which makes read-write locking impossible without modifying table data.
+            # MEMORY is safe here since no writes happen, so a crash cannot corrupt the DB.
+            # See https://sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
+            #
+            # Recompute the remaining timeout after the blocking journal_mode pragma.
+            waited = time.perf_counter() - start_time
+            recomputed = timeout_for_sqlite(timeout, blocking=blocking, already_waited=waited)
+            self._raise_if_process_changed(operation_pid)
+            statements = f"PRAGMA busy_timeout={recomputed}; " if recomputed != timeout_ms else ""
+            statements += "BEGIN EXCLUSIVE TRANSACTION;" if mode == "write" else "BEGIN TRANSACTION;"
+            if mode == "read":
+                # SQLite takes the SHARED lock only when a statement reads; BEGIN alone stays deferred.
+                # https://www.sqlite.org/lockingv3.html#transaction_control
+                statements += " SELECT name FROM sqlite_schema LIMIT 1;"
+            connection.executescript(statements).close()
+
+    def _open_connection(self, *, sqlite_timeout: float) -> _ForkSafeConnection:
+        with _sqlite_transition():
+            creator_pid = _GETPID()
+            functions = _CONNECTION_ESCROW.functions()
+            if _GETPID() != creator_pid:  # pragma: no cover - exercised only in a forked constructor callback
+                msg = "SQLite connection construction cannot continue after fork"
+                raise RuntimeError(msg)
+            connection = _connect(
+                os.fspath(self._canonical_path),
+                factory=_ForkSafeConnection,
+                timeout=sqlite_timeout,
+            )
+            if functions is not None:
+                connection.acquire_escrow(functions)
+            if _GETPID() != creator_pid:  # pragma: no cover - exercised only in a forked constructor callback
+                _FORKED_DATABASES.poison_after_fork(
+                    self._canonical_path,
+                    _FORKED_DATABASES.identity(self._canonical_path),
+                )
+                msg = "SQLite connection construction cannot continue after fork"
+                raise RuntimeError(msg)
+            return connection
+
+    def _finish_connection(self) -> None:
+        with _sqlite_transition():
+            if (connection := self._con) is None:
+                return
+            rollback_error: sqlite3.Error | None = None
+            if not self._connection_transaction_released:
+                if connection.in_transaction:
+                    try:
+                        connection.rollback()
+                    except sqlite3.Error as error:
+                        if connection.in_transaction:
+                            raise
+                        self._connection_transaction_released = True
+                        rollback_error = error
+                    else:
+                        self._connection_transaction_released = True
+                else:
+                    self._connection_transaction_released = True
+            try:
+                connection.close()
+            except sqlite3.Error as close_error:
+                if rollback_error is not None:
+                    _raise_chained_errors(rollback_error, close_error)
+                raise
+            self._con = None
+            self._connection_transaction_released = True
+            self._connection_identity = None
+            if rollback_error is not None:
+                raise rollback_error
 
     def _validate_reentrant(self, mode: Literal["read", "write"]) -> AcquireReturnProxy:
         if self._current_mode != mode:
@@ -375,6 +704,48 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         if not acquired:
             raise Timeout(self.lock_file) from None
 
+    def _raise_if_acquiring(self, operation: Literal["acquire", "close", "release"]) -> None:
+        with self._internal_lock:
+            active_in_current_thread = threading.get_ident() in self._acquisition_thread_ids
+        if active_in_current_thread:  # pragma: no cover - exercised in an audit callback
+            msg = f"Cannot {operation} ReadWriteLock on {self.lock_file} while acquisition is active in this thread"
+            raise RuntimeError(msg)
+
+    def _raise_if_process_changed(self, operation_pid: int) -> None:
+        if _GETPID() != operation_pid or self._inherited:  # pragma: no cover - exercised only in a fork child
+            msg = f"ReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
+            raise RuntimeError(msg)
+
+
+def _connect(database: str, *, factory: type[_ForkSafeConnection], timeout: float) -> _ForkSafeConnection:
+    _FORKED_DATABASES.note_sqlite_use()
+    return sqlite3.connect(
+        database,
+        check_same_thread=False,
+        factory=factory,
+        cached_statements=0,
+        timeout=timeout,
+    )
+
+
+@contextmanager
+def _sqlite_transition() -> Generator[None]:
+    _SQLITE_TRANSITION_CONTEXT.depth += 1
+    try:
+        yield
+    finally:
+        _SQLITE_TRANSITION_CONTEXT.depth -= 1
+
+
+def _abort_forked_sqlite_transition() -> None:  # pragma: no cover - exits the isolated fork child
+    if _SQLITE_TRANSITION_CONTEXT.depth:
+        os._exit(_UNSAFE_FORK_EXIT_STATUS)  # inherited SQLite handles cannot be used or closed safely
+
+
+def _track_sqlite_use(event: str, _args: tuple[object, ...]) -> None:  # audit payloads are heterogeneous
+    if event == "sqlite3.connect":
+        _FORKED_DATABASES.note_sqlite_use()
+
 
 def timeout_for_sqlite(timeout: float, *, blocking: bool, already_waited: float) -> int:
     if blocking is False:
@@ -392,3 +763,17 @@ def timeout_for_sqlite(timeout: float, *, blocking: bool, already_waited: float)
         _LOGGER.warning("timeout %s is too large for SQLite, using %s ms instead", timeout, _MAX_SQLITE_TIMEOUT_MS)
         return _MAX_SQLITE_TIMEOUT_MS
     return timeout_ms
+
+
+_register_fork_object(_CONNECTION_ESCROW)
+_register_fork_object(_FORKED_DATABASES)
+_register_fork_class(ReadWriteLock)
+if _IS_PYPY:
+    sys.addaudithook(_track_sqlite_use)
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_abort_forked_sqlite_transition)
+
+__all__ = [
+    "ReadWriteLock",
+    "timeout_for_sqlite",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import gc
 import os
-import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,27 +9,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
     from pytest_mock import MockerFixture
-
-    from filelock._read_write import _cleanup_connections
-else:
-    try:
-        from filelock._read_write import _cleanup_connections
-    except ImportError:
-        _cleanup_connections = None
-
-
-def pytest_sessionfinish() -> None:
-    if _cleanup_connections is None:
-        return
-    # PyPy runs finalizers during GC rather than on refcount drop, so force lock handles closed around cleanup.
-    on_pypy = hasattr(sys, "pypy_version_info")
-    if on_pypy:
-        gc.collect()
-        gc.collect()
-    _cleanup_connections()
-    if on_pypy:
-        gc.collect()
-        gc.collect()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,14 @@ def close_failure(
     def capture(fd: int) -> None:
         nonlocal locked_fd
         locked_fd = fd
-        mocker.patch("filelock._api.os.close", side_effect=release_error)
+        mocker.patch("filelock._api.os.close", side_effect=close)
+
+    def close(fd: int) -> None:
+        # filelock._api.os is the os module, so this patches os.close process-wide. Raise only for the descriptor
+        # under test. An unrelated close inside a GC finalizer would escape as an unraisable exception.
+        if fd == locked_fd:
+            raise release_error
+        real_close(fd)
 
     yield capture, release_error, release_cause
     if locked_fd is not None:

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -50,10 +50,9 @@ async def test_lock_context_manager(lock_file: str, mode: Literal["read", "write
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     ctx = lock.read_lock() if mode == "read" else lock.write_lock()
     async with ctx:
-        assert lock._lock._lock_level == 1
-        assert lock._lock._current_mode == mode
-    assert lock._lock._lock_level == 0
-    assert lock._lock._current_mode is None
+        assert_mode_held(lock_file, mode)
+    with pytest.raises(RuntimeError, match="not held"):
+        await lock.release()
 
 
 @pytest.mark.parametrize("mode", [pytest.param("read", id="read"), pytest.param("write", id="write")])
@@ -63,12 +62,11 @@ async def test_reentrant(lock_file: str, mode: Literal["read", "write"]) -> None
     acquire = lock.acquire_read if mode == "read" else lock.acquire_write
     await acquire()
     await acquire()
-    assert lock._lock._lock_level == 2
     await lock.release()
-    assert lock._lock._lock_level == 1
-    assert lock._lock._current_mode == mode
+    assert_mode_held(lock_file, mode)
     await lock.release()
-    assert lock._lock._lock_level == 0
+    with pytest.raises(RuntimeError, match="not held"):
+        await lock.release()
 
 
 @pytest.mark.parametrize(
@@ -129,10 +127,9 @@ async def test_release_force(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     await lock.acquire_write()
     await lock.acquire_write()
-    assert lock._lock._lock_level == 2
     await lock.release(force=True)
-    assert lock._lock._lock_level == 0
-    assert lock._lock._current_mode is None
+    with pytest.raises(RuntimeError, match="not held"):
+        await lock.release()
 
 
 @pytest.mark.asyncio
@@ -141,23 +138,26 @@ async def test_release_force_unheld_is_noop(lock_file: str) -> None:
     await lock.release(force=True)
 
 
+@pytest.mark.parametrize(
+    ("held", "supplied_executor"),
+    [
+        pytest.param(False, False, id="idle-owned-executor"),
+        pytest.param(True, False, id="held-owned-executor"),
+        pytest.param(False, True, id="idle-supplied-executor"),
+        pytest.param(True, True, id="held-supplied-executor"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_close(lock_file: str) -> None:
-    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    await lock.acquire_write()
-    assert lock._lock._lock_level == 1
-    await lock.close()
-    assert lock._lock._lock_level == 0
-    with pytest.raises(sqlite3.ProgrammingError, match="Cannot operate on a closed database"):
-        lock._lock._con.execute("SELECT 1;")
-
-
-@pytest.mark.asyncio
-async def test_close_on_unheld_lock(lock_file: str) -> None:
-    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+async def test_close_rejects_later_acquisition(lock_file: str, held: bool, supplied_executor: bool) -> None:
+    executor = ThreadPoolExecutor(max_workers=1) if supplied_executor else None
+    lock = AsyncReadWriteLock(lock_file, is_singleton=False, executor=executor)
+    if held:
+        await lock.acquire_write()
     await lock.close()
     with pytest.raises(sqlite3.ProgrammingError, match="Cannot operate on a closed database"):
-        lock._lock._con.execute("SELECT 1;")
+        await lock.acquire_read()
+    if executor is not None:
+        executor.shutdown(wait=False)
 
 
 def test_properties(lock_file: str) -> None:
@@ -176,16 +176,17 @@ async def test_custom_executor(lock_file: str) -> None:
     executor = ThreadPoolExecutor(max_workers=1)
     lock = AsyncReadWriteLock(lock_file, is_singleton=False, executor=executor)
     async with lock.read_lock():
-        assert lock._lock._current_mode == "read"
-    assert lock._lock._lock_level == 0
+        assert_mode_held(lock_file, "read")
+    with pytest.raises(RuntimeError, match="not held"):
+        await lock.release()
     executor.shutdown(wait=False)
 
 
 @pytest.mark.asyncio
 async def test_close_shuts_down_owned_executor(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
-    assert lock._owns_executor is True
     executor = lock.executor
+    await lock.close()
     await lock.close()
     with pytest.raises(RuntimeError):
         executor.submit(int)
@@ -195,7 +196,6 @@ async def test_close_shuts_down_owned_executor(lock_file: str) -> None:
 async def test_close_keeps_provided_executor_open(lock_file: str) -> None:
     executor = ThreadPoolExecutor(max_workers=1)
     lock = AsyncReadWriteLock(lock_file, is_singleton=False, executor=executor)
-    assert lock._owns_executor is False
     await lock.close()
     assert executor.submit(int).result(timeout=5) == 0
     executor.shutdown(wait=False)
@@ -204,7 +204,6 @@ async def test_close_keeps_provided_executor_open(lock_file: str) -> None:
 def test_del_shuts_down_owned_executor(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     executor = lock.executor
-    lock._lock.close()  # isolate the executor lifecycle from the sqlite connection
     del lock
     gc.collect()
     with pytest.raises(RuntimeError):
@@ -214,7 +213,6 @@ def test_del_shuts_down_owned_executor(lock_file: str) -> None:
 def test_del_keeps_provided_executor_open(lock_file: str) -> None:
     executor = ThreadPoolExecutor(max_workers=1)
     lock = AsyncReadWriteLock(lock_file, is_singleton=False, executor=executor)
-    lock._lock.close()
     del lock
     gc.collect()
     assert executor.submit(int).result(timeout=5) == 0
@@ -226,8 +224,9 @@ async def test_acquire_return_proxy_context_manager(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     async with await lock.acquire_read() as ctx:
         assert ctx is lock
-        assert lock._lock._lock_level == 1
-    assert lock._lock._lock_level == 0
+        assert_mode_held(lock_file, "read")
+    with pytest.raises(RuntimeError, match="not held"):
+        await lock.release()
 
 
 @pytest.mark.parametrize("mode", [pytest.param("read", id="read"), pytest.param("write", id="write")])
@@ -236,20 +235,21 @@ async def test_nested_context_managers(lock_file: str, mode: Literal["read", "wr
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     make_ctx = lock.read_lock if mode == "read" else lock.write_lock
     async with make_ctx():
-        assert lock._lock._lock_level == 1
+        assert_mode_held(lock_file, mode)
         async with make_ctx():
-            assert lock._lock._lock_level == 2
-        assert lock._lock._lock_level == 1
-    assert lock._lock._lock_level == 0
+            assert_mode_held(lock_file, mode)
+        assert_mode_held(lock_file, mode)
+    with pytest.raises(RuntimeError, match="not held"):
+        await lock.release()
 
 
 @pytest.mark.asyncio
 async def test_context_manager_uses_instance_defaults(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, timeout=3.0, blocking=True, is_singleton=False)
     async with lock.read_lock():
-        assert lock._lock._current_mode == "read"
+        assert_mode_held(lock_file, "read")
     async with lock.write_lock():
-        assert lock._lock._current_mode == "write"
+        assert_mode_held(lock_file, "write")
 
 
 @pytest.mark.asyncio
@@ -261,3 +261,11 @@ async def test_sequential_mode_switch(lock_file: str) -> None:
         pass
     async with lock.read_lock():
         pass
+
+
+def assert_mode_held(lock_file: str, mode: Literal["read", "write"]) -> None:
+    contender = ReadWriteLock(lock_file, is_singleton=False)
+    acquire = contender.acquire_write if mode == "read" else contender.acquire_read
+    with pytest.raises(Timeout):
+        acquire(blocking=False)
+    contender.close()

--- a/tests/test_async_read_write_cancellation.py
+++ b/tests/test_async_read_write_cancellation.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import multiprocessing
 import sqlite3
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 import pytest
 from async_filelock_cancellation_helpers import assert_cancellation_message
@@ -38,7 +39,7 @@ async def test_acquire_cancellation_before_executor_start_rolls_back(
     rollback_started = asyncio.Event()
     finish_rollback = threading.Event()
     loop = asyncio.get_running_loop()
-    _patch_async_rollback(lock_file, mocker, loop, rollback_started, finish_rollback)
+    _patch_async_rollback(mocker, loop, rollback_started, finish_rollback)
 
     with ThreadPoolExecutor(max_workers=1) as executor:
         blocker = executor.submit(_block_executor, executor_started, release_executor)
@@ -120,7 +121,7 @@ async def test_acquire_cancellation_surfaces_compensation_failure(lock_file: str
     rollback_started = asyncio.Event()
     finish_rollback = threading.Event()
     rollback_error = _patch_async_rollback_failure(
-        lock_file, mocker, asyncio.get_running_loop(), rollback_started, finish_rollback
+        mocker, asyncio.get_running_loop(), rollback_started, finish_rollback
     )
 
     with ThreadPoolExecutor(max_workers=1) as executor:
@@ -163,7 +164,7 @@ async def test_acquire_cancellation_while_sqlite_waits_rolls_back(
     try:
         assert holder_acquired.wait(timeout=5), "read-write lock holder did not acquire"
         execute_started = asyncio.Event()
-        _patch_async_execute_signal(lock_file, mocker, asyncio.get_running_loop(), execute_started)
+        _patch_async_execute_signal(mocker, asyncio.get_running_loop(), execute_started)
         lock = AsyncReadWriteLock(lock_file, is_singleton=False)
         task = asyncio.create_task((lock.acquire_read if mode == "read" else lock.acquire_write)())
         await execute_started.wait()
@@ -194,7 +195,7 @@ async def test_acquire_cancellation_surfaces_acquire_and_rollback_errors(
     finish_acquire = threading.Event()
     loop = asyncio.get_running_loop()
     acquire_error, rollback_error, prior_rollback_error = _patch_async_acquire_and_rollback_failure(
-        lock_file, mocker, loop, acquire_started, finish_acquire, mode
+        mocker, loop, acquire_started, finish_acquire, mode
     )
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     task = asyncio.create_task((lock.acquire_read if mode == "read" else lock.acquire_write)())
@@ -225,7 +226,7 @@ async def test_acquire_cancellation_surfaces_acquire_and_rollback_errors(
 async def test_close_cancellation_shuts_down_owned_executor(lock_file: str, mocker: MockerFixture) -> None:
     rollback_started = asyncio.Event()
     finish_rollback = threading.Event()
-    _patch_async_rollback(lock_file, mocker, asyncio.get_running_loop(), rollback_started, finish_rollback)
+    _patch_async_rollback(mocker, asyncio.get_running_loop(), rollback_started, finish_rollback)
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     await lock.acquire_write()
     executor = lock.executor
@@ -250,7 +251,7 @@ async def test_cancellation_surfaces_rollback_error(
     rollback_started = asyncio.Event()
     finish_rollback = threading.Event()
     rollback_error = _patch_async_rollback_failure(
-        lock_file, mocker, asyncio.get_running_loop(), rollback_started, finish_rollback
+        mocker, asyncio.get_running_loop(), rollback_started, finish_rollback
     )
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     await lock.acquire_write()
@@ -287,7 +288,6 @@ async def test_context_cancellation_preserves_body_and_rollback_contexts(
     body_error = ValueError("body failed")
     prior_error = LookupError("prior rollback failure")
     rollback_error = _patch_async_rollback_failure(
-        lock_file,
         mocker,
         asyncio.get_running_loop(),
         rollback_started,
@@ -324,20 +324,17 @@ async def test_context_cancellation_preserves_body_and_rollback_contexts(
 
 
 def _patch_async_rollback(
-    lock_file: str,
     mocker: MockerFixture,
     loop: asyncio.AbstractEventLoop,
     rollback_started: asyncio.Event,
     finish_rollback: threading.Event,
 ) -> None:
-    real_connection = sqlite3.connect(lock_file, check_same_thread=False)
-
-    def rollback() -> None:
+    def rollback(real_connection: sqlite3.Connection) -> None:
         loop.call_soon_threadsafe(rollback_started.set)
         assert finish_rollback.wait(timeout=5)
         real_connection.rollback()
 
-    _patch_async_connection(mocker, real_connection, rollback=rollback)
+    _patch_async_connection(mocker, rollback=rollback)
 
 
 def _cancel_queued_read_write_acquire(lock_file: str, cancel_caller: bool, canceled: Synchronized[bool]) -> None:
@@ -373,23 +370,19 @@ def _cancel_queued_read_write_acquire(lock_file: str, cancel_caller: bool, cance
 
 
 def _patch_async_execute_signal(
-    lock_file: str,
     mocker: MockerFixture,
     loop: asyncio.AbstractEventLoop,
     execute_started: asyncio.Event,
 ) -> None:
-    real_connection = sqlite3.connect(lock_file, check_same_thread=False)
-
-    def execute(statement: str) -> sqlite3.Cursor:
-        if statement.startswith("PRAGMA journal_mode"):
+    def executescript(real_connection: sqlite3.Connection, statement: str) -> sqlite3.Cursor:
+        if "PRAGMA journal_mode" in statement:
             loop.call_soon_threadsafe(execute_started.set)
-        return real_connection.execute(statement)
+        return real_connection.executescript(statement)
 
-    _patch_async_connection(mocker, real_connection, execute=execute)
+    _patch_async_connection(mocker, executescript=executescript)
 
 
 def _patch_async_rollback_failure(
-    lock_file: str,
     mocker: MockerFixture,
     loop: asyncio.AbstractEventLoop,
     rollback_started: asyncio.Event,
@@ -397,12 +390,11 @@ def _patch_async_rollback_failure(
     *,
     prior_context: BaseException | None = None,
 ) -> sqlite3.OperationalError:
-    real_connection = sqlite3.connect(lock_file, check_same_thread=False)
     rollback_error = sqlite3.OperationalError("rollback failed")
     rollback_error.__context__ = prior_context
     rollback_failed = False
 
-    def rollback() -> None:
+    def rollback(real_connection: sqlite3.Connection) -> None:
         nonlocal rollback_failed
         if rollback_failed:
             real_connection.rollback()
@@ -412,19 +404,17 @@ def _patch_async_rollback_failure(
         assert finish_rollback.wait(timeout=5)
         raise rollback_error
 
-    _patch_async_connection(mocker, real_connection, rollback=rollback)
+    _patch_async_connection(mocker, rollback=rollback)
     return rollback_error
 
 
 def _patch_async_acquire_and_rollback_failure(
-    lock_file: str,
     mocker: MockerFixture,
     loop: asyncio.AbstractEventLoop,
     acquire_started: asyncio.Event,
     finish_acquire: threading.Event,
     mode: Literal["read", "write"],
 ) -> tuple[sqlite3.OperationalError, sqlite3.OperationalError, LookupError]:
-    real_connection = sqlite3.connect(lock_file, check_same_thread=False)
     acquire_error = sqlite3.OperationalError("acquire failed")
     rollback_error = sqlite3.OperationalError("rollback failed")
     prior_rollback_error = LookupError("prior rollback failure")
@@ -432,10 +422,10 @@ def _patch_async_acquire_and_rollback_failure(
     acquire_failed = False
     rollback_failed = False
 
-    def execute(statement: str) -> sqlite3.Cursor:
+    def executescript(real_connection: sqlite3.Connection, statement: str) -> sqlite3.Cursor:
         nonlocal acquire_failed
-        cursor = real_connection.execute(statement)
-        target = statement.startswith("SELECT") if mode == "read" else statement.startswith("BEGIN EXCLUSIVE")
+        cursor = real_connection.executescript(statement)
+        target = "SELECT name" in statement if mode == "read" else "BEGIN EXCLUSIVE" in statement
         if target and not acquire_failed:
             acquire_failed = True
             loop.call_soon_threadsafe(acquire_started.set)
@@ -444,7 +434,7 @@ def _patch_async_acquire_and_rollback_failure(
             raise acquire_error
         return cursor
 
-    def rollback() -> None:
+    def rollback(real_connection: sqlite3.Connection) -> None:
         nonlocal rollback_failed
         if not rollback_failed:
             rollback_failed = True
@@ -454,37 +444,52 @@ def _patch_async_acquire_and_rollback_failure(
                 raise rollback_error  # noqa: B904  # exercise implicit backend context preservation
         real_connection.rollback()
 
-    _patch_async_connection(mocker, real_connection, execute=execute, rollback=rollback)
+    _patch_async_connection(mocker, executescript=executescript, rollback=rollback)
     return acquire_error, rollback_error, prior_rollback_error
 
 
 def _patch_async_connection(
     mocker: MockerFixture,
-    real_connection: sqlite3.Connection,
     *,
-    execute: Callable[[str], sqlite3.Cursor] | None = None,
-    rollback: Callable[[], None] | None = None,
+    executescript: Callable[[sqlite3.Connection, str], sqlite3.Cursor] | None = None,
+    rollback: Callable[[sqlite3.Connection], None] | None = None,
 ) -> None:
-    configuration: dict[str, Callable[[str], sqlite3.Cursor] | Callable[[], None]] = {}
-    if execute is not None:
-        configuration["execute.side_effect"] = execute
-    if rollback is not None:
-        configuration["rollback.side_effect"] = rollback
-    connection = mocker.MagicMock(spec_set=sqlite3.Connection, wraps=real_connection, **configuration)
-    mocker.patch.object(
-        type(connection),
-        "in_transaction",
-        new_callable=mocker.PropertyMock,
-        create=True,
-        side_effect=lambda: real_connection.in_transaction,
-    )
-    sqlite_module = mocker.MagicMock(
-        spec_set=sqlite3,
-        Error=sqlite3.Error,
-        OperationalError=sqlite3.OperationalError,
-        connect=mocker.create_autospec(sqlite3.connect, return_value=connection),
-    )
-    mocker.patch("filelock._read_write.sqlite3", sqlite_module)
+    real_connect = sqlite3.connect
+    connection_count = 0
+
+    def connect(
+        database: str,
+        *,
+        factory: type[sqlite3.Connection],
+        timeout: float,
+    ) -> sqlite3.Connection:
+        nonlocal connection_count
+        real_connection = real_connect(
+            database,
+            check_same_thread=False,
+            factory=factory,
+            cached_statements=0,
+            timeout=timeout,
+        )
+        connection_count += 1
+        if connection_count != 2:
+            return real_connection
+        configuration: dict[str, Callable[[str], sqlite3.Cursor] | Callable[[], None]] = {}
+        if executescript is not None:
+            configuration["executescript.side_effect"] = functools.partial(executescript, real_connection)
+        if rollback is not None:
+            configuration["rollback.side_effect"] = functools.partial(rollback, real_connection)
+        connection = mocker.MagicMock(spec_set=type(real_connection), wraps=real_connection, **configuration)
+        mocker.patch.object(
+            type(connection),
+            "in_transaction",
+            new_callable=mocker.PropertyMock,
+            create=True,
+            side_effect=lambda: real_connection.in_transaction,
+        )
+        return cast("sqlite3.Connection", connection)
+
+    mocker.patch("filelock._read_write._connect", side_effect=connect)
 
 
 def _block_executor(executor_started: threading.Event, release_executor: threading.Event) -> None:

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import sys
 import time
 from contextlib import contextmanager
-from multiprocessing import Event, Process, Value
-from typing import TYPE_CHECKING, Final, Literal
+from multiprocessing import Event, Process, Value, set_start_method
+from typing import TYPE_CHECKING, Final, Literal, cast
 
 import pytest
 
@@ -14,6 +15,9 @@ import sqlite3
 from read_write_helpers import assert_read_write_lock_state
 
 from filelock import ReadWriteLock, Timeout
+
+if sys.implementation.name == "pypy":
+    set_start_method("spawn", force=True)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -326,6 +330,39 @@ def test_sequential_lock_modes(
 
 
 @pytest.mark.parametrize(
+    "path_change",
+    [pytest.param("cwd", id="relative-cwd"), pytest.param("symlink", id="retargeted-symlink")],
+)
+def test_read_write_lock_keeps_constructed_database(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, path_change: Literal["cwd", "symlink"]
+) -> None:
+    first_directory = tmp_path / "first"
+    second_directory = tmp_path / "second"
+    first_directory.mkdir()
+    second_directory.mkdir()
+    first_database = first_directory / "lock.db"
+    second_database = second_directory / "lock.db"
+    if path_change == "cwd":
+        monkeypatch.chdir(first_directory)
+        lock = ReadWriteLock("lock.db", is_singleton=False)
+        monkeypatch.chdir(second_directory)
+    else:
+        lock_path = tmp_path / "lock.db"
+        try:
+            lock_path.symlink_to(first_database)
+        except OSError as error:  # pragma: no cover - platform policy can deny symlink creation
+            pytest.skip(str(error))
+        lock = ReadWriteLock(lock_path, is_singleton=False)
+        lock_path.unlink()
+        lock_path.symlink_to(second_database)
+
+    with lock.read_lock():
+        assert_read_write_lock_state(str(first_database), "write", available=False)
+        assert_read_write_lock_state(str(second_database), "write", available=True)
+    lock.close()
+
+
+@pytest.mark.parametrize(
     ("held_mode", "probe_mode"),
     [
         pytest.param("read", "write", id="read"),
@@ -348,7 +385,7 @@ def test_release_rollback_failure_reconciles_lock_state(
     after_rollback: bool,
     available_after_failure: bool,
 ) -> None:
-    rollback_error = _patch_rollback_failure(lock_file, mocker, after_rollback=after_rollback)
+    rollback_error = _patch_rollback_failure(mocker, after_rollback=after_rollback)
     lock = ReadWriteLock(lock_file, is_singleton=False)
     (lock.acquire_read if held_mode == "read" else lock.acquire_write)()
 
@@ -366,40 +403,55 @@ def test_release_rollback_failure_reconciles_lock_state(
     lock.close()
 
 
-def _patch_rollback_failure(lock_file: str, mocker: MockerFixture, *, after_rollback: bool) -> sqlite3.OperationalError:
-    real_connection = sqlite3.connect(lock_file, check_same_thread=False)
+def _patch_rollback_failure(mocker: MockerFixture, *, after_rollback: bool) -> sqlite3.OperationalError:
+    real_connect = sqlite3.connect
     rollback_error = sqlite3.OperationalError("rollback failed")
-    failed = False
+    connection_count = 0
 
-    def fail_first_rollback() -> None:
-        nonlocal failed
-        if failed:
-            real_connection.rollback()
-            return
-        failed = True
-        if after_rollback:
-            real_connection.rollback()
-        raise rollback_error
+    def connect(
+        database: str,
+        *,
+        factory: type[sqlite3.Connection],
+        timeout: float,
+    ) -> sqlite3.Connection:
+        nonlocal connection_count
+        connection_count += 1
+        real_connection = real_connect(
+            database,
+            check_same_thread=False,
+            factory=factory,
+            cached_statements=0,
+            timeout=timeout,
+        )
+        if connection_count != 2:
+            return real_connection
 
-    connection = mocker.MagicMock(
-        spec_set=sqlite3.Connection,
-        wraps=real_connection,
-        **{"rollback.side_effect": fail_first_rollback},
-    )
-    mocker.patch.object(
-        type(connection),
-        "in_transaction",
-        new_callable=mocker.PropertyMock,
-        create=True,
-        side_effect=lambda: real_connection.in_transaction,
-    )
-    sqlite_module = mocker.MagicMock(
-        spec_set=sqlite3,
-        Error=sqlite3.Error,
-        OperationalError=sqlite3.OperationalError,
-        connect=mocker.create_autospec(sqlite3.connect, return_value=connection),
-    )
-    mocker.patch("filelock._read_write.sqlite3", sqlite_module)
+        rollback_failed = False
+
+        def rollback() -> None:
+            nonlocal rollback_failed
+            if not rollback_failed:
+                rollback_failed = True
+                if after_rollback:
+                    real_connection.rollback()
+                raise rollback_error
+            real_connection.rollback()
+
+        connection = mocker.MagicMock(
+            spec_set=type(real_connection),
+            wraps=real_connection,
+            **{"rollback.side_effect": rollback},
+        )
+        mocker.patch.object(
+            type(connection),
+            "in_transaction",
+            new_callable=mocker.PropertyMock,
+            create=True,
+            side_effect=lambda: real_connection.in_transaction,
+        )
+        return cast("sqlite3.Connection", connection)
+
+    mocker.patch("filelock._read_write._connect", side_effect=connect)
     return rollback_error
 
 
@@ -437,6 +489,7 @@ def cleanup_processes(processes: list[Process]) -> Generator[None]:
         for proc in processes:
             proc.terminate()
             proc.join(timeout=1)
+            proc.close()
 
 
 def chain_reader(

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -1,0 +1,991 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import subprocess  # noqa: S404  # isolates process-global audit hooks and fork exits
+import sys
+import textwrap
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from filelock import ReadWriteLock
+
+
+def test_read_write_lock_closes_idle_connections(tmp_path: Path) -> None:
+    lock_path = tmp_path / "idle.db"
+    connection_events = 0
+
+    def audit_hook(  # pragma: no cover - interpreter audit hooks run with tracing disabled
+        event: str, args: tuple[object, ...]
+    ) -> None:
+        nonlocal connection_events
+        if event != "sqlite3.connect":
+            return
+        database = args[0]
+        if isinstance(database, (str, bytes)) and os.fsdecode(database) == str(lock_path):
+            connection_events += 1
+
+    sys.addaudithook(audit_hook)
+    lock = ReadWriteLock(lock_path, is_singleton=False)
+    lock.acquire_read()
+    lock.acquire_read()
+    lock.release()
+    lock.release()
+    lock.acquire_write()
+    lock.release()
+    lock_path.unlink()
+
+    assert connection_events == 3
+
+
+@pytest.mark.skipif(
+    not Path("/dev/fd").is_dir() and not Path("/proc/self/fd").is_dir(),
+    reason="no descriptor view",
+)
+def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) -> None:
+    result = _run_fork_script(_dropped_instances_script(), [str(tmp_path)], timeout=10)
+
+    assert result == (0, "", "")
+
+
+@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="requires fork transitions")
+def test_async_read_write_lock_allows_finalizer_reentry(tmp_path: Path) -> None:
+    result = _run_fork_script(
+        _reentrant_finalizer_script(),
+        [str(tmp_path / "async.db"), str(tmp_path / "finalizer.db")],
+        timeout=10,
+    )
+
+    assert result == (0, "", "")
+
+
+def test_read_write_lock_subclass_has_independent_singletons(tmp_path: Path) -> None:
+    class DerivedReadWriteLock(ReadWriteLock):
+        pass
+
+    lock_path = tmp_path / "subclass.db"
+    base_lock = ReadWriteLock(lock_path)
+    derived_lock = DerivedReadWriteLock(lock_path)
+
+    assert (derived_lock is DerivedReadWriteLock(lock_path), derived_lock is not base_lock) == (True, True)
+
+
+@pytest.mark.parametrize(
+    "audit_event",
+    [
+        pytest.param("sqlite3.connect", id="sqlite-connect"),
+        pytest.param(
+            "ctypes.dlsym",
+            marks=pytest.mark.skipif(
+                sys.implementation.name != "cpython" or sys.version_info >= (3, 12) or sys.platform == "win32",
+                reason="connection escrow uses this audit event only on POSIX CPython before 3.12",
+            ),
+            id="ctypes-dlsym",
+        ),
+    ],
+)
+def test_read_write_lock_rejects_recursive_singleton_construction(tmp_path: Path, audit_event: str) -> None:
+    result = subprocess.run(  # executes this test's fixed interpreter and source
+        [sys.executable, "-c", _recursive_construction_script(), str(tmp_path / "construction.db"), audit_event],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@pytest.mark.skipif(
+    sys.implementation.name != "cpython" or sys.version_info >= (3, 12),
+    reason="connection escrow uses CPython reference functions before 3.12",
+)
+def test_read_write_lock_escrow_ignores_shared_ctypes_signatures(tmp_path: Path) -> None:
+    result = subprocess.run(  # executes this test's fixed interpreter and source
+        [sys.executable, "-c", _ctypes_signature_script(), str(tmp_path / "ctypes.db")],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        pytest.param("acquire", id="acquire"),
+        pytest.param("release", id="release"),
+        pytest.param("close", id="close"),
+    ],
+)
+def test_read_write_lock_rejects_same_thread_operation_during_acquisition(
+    tmp_path: Path, operation: Literal["acquire", "release", "close"]
+) -> None:
+    result = subprocess.run(  # executes this test's fixed interpreter and source
+        [sys.executable, "-c", _recursive_acquisition_script(), str(tmp_path / "acquisition.db"), operation],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        pytest.param("release", id="release"),
+        pytest.param("close", id="close"),
+    ],
+)
+def test_read_write_lock_serializes_other_thread_operation_during_acquisition(
+    tmp_path: Path, operation: Literal["release", "close"]
+) -> None:
+    result = subprocess.run(  # executes this test's fixed interpreter and source
+        [sys.executable, "-c", _concurrent_operation_script(), str(tmp_path / "concurrent.db"), operation],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+@pytest.mark.parametrize(
+    ("mode", "fork_name", "reject_audit_hook"),
+    [
+        pytest.param("read", "fork", False, id="read-fork"),
+        pytest.param("write", "fork", False, id="write-fork"),
+        pytest.param("write", "fork", True, id="write-fork-rejected-audit-hook"),
+        pytest.param(
+            "read",
+            "fork1",
+            False,
+            marks=pytest.mark.skipif(not hasattr(os, "fork1"), reason="requires os.fork1"),
+            id="read-fork1",
+        ),
+        pytest.param(
+            "write",
+            "fork1",
+            False,
+            marks=pytest.mark.skipif(not hasattr(os, "fork1"), reason="requires os.fork1"),
+            id="write-fork1",
+        ),
+    ],
+)
+def test_read_write_lock_survives_normal_fork_child_exit(
+    tmp_path: Path,
+    mode: Literal["read", "write"],
+    fork_name: Literal["fork", "fork1"],
+    reject_audit_hook: bool,
+) -> None:
+    result = _run_fork_script(
+        _fork_script(),
+        [
+            str(tmp_path / "fork.db"),
+            mode,
+            fork_name,
+            "reject" if reject_audit_hook else "allow",
+        ],
+        timeout=15,
+    )
+
+    assert result == (0, "", "")
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+def test_read_write_lock_fork_waits_for_sqlite_operation(tmp_path: Path) -> None:
+    result = _run_fork_script(_fork_during_sqlite_script(), [str(tmp_path / "fork-gate.db")], timeout=15)
+
+    assert result == (0, "", "")
+
+
+@pytest.mark.skipif(
+    sys.implementation.name != "cpython" or not hasattr(os, "fork"),
+    reason="requires CPython profile events and os.fork",
+)
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        pytest.param("executescript", id="execute"),
+        pytest.param("rollback", id="rollback"),
+        pytest.param("close", id="close"),
+        pytest.param("connection-return", id="connection-return"),
+    ],
+)
+def test_read_write_lock_fork_at_sqlite_boundary_exits_child(
+    tmp_path: Path, boundary: Literal["executescript", "rollback", "close", "connection-return"]
+) -> None:
+    result = _run_fork_script(
+        _fork_at_sqlite_boundary_script(),
+        [str(tmp_path / "fork-boundary.db"), boundary],
+        timeout=10,
+    )
+
+    assert result == (0, "", "")
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+def test_read_write_lock_idle_fork_handles_fresh_child_lock(tmp_path: Path) -> None:
+    result = _run_fork_script(_idle_fork_script(), [str(tmp_path / "idle-fork.db")], timeout=10)
+
+    assert result == (0, "", "")
+
+
+@pytest.mark.skipif(sys.implementation.name != "pypy" or not hasattr(os, "fork"), reason="requires fork on PyPy")
+def test_read_write_lock_pypy_child_allows_without_known_sqlite_use(tmp_path: Path) -> None:
+    result = _run_fork_script(
+        _pypy_fork_script(),
+        [str(tmp_path / "child.db")],
+        timeout=10,
+    )
+
+    assert result == (0, "", "")
+
+
+@pytest.mark.skipif(sys.implementation.name != "pypy" or not hasattr(os, "fork"), reason="requires fork on PyPy")
+def test_read_write_lock_pypy_child_rejects_after_external_sqlite_use(tmp_path: Path) -> None:
+    result = _run_fork_script(
+        _pypy_external_sqlite_script(),
+        [str(tmp_path / "external.db"), str(tmp_path / "child.db")],
+        timeout=10,
+    )
+
+    assert result == (0, "", "")
+
+
+def test_fork_script_terminates_timed_out_process_group() -> None:
+    with pytest.raises(AssertionError, match="fork script exceeded"):
+        _run_fork_script("import time; time.sleep(10)", [], timeout=0.01)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+def test_read_write_lock_subclass_cache_resets_after_fork(tmp_path: Path) -> None:
+    result = _run_fork_script(_subclass_fork_script(), [str(tmp_path / "subclass-fork.db")], timeout=10)
+
+    assert result == (0, "", "")
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+@pytest.mark.parametrize("held", [pytest.param(False, id="idle"), pytest.param(True, id="held")])
+def test_async_read_write_lock_fork_behavior(tmp_path: Path, held: bool) -> None:
+    result = _run_fork_script(
+        _async_fork_script(),
+        [str(tmp_path / "async-fork.db"), "held" if held else "idle"],
+        timeout=15,
+    )
+
+    assert result == (0, "", "")
+
+
+def _run_fork_script(script: str, arguments: list[str], *, timeout: float) -> tuple[int, str, str]:
+    process = subprocess.Popen(  # executes this test's fixed interpreter and source
+        [sys.executable, "-c", script, *arguments],
+        start_new_session=True,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        process_output, process_error = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as error:
+        with contextlib.suppress(ProcessLookupError):
+            if sys.platform == "win32":
+                process.kill()
+            else:
+                os.killpg(process.pid, signal.SIGKILL)
+        process_output, process_error = process.communicate()
+        msg = f"fork script exceeded {timeout} seconds: stdout={process_output!r}, stderr={process_error!r}"
+        raise AssertionError(msg) from error
+    assert process.returncode is not None
+    return process.returncode, process_output, process_error
+
+
+def _dropped_instances_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import gc
+        import sys
+        from pathlib import Path
+
+        from filelock import ReadWriteLock
+
+        root = Path(sys.argv[1])
+        descriptor_path = Path("/dev/fd") if Path("/dev/fd").is_dir() else Path("/proc/self/fd")
+        gc.collect()
+        initial_count = sum(1 for _ in descriptor_path.iterdir())
+        for index in range(100):
+            lock = ReadWriteLock(root / f"dropped-{index}.db", is_singleton=False)
+            lock.acquire_write()
+            del lock
+        gc.collect()
+
+        assert sum(1 for _ in descriptor_path.iterdir()) == initial_count
+        with ReadWriteLock(root / "dropped-0.db", is_singleton=False).read_lock():
+            pass
+        """
+    )
+
+
+def _reentrant_finalizer_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import asyncio
+        import gc
+        import sys
+        import weakref
+        from threading import Condition, Event
+        from types import CodeType, FrameType
+        from typing import Final
+
+        from filelock import AsyncReadWriteLock, ReadWriteLock
+
+        class _FinalizerTarget:
+            cycle: _FinalizerTarget
+
+        _FINALIZED: Final[Event] = Event()
+
+        def _close_lock() -> None:
+            ReadWriteLock(sys.argv[2], is_singleton=False).close()
+            _FINALIZED.set()
+
+        _TARGET = _FinalizerTarget()
+        _TARGET.cycle = _TARGET
+        weakref.finalize(_TARGET, _close_lock)
+        del _TARGET
+
+        _NOTIFY_CODE: Final[CodeType] = Condition.notify_all.__code__
+
+        def _collect_at_notify(frame: FrameType, _event: str, _argument: None) -> None:
+            if frame.f_code is _NOTIFY_CODE:
+                sys.settrace(None)
+                gc.collect()
+
+        sys.settrace(_collect_at_notify)
+        _LOCK: Final[AsyncReadWriteLock] = AsyncReadWriteLock(sys.argv[1], is_singleton=False)
+        sys.settrace(None)
+
+        assert _FINALIZED.is_set()
+        asyncio.run(_LOCK.close())
+        """
+    )
+
+
+def _recursive_construction_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import sys
+
+        from filelock import ReadWriteLock
+
+        lock_path, audit_event = sys.argv[1:]
+        armed = True
+
+        def audit_hook(event: str, _args: tuple[object, ...]) -> None:
+            # CPython supplies heterogeneous values for process-wide audit events.
+            if armed and event == audit_event:
+                ReadWriteLock(lock_path)
+
+        sys.addaudithook(audit_hook)
+        try:
+            ReadWriteLock(lock_path)
+        except RuntimeError as error:
+            assert str(error) == f"Singleton lock construction is already active for {lock_path}"
+        else:
+            raise AssertionError("recursive singleton construction succeeded")
+
+        armed = False
+        with ReadWriteLock(lock_path).read_lock():
+            pass
+        """
+    )
+
+
+def _recursive_acquisition_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import sys
+
+        from filelock import ReadWriteLock
+
+        lock_path, operation = sys.argv[1:]
+        lock = ReadWriteLock(lock_path)
+        armed = True
+
+        def audit_hook(event: str, _args: tuple[object, ...]) -> None:
+            # CPython supplies heterogeneous values for process-wide audit events.
+            if armed and event == "sqlite3.connect":
+                if operation == "acquire":
+                    lock.acquire_read()
+                elif operation == "release":
+                    lock.release()
+                else:
+                    lock.close()
+
+        sys.addaudithook(audit_hook)
+        try:
+            lock.acquire_read()
+        except RuntimeError as error:
+            assert str(error) == (
+                f"Cannot {operation} ReadWriteLock on {lock_path} while acquisition is active in this thread"
+            )
+        else:
+            raise AssertionError(f"recursive {operation} succeeded")
+
+        armed = False
+        with lock.read_lock():
+            pass
+        """
+    )
+
+
+def _ctypes_signature_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import ctypes
+        import sys
+
+        ctypes.pythonapi.Py_IncRef.argtypes = (ctypes.c_void_p,)
+        from filelock import ReadWriteLock
+
+        lock = ReadWriteLock(sys.argv[1], is_singleton=False)
+        lock.acquire_read()
+        ctypes.pythonapi.Py_DecRef.argtypes = (ctypes.c_void_p,)
+        lock.release()
+        with ReadWriteLock(sys.argv[1], is_singleton=False).write_lock():
+            pass
+        """
+    )
+
+
+def _concurrent_operation_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import queue
+        import sqlite3
+        import sys
+        import threading
+
+        from filelock import ReadWriteLock
+
+        lock_path, operation = sys.argv[1:]
+        lock = ReadWriteLock(lock_path)
+        acquisition_inside_connect = threading.Event()
+        continue_acquisition = threading.Event()
+        acquire_errors: queue.SimpleQueue[BaseException] = queue.SimpleQueue()
+        operation_errors: queue.SimpleQueue[BaseException] = queue.SimpleQueue()
+        armed = True
+
+        def audit_hook(event: str, _args: tuple[object, ...]) -> None:
+            # CPython supplies heterogeneous values for process-wide audit events.
+            if armed and event == "sqlite3.connect":
+                acquisition_inside_connect.set()
+                assert continue_acquisition.wait(5)
+
+        def acquire() -> None:
+            try:
+                lock.acquire_write()
+            except BaseException as error:
+                acquire_errors.put(error)
+
+        def operate() -> None:
+            try:
+                getattr(lock, operation)()
+            except BaseException as error:
+                operation_errors.put(error)
+
+        sys.addaudithook(audit_hook)
+        acquire_thread = threading.Thread(target=acquire)
+        acquire_thread.start()
+        assert acquisition_inside_connect.wait(5)
+        operation_thread = threading.Thread(target=operate)
+        operation_thread.start()
+        operation_thread.join(0.1)
+        assert operation_thread.is_alive()
+        armed = False
+        continue_acquisition.set()
+        acquire_thread.join(5)
+        operation_thread.join(5)
+        assert not acquire_thread.is_alive()
+        assert not operation_thread.is_alive()
+        assert acquire_errors.empty()
+        assert operation_errors.empty()
+        if operation == "release":
+            with lock.write_lock():
+                pass
+        else:
+            try:
+                lock.acquire_read()
+            except sqlite3.ProgrammingError as error:
+                assert str(error) == "Cannot operate on a closed database."
+            else:
+                raise AssertionError("concurrent acquisition reopened a closed lock")
+        """
+    )
+
+
+def _fork_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import gc
+        import os
+        import sqlite3
+        import sys
+
+        lock_path, mode, fork_name, audit_hook_mode = sys.argv[1:]
+        if audit_hook_mode == "reject":
+            def reject_filelock_audit_hook(event: str, _args: tuple[object, ...]) -> None:
+                # CPython supplies heterogeneous values for process-wide audit events.
+                if event == "sys.addaudithook":
+                    raise RuntimeError("audit hook registration rejected")
+
+            sys.addaudithook(reject_filelock_audit_hook)
+
+        from filelock import ReadWriteLock, Timeout
+
+        lock = ReadWriteLock(lock_path, is_singleton=False)
+        acquire = lock.acquire_read if mode == "read" else lock.acquire_write
+        proxy = acquire()
+        parent_to_child_read, parent_to_child_write = os.pipe()
+        child_to_parent_read, child_to_parent_write = os.pipe()
+
+        child_pid = getattr(os, fork_name)()
+        if child_pid == 0:
+            os.close(parent_to_child_write)
+            os.close(child_to_parent_read)
+            try:
+                with proxy:
+                    pass
+                try:
+                    lock.acquire_read()
+                except RuntimeError as error:
+                    assert "was invalidated by fork()" in str(error)
+                else:
+                    raise AssertionError("inherited acquisition succeeded")
+                lock.release()
+                lock.close()
+                del proxy
+                del lock
+                gc.collect()
+                sqlite_connects = 0
+
+                def count_sqlite_connects(event: str, _args: tuple[object, ...]) -> None:
+                    # CPython supplies heterogeneous values for process-wide audit events.
+                    global sqlite_connects
+                    if event == "sqlite3.connect":
+                        sqlite_connects += 1
+
+                sys.addaudithook(count_sqlite_connects)
+                try:
+                    ReadWriteLock(lock_path, is_singleton=False)
+                except RuntimeError as error:
+                    expected = (
+                        "ReadWriteLock is unavailable in a PyPy fork child"
+                        if sys.implementation.name == "pypy"
+                        else "was active across fork(); exec or exit"
+                    )
+                    assert expected in str(error)
+                else:
+                    raise AssertionError("child reopened a database active during fork")
+                assert sqlite_connects == 0
+                os.write(child_to_parent_write, b"1")
+                assert os.read(parent_to_child_read, 1) == b"1"
+            except BaseException:
+                import traceback
+
+                traceback.print_exc()
+                sys.exit(1)
+            sys.exit(0)
+
+        os.close(parent_to_child_read)
+        os.close(child_to_parent_write)
+        assert os.read(child_to_parent_read, 1) == b"1"
+        contender = ReadWriteLock(lock_path, is_singleton=False)
+        conflicting_acquire = contender.acquire_write if mode == "read" else contender.acquire_read
+        try:
+            conflicting_acquire(blocking=False)
+        except Timeout:
+            pass
+        else:
+            raise AssertionError("child exit released the parent's lock")
+        lock.release()
+        os.write(parent_to_child_write, b"1")
+        _, status = os.waitpid(child_pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+        with sqlite3.connect(lock_path) as connection:
+            assert connection.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+        """
+    )
+
+
+def _fork_during_sqlite_script() -> str:
+    return textwrap.dedent(
+        r"""
+        from __future__ import annotations
+
+        import os
+        import queue
+        import sqlite3
+        import sys
+        import threading
+        import time
+        import warnings
+
+        from filelock import ReadWriteLock
+
+        warnings.filterwarnings("ignore", category=DeprecationWarning, message=r".*fork\(\).*")
+
+        lock_path = sys.argv[1]
+        waiter = ReadWriteLock(lock_path, is_singleton=False)
+        holder = sqlite3.connect(lock_path, check_same_thread=False)
+        holder.executescript("PRAGMA journal_mode=MEMORY; BEGIN EXCLUSIVE TRANSACTION;").close()
+        waiter_inside_connect = threading.Event()
+        continue_connect = threading.Event()
+        acquisition_errors: queue.SimpleQueue[BaseException] = queue.SimpleQueue()
+        armed = True
+
+        def audit_hook(event: str, args: tuple[object, ...]) -> None:
+            # CPython supplies heterogeneous values for process-wide audit events.
+            if not armed or event != "sqlite3.connect":
+                return
+            database = args[0]
+            if (
+                isinstance(database, (str, bytes))
+                and os.fsdecode(database) == lock_path
+            ):
+                waiter_inside_connect.set()
+                assert continue_connect.wait(5)
+
+        def acquire() -> None:
+            try:
+                with waiter.read_lock(timeout=5):
+                    pass
+            except BaseException as error:
+                acquisition_errors.put(error)
+
+        def release_holder() -> None:
+            threading.Event().wait(0.2)
+            continue_connect.set()
+            holder.rollback()
+            holder.close()
+
+        sys.addaudithook(audit_hook)
+        waiter_thread = threading.Thread(target=acquire)
+        waiter_thread.start()
+        assert waiter_inside_connect.wait(5)
+        release_thread = threading.Thread(target=release_holder)
+        release_thread.start()
+        start = time.monotonic()
+        child_pid = os.fork()
+        elapsed = time.monotonic() - start
+        if child_pid == 0:
+            sys.exit(0)
+        armed = False
+        _, status = os.waitpid(child_pid, 0)
+        waiter_thread.join(5)
+        release_thread.join(5)
+        assert os.waitstatus_to_exitcode(status) == 0
+        assert elapsed >= 0.1
+        assert not waiter_thread.is_alive()
+        assert not release_thread.is_alive()
+        if not acquisition_errors.empty():
+            raise acquisition_errors.get()
+        """
+    )
+
+
+def _fork_at_sqlite_boundary_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import os
+        import sqlite3
+        import sys
+        from types import FrameType
+        from typing import Protocol
+
+        class ProfiledCall(Protocol):
+            @property
+            def __name__(self) -> str: ...
+
+        def reject_filelock_audit_hook(event: str, _args: tuple[object, ...]) -> None:
+            # CPython audit events have heterogeneous interpreter-owned payloads.
+            if event == "sys.addaudithook":
+                raise RuntimeError("audit hook registration rejected")
+
+        sys.addaudithook(reject_filelock_audit_hook)
+
+        from filelock import ReadWriteLock
+
+        lock_path, boundary = sys.argv[1:]
+        child_pids: list[int] = []
+        armed = True
+
+        def profile(
+            _frame: FrameType,
+            event: str,
+            value: ProfiledCall | sqlite3.Connection | None,
+        ) -> None:
+            global armed
+            connection_returned = boundary == "connection-return" and event == "return" and isinstance(
+                value, sqlite3.Connection
+            )
+            sqlite_called = (
+                boundary != "connection-return"
+                and event == "c_call"
+                and value is not None
+                and value.__name__ == boundary
+            )
+            if armed and (connection_returned or sqlite_called):
+                armed = False
+                child_pids.append(os.fork())
+
+        sys.setprofile(profile)
+        with ReadWriteLock(lock_path, is_singleton=False).write_lock():
+            pass
+        sys.setprofile(None)
+
+        assert len(child_pids) == 1
+        _, status = os.waitpid(child_pids[0], 0)
+        assert os.waitstatus_to_exitcode(status) == 70
+        """
+    )
+
+
+def _idle_fork_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import os
+        import sys
+
+        from filelock import ReadWriteLock
+
+        lock_path = sys.argv[1]
+        inherited_lock = ReadWriteLock(lock_path, is_singleton=False)
+        child_pid = os.fork()
+        if child_pid == 0:
+            try:
+                inherited_lock.acquire_read()
+            except RuntimeError as error:
+                assert "was invalidated by fork()" in str(error)
+            else:
+                raise AssertionError("inherited idle lock acquired")
+            if sys.implementation.name == "pypy":
+                try:
+                    ReadWriteLock(lock_path, is_singleton=False)
+                except RuntimeError as error:
+                    assert str(error) == (
+                        "ReadWriteLock is unavailable in a PyPy fork child; exec or exit before using it"
+                    )
+                else:
+                    raise AssertionError("PyPy child opened SQLite after fork")
+            else:
+                with ReadWriteLock(lock_path, is_singleton=False).write_lock():
+                    pass
+            sys.exit(0)
+        _, status = os.waitpid(child_pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+        """
+    )
+
+
+def _pypy_fork_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import os
+        import sys
+
+        from filelock import ReadWriteLock
+
+        child_path = sys.argv[1]
+        child_pid = os.fork()
+        if child_pid == 0:
+            with ReadWriteLock(child_path, is_singleton=False).read_lock():
+                pass
+            sys.exit(0)
+        _, status = os.waitpid(child_pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+        """
+    )
+
+
+def _pypy_external_sqlite_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import os
+        import sqlite3
+        import sys
+
+        from filelock import ReadWriteLock
+
+        external_path, child_path = sys.argv[1:]
+        sqlite3.connect(external_path).close()
+        child_pid = os.fork()
+        if child_pid == 0:
+            try:
+                ReadWriteLock(child_path, is_singleton=False)
+            except RuntimeError as error:
+                assert str(error) == (
+                    "ReadWriteLock is unavailable in a PyPy fork child; exec or exit before using it"
+                )
+            else:
+                raise AssertionError("PyPy child opened SQLite after parent use")
+            sys.exit(0)
+        _, status = os.waitpid(child_pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+        """
+    )
+
+
+def _subclass_fork_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import os
+        import sys
+
+        from filelock import ReadWriteLock
+
+        class DerivedReadWriteLock(ReadWriteLock):
+            pass
+
+        lock_path = sys.argv[1]
+        inherited_lock = DerivedReadWriteLock(lock_path)
+        child_pid = os.fork()
+        if child_pid == 0:
+            if sys.implementation.name == "pypy":
+                try:
+                    DerivedReadWriteLock(lock_path)
+                except RuntimeError as error:
+                    assert str(error) == (
+                        "ReadWriteLock is unavailable in a PyPy fork child; exec or exit before using it"
+                    )
+                else:
+                    raise AssertionError("PyPy child constructed a lock after fork")
+            else:
+                child_lock = DerivedReadWriteLock(lock_path)
+                assert child_lock is not inherited_lock
+                with child_lock.read_lock():
+                    pass
+            sys.exit(0)
+        _, status = os.waitpid(child_pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+        """
+    )
+
+
+def _async_fork_script() -> str:
+    return textwrap.dedent(
+        r"""
+        from __future__ import annotations
+
+        import asyncio
+        import gc
+        import os
+        import sqlite3
+        import sys
+        import warnings
+
+        from filelock import AsyncAcquireReadWriteReturnProxy, AsyncReadWriteLock, ReadWriteLock, Timeout
+
+        warnings.filterwarnings("ignore", category=DeprecationWarning, message=r".*fork\(\).*")
+        lock_path, state = sys.argv[1:]
+
+        async def set_up_parent() -> tuple[AsyncReadWriteLock, AsyncAcquireReadWriteReturnProxy | None]:
+            parent_lock = AsyncReadWriteLock(lock_path, is_singleton=False)
+            parent_proxy = await parent_lock.acquire_write() if state == "held" else None
+            return parent_lock, parent_proxy
+
+        lock, proxy = asyncio.run(set_up_parent())
+        child_pid = os.fork()
+        if child_pid == 0:
+            async def check_child() -> None:
+                if proxy is not None:
+                    async with proxy:
+                        pass
+                try:
+                    await lock.acquire_read()
+                except RuntimeError as error:
+                    assert "was invalidated by fork()" in str(error)
+                else:
+                    raise AssertionError("inherited async lock acquired")
+                await lock.release()
+                await lock.close()
+                if sys.implementation.name == "pypy":
+                    try:
+                        AsyncReadWriteLock(lock_path, is_singleton=False)
+                    except RuntimeError as error:
+                        assert str(error) == (
+                            "ReadWriteLock is unavailable in a PyPy fork child; exec or exit before using it"
+                        )
+                    else:
+                        raise AssertionError("PyPy child constructed an async lock after fork")
+                elif state == "idle":
+                    fresh_lock = AsyncReadWriteLock(lock_path, is_singleton=False)
+                    async with fresh_lock.write_lock():
+                        pass
+                    await fresh_lock.close()
+                else:
+                    try:
+                        ReadWriteLock(lock_path, is_singleton=False)
+                    except RuntimeError as error:
+                        expected = (
+                            "ReadWriteLock is unavailable in a PyPy fork child"
+                            if sys.implementation.name == "pypy"
+                            else "was active across fork(); exec or exit"
+                        )
+                        assert expected in str(error)
+                    else:
+                        raise AssertionError("active async database reopened in child")
+
+            asyncio.run(check_child())
+            del lock
+            gc.collect()
+            sys.exit(0)
+
+        _, status = os.waitpid(child_pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+        if state == "held":
+            contender = ReadWriteLock(lock_path, is_singleton=False)
+            try:
+                contender.acquire_read(blocking=False)
+            except Timeout:
+                pass
+            else:
+                raise AssertionError("async child cleanup released the parent's lock")
+            asyncio.run(lock.release())
+        asyncio.run(lock.close())
+        with sqlite3.connect(lock_path) as connection:
+            assert connection.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+        """
+    )

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import threading
 from typing import TYPE_CHECKING, Literal
 
@@ -9,21 +8,13 @@ import pytest
 pytest.importorskip("sqlite3")
 
 import sqlite3
-
-from conftest import pytest_sessionfinish
+from pathlib import Path
 
 from filelock import Timeout
-from filelock._read_write import (
-    _MAX_SQLITE_TIMEOUT_MS,
-    ReadWriteLock,
-    _all_connections,
-    _cleanup_connections,
-    timeout_for_sqlite,
-)
+from filelock._read_write import _MAX_SQLITE_TIMEOUT_MS, ReadWriteLock, timeout_for_sqlite
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from pathlib import Path
 
     from pytest_mock import MockerFixture
 
@@ -112,7 +103,7 @@ def test_init_sets_attributes(lock_file: str) -> None:
     assert lock._lock_level == 0
     assert lock._current_mode is None
     assert lock._write_thread_id is None
-    assert lock._con is not None
+    assert Path(lock_file).is_file()
 
 
 def test_acquire_release_read(lock_file: str) -> None:
@@ -243,14 +234,14 @@ def test_close_releases_lock_and_closes_connection(lock_file: str) -> None:
     lock.close()
     assert lock._lock_level == 0
     with pytest.raises(sqlite3.ProgrammingError, match="Cannot operate on a closed database"):
-        lock._con.execute("SELECT 1;")
+        lock.acquire_read()
 
 
 def test_close_on_unheld_lock_closes_connection(lock_file: str) -> None:
     lock = ReadWriteLock(lock_file, is_singleton=False)
     lock.close()
     with pytest.raises(sqlite3.ProgrammingError, match="Cannot operate on a closed database"):
-        lock._con.execute("SELECT 1;")
+        lock.acquire_read()
 
 
 def test_write_lock_reentrant_from_different_thread_prohibited(lock_file: str) -> None:
@@ -440,7 +431,7 @@ def test_double_check_read_reentrance(lock_file: str, mocker: MockerFixture) -> 
     assert proxy is not None
     lock._lock_level = 0
     lock._current_mode = None
-    lock._con.rollback()
+    lock.release(force=True)
 
 
 def test_double_check_write_reentrance(lock_file: str, mocker: MockerFixture) -> None:
@@ -463,7 +454,7 @@ def test_double_check_write_reentrance(lock_file: str, mocker: MockerFixture) ->
     lock._lock_level = 0
     lock._current_mode = None
     lock._write_thread_id = None
-    lock._con.rollback()
+    lock.release(force=True)
 
 
 @pytest.mark.parametrize(
@@ -498,35 +489,6 @@ def test_double_check_wrong_mode_raises(
     lock._current_mode = None
 
 
-@pytest.mark.parametrize(
-    ("error_msg", "expected_exception"),
-    [
-        pytest.param("disk I/O error", sqlite3.OperationalError, id="non-locked-reraised"),
-        pytest.param("database is locked", Timeout, id="locked-becomes-timeout"),
-    ],
-)
-@pytest.mark.parametrize(
-    "mode",
-    [
-        pytest.param("read", id="read"),
-        pytest.param("write", id="write"),
-    ],
-)
-def test_operational_error_handling(
-    lock_file: str,
-    mocker: MockerFixture,
-    error_msg: str,
-    expected_exception: type[Exception],
-    mode: Literal["read", "write"],
-) -> None:
-    lock = ReadWriteLock(lock_file, is_singleton=False)
-    con_mock = mocker.MagicMock()
-    con_mock.execute.side_effect = sqlite3.OperationalError(error_msg)
-    lock._con = con_mock
-    with pytest.raises(expected_exception):
-        (lock.acquire_read if mode == "read" else lock.acquire_write)()
-
-
 def test_write_lock_context_manager_overrides_defaults(lock_file: str) -> None:
     lock = ReadWriteLock(lock_file, timeout=10.0, blocking=False, is_singleton=False)
     with lock.write_lock(timeout=5.0, blocking=True):
@@ -543,162 +505,19 @@ def test_write_lock_context_manager_overrides_defaults(lock_file: str) -> None:
 def test_busy_timeout_recomputed_after_journal_mode(
     lock_file: str, mocker: MockerFixture, mode: Literal["read", "write"]
 ) -> None:
-    counter = iter([0.0, 0.0, 0.5])
+    counter = iter([0.0, 0.0, 0.0, 0.5])
     mocker.patch("filelock._read_write.time.perf_counter", side_effect=counter)
     lock = ReadWriteLock(lock_file, is_singleton=False)
     (lock.acquire_read if mode == "read" else lock.acquire_write)(timeout=2.0)
     lock.release()
 
 
-def test_connection_tracked_in_all_connections(lock_file: str) -> None:
+def test_acquire_converts_connect_lock_error_to_timeout(lock_file: str, mocker: MockerFixture) -> None:
     lock = ReadWriteLock(lock_file, is_singleton=False)
-    assert lock._con in _all_connections
-    lock.close()
+    mocker.patch(
+        "filelock._read_write._connect",
+        side_effect=sqlite3.OperationalError("database is locked"),
+    )
 
-
-def test_cleanup_connections_closes_all(tmp_path: Path) -> None:
-    lock1 = ReadWriteLock(str(tmp_path / "a.db"), is_singleton=False)
-    lock2 = ReadWriteLock(str(tmp_path / "b.db"), is_singleton=False)
-    con1, con2 = lock1._con, lock2._con
-    _cleanup_connections()
-    with pytest.raises(sqlite3.ProgrammingError, match="Cannot operate on a closed database"):
-        con1.execute("SELECT 1;")
-    with pytest.raises(sqlite3.ProgrammingError, match="Cannot operate on a closed database"):
-        con2.execute("SELECT 1;")
-
-
-def test_release_rollback_serialised_against_concurrent_acquire(lock_file: str) -> None:
-    # release() rolls back the transaction on the shared connection; a concurrent acquire on another thread
-    # must not be able to BEGIN while that rollback is still in flight. Park the rollback with the lock level
-    # already back at 0 and confirm the racing acquire waits for it instead of erroring with "cannot start a
-    # transaction within a transaction".
-    lock = ReadWriteLock(lock_file, is_singleton=False)
-    lock.acquire_read()
-
-    started = threading.Event()
-    proceed = threading.Event()
-    real_con = lock._con
-
-    class _SlowRollbackCon:
-        def rollback(self) -> None:  # noqa: PLR6301
-            started.set()
-            proceed.wait(timeout=5)
-            real_con.rollback()
-
-        def __getattr__(self, name: str) -> object:
-            return getattr(real_con, name)
-
-    lock._con = _SlowRollbackCon()  # ty: ignore[invalid-assignment]
-    threading.Thread(target=lock.release, daemon=True).start()
-    assert started.wait(timeout=5)
-
-    result: dict[str, object] = {}
-
-    def acquirer() -> None:
-        try:
-            lock.acquire_read()
-            result["ok"] = True
-        except BaseException as exc:
-            result["exc"] = exc
-
-    thread = threading.Thread(target=acquirer, daemon=True)
-    thread.start()
-    thread.join(timeout=1)
-    assert thread.is_alive()  # blocked on _transaction_lock, not racing the rollback
-
-    proceed.set()
-    thread.join(timeout=5)
-    lock._con = real_con
-    assert result.get("ok") is True
-    assert "exc" not in result
-    lock.release()
-
-
-def test_read_acquire_rolls_back_begin_when_select_loses_lock_race(lock_file: str) -> None:
-    # A read acquire runs BEGIN (a deferred transaction that takes no lock) and only then the SELECT that takes
-    # the SHARED lock. If a writer grabs EXCLUSIVE between the two, the SELECT fails but BEGIN's transaction is
-    # left open on the shared connection; without a rollback the next acquire's BEGIN dies with "cannot start a
-    # transaction within a transaction" and the instance is wedged. Force that interleaving and confirm the
-    # connection is rolled back and the instance still works.
-    reader = ReadWriteLock(lock_file, is_singleton=False)
-    writer = ReadWriteLock(lock_file, is_singleton=False)
-    real_con = reader._con
-
-    class _RaceCon:
-        def execute(self, sql: str) -> object:  # noqa: PLR6301
-            if sql.lstrip().upper().startswith("SELECT") and not writer._con.in_transaction:
-                writer.acquire_write()  # writer slips in between the reader's BEGIN and SELECT
-            return real_con.execute(sql)
-
-        def __getattr__(self, name: str) -> object:
-            return getattr(real_con, name)
-
-    reader._con = _RaceCon()  # ty: ignore[invalid-assignment]
     with pytest.raises(Timeout):
-        reader.acquire_read(timeout=0.3)
-    reader._con = real_con
-    assert real_con.in_transaction is False
-
-    writer.release()
-    with reader.read_lock(timeout=1):
-        assert reader._current_mode == "read"
-    reader.close()
-    writer.close()
-
-
-def test_failed_reentrant_double_check_keeps_a_concurrent_holders_lock(lock_file: str) -> None:
-    # The acquire-failure handler must not roll back on a reentrant-validation RuntimeError. A writer that reaches
-    # _do_acquire_inner's double-check after a reader took the lock would otherwise roll back the reader's still-open
-    # transaction on the shared connection, dropping a lock the reader believes it holds. Force that interleaving.
-    lock = ReadWriteLock(lock_file, is_singleton=False)
-    writer_at_gate = threading.Event()
-    reader_acquired = threading.Event()
-    real_acquire_tx = lock._acquire_transaction_lock
-    writer_tid: dict[str, int] = {}
-    errors: dict[str, RuntimeError] = {}
-
-    def gated(*, blocking: bool, timeout: float) -> None:
-        if threading.get_ident() == writer_tid.get("id"):  # writer has passed its early check at lock_level == 0
-            writer_at_gate.set()
-            reader_acquired.wait(5)  # let the reader acquire (and open its transaction) first
-        real_acquire_tx(blocking=blocking, timeout=timeout)
-
-    def acquire_write_in_thread() -> None:
-        writer_tid["id"] = threading.get_ident()
-        try:
-            lock.acquire_write(timeout=5)
-        except RuntimeError as exc:
-            errors["writer"] = exc
-
-    lock._acquire_transaction_lock = gated  # ty: ignore[invalid-assignment]
-    thread = threading.Thread(target=acquire_write_in_thread)
-    thread.start()
-    assert writer_at_gate.wait(5)
-    lock.acquire_read(timeout=5)  # reader opens the SHARED transaction on the shared connection
-    reader_acquired.set()
-    thread.join(5)
-
-    assert "writer" in errors  # writer's upgrade rejected with RuntimeError
-    assert lock._con.in_transaction is True  # the reader's transaction survived the writer's failure
-    assert lock._lock_level == 1
-    assert lock._current_mode == "read"
-    lock.release()
-    lock.close()
-
-
-def test_pytest_session_finish_calls_cleanup(mocker: MockerFixture) -> None:
-    mock = mocker.patch("conftest._cleanup_connections")
-    pytest_sessionfinish()
-    mock.assert_called_once_with()
-
-
-def test_pytest_session_finish_calls_cleanup_pypy(mocker: MockerFixture) -> None:
-    mocker.patch.object(sys, "pypy_version_info", (7, 3, 0), create=True)
-    mock = mocker.patch("conftest._cleanup_connections")
-    pytest_sessionfinish()
-    mock.assert_called_once_with()
-
-
-def test_pytest_session_finish_no_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("conftest._cleanup_connections", None)
-    pytest_sessionfinish()  # must not raise, just skips cleanup
+        lock.acquire_read(timeout=0.1)


### PR DESCRIPTION
SQLite forbids a process from using or closing a database connection inherited through `fork()`. Read-write locks kept one connection for the object's lifetime, so a child could close its parent's handle during interpreter shutdown and corrupt the database. Each outer acquisition now owns its connection, and a forked child abandons inherited handles according to [SQLite's fork guidance](https://sqlite.org/howtocorrupt.html#_carrying_an_open_database_connection_across_a_fork_). Closes #635.

The child rejects an active database by canonical path or inode until `exec()`. CPython 3.10 and 3.11 keep inherited base connections alive through a raw-reference escrow; later CPython versions use the guarded subclass finalizer. The implementation follows the [CPython 3.10 `_sqlite` lifecycle](https://github.com/python/cpython/blob/v3.10.20/Modules/_sqlite/connection.c) and [current CPython source](https://github.com/python/cpython/blob/main/Modules/_sqlite/connection.c). A child forked from a SQLite callback waits for the call to leave SQLite, or exits with status 70 if an earlier audit hook prevents coordination. Fork registration uses a reentrant gate because connection finalizers can register another lock while the current thread owns that gate.

PyPy can retain unsafe process-wide SQLite state after tracked connections close. A PyPy child rejects read-write locks when the parent used SQLite after importing filelock; importing filelock in the child cannot detect earlier parent use. The public acquisition interfaces stay unchanged. Final release closes the per-acquisition connection. A local 2,000-acquisition benchmark measured 5.7 microseconds for the former persistent connection and 45.6 microseconds for the per-acquisition design.

This replaces #654, which GitHub closed after merging #653 deleted its base branch `fix/634-fork-ownership`. The branch now sits on `main` and carries the same work.

It also carries the `close_failure` fixture change from #656, without which the `pypy3.11` job fails here. Landing #656 first drops that commit from this branch on the next rebase.
