### PR TITLE
✨ feat(soft): add strict soft locks and leases

### DIFF
--- a/docs/changelog/636.feature.rst
+++ b/docs/changelog/636.feature.rst
@@ -1,1 +1,3 @@
-Warn when `SoftFileLock.lifetime` enables age-based expiry, and direct callers to strict-lock or lease interfaces.
+Add ``StrictSoftFileLock``, which treats every marker it did not publish as contention, and ``SoftFileLease``, whose
+claim expires and whose holder learns through ``on_compromise`` when it is lost. ``SoftFileLock(lifetime=...)`` now warns
+and names them. Both publish a record ``SoftFileLock`` evicts, so do not mix contracts on one path.

--- a/docs/changelog/636.feature.rst
+++ b/docs/changelog/636.feature.rst
@@ -1,0 +1,1 @@
+Warn when `SoftFileLock.lifetime` enables age-based expiry, and direct callers to strict-lock or lease interfaces.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -86,8 +86,8 @@ File locking takes two approaches:
 
 **OS-level locking** (FileLock on Windows/Unix, UnixFileLock, WindowsFileLock)
 
-The operating system manages locks. When you create a lock, the OS tracks it and enforces it. Only code with an open
-file handle can lock it. When a process dies, the OS automatically releases its locks.
+The operating system tracks locks on open handles and releases them when a process exits. These locks coordinate code
+that follows the same locking convention; they do not prevent unrelated access to the protected resource.
 
 .. list-table::
     :header-rows: 1
@@ -98,35 +98,34 @@ file handle can lock it. When a process dies, the OS automatically releases its 
       - ✗ Exclusive only, with no reader/writer distinction (use ReadWriteLock for that).
     - - ✓ Works even if your process crashes.
       - ✗ Unreliable on some network filesystems.
-    - - ✓ No network filesystem issues.
-      -
     - - ✓ Lower overhead.
       -
 
 **Soft locks / PID locks** (SoftFileLock, the fallback on systems without fcntl)
 
-A separate "lock file" indicates that a resource is in use. The lock file contains the PID and hostname of the holder
-(one per line). A process acquires a lock by creating this file atomically with ``O_CREAT | O_EXCL``; it releases by
-deleting it.
+A shared marker indicates that a resource is in use. The marker contains the PID and hostname of the holder. A process
+attempts acquisition with ``O_CREAT | O_EXCL`` and releases by deleting the pathname. The filesystem must provide
+coherent exclusive creation and directory updates to every participant.
 
-This is the same concept as a traditional **PID lock file** (as used by Unix daemons and the deprecated `lockfile <https://pypi.org/project/lockfile/>`_
-library's ``PIDLockFile``). The PID stored in the file identifies the lock holder via the
-:attr:`~filelock.SoftFileLock.pid` property and lets a waiter detect stale locks when the holding process has died.
+This is the same concept as a traditional **PID lock file** (as used by Unix daemons and the deprecated
+`lockfile <https://pypi.org/project/lockfile/>`_ library's ``PIDLockFile``). The PID stored in the file identifies the
+lock holder via the :attr:`~filelock.SoftFileLock.pid` property and lets a waiter detect stale locks when the holding
+process has died.
 
-On all platforms, processes can check if the lock holder is still alive and break stale locks automatically. On Windows,
-the lock file additionally stores the process creation time to guard against PID recycling.
+Same-host contenders can check whether the recorded PID exists. Windows also records process creation time to
+distinguish a reused PID. Other platforms can mistake a reused PID for the original holder and remain blocked.
 
 .. list-table::
     :header-rows: 1
 
     - - Pros
       - Cons
-    - - ✓ Works on any filesystem, including network mounts.
-      - ✗ Not enforced; it requires cooperation (a buggy process can ignore it).
-    - - ✓ Portable; the same code works everywhere.
+    - - ✓ Does not require a native file-locking API.
+      - ✗ Not enforced; it requires cooperation.
+    - - ✓ Uses filesystem operations available on supported platforms.
       - ✗ Higher overhead than OS-level locks.
-    - - ✓ Can detect stale locks (all platforms).
-      - ✗ Cross-host detection doesn't work (stale locks from other hosts require manual cleanup).
+    - - ✓ Can inspect same-host PID records.
+      - ✗ Network filesystems require deployment-specific tests for creation and cache coherence.
 
 ***************************
  Platform-specific details
@@ -134,8 +133,7 @@ the lock file additionally stores the process creation time to guard against PID
 
 **Windows**
     Uses the :class:`WindowsFileLock <filelock.WindowsFileLock>` class, backed by ``LockFileEx``/``UnlockFileEx`` over a
-    one-byte range on a handle opened with ``NtCreateFile``. This is enforced by Windows, so all code running on the
-    system respects it, whether it uses filelock or not.
+    one-byte range on a handle opened with ``NtCreateFile``. Processes using the same byte-range convention contend.
 
     The lock is exclusive and works reliably on local filesystems. Network filesystem (SMB) support is available but
     considered less reliable.
@@ -173,17 +171,17 @@ the lock file additionally stores the process creation time to guard against PID
 
     lock = FileLock("work.lock")
 
-This gives you OS-level locking on Windows and Unix/macOS, with an automatic fallback to soft locks on other systems.
-It's the right choice 99% of the time.
+This gives you OS-level locking on Windows and Unix/macOS, with a soft-lock alias on builds without ``fcntl``. To
+require the Unix backend and reject its runtime ``ENOSYS`` fallback, construct
+``UnixFileLock(..., fallback_to_soft=False)`` explicitly. The option cannot change which class ``FileLock`` aliases
+when ``fcntl`` is unavailable.
 
-**Use UnixFileLock or WindowsFileLock** only if you need to force a specific backend. This is rare and usually only
-necessary in testing or if you need platform-specific behavior.
+**Use UnixFileLock or WindowsFileLock** when the application requires that backend or its platform-specific behavior.
 
 **Use SoftFileLock** when:
 
-- You're on a network filesystem where OS-level locking is unavailable (NFS).
-- You need cross-filesystem compatibility and can tolerate the overhead.
-- You need stale lock detection.
+- The filesystem lacks a usable native lock, and operators have verified exclusive creation and cache behavior.
+- Cooperating processes can tolerate shared-marker recovery and its overlap risks.
 
 **Use ReadWriteLock** when:
 
@@ -194,9 +192,8 @@ necessary in testing or if you need platform-specific behavior.
 
 **Use SoftReadWriteLock** when:
 
-- You want reader/writer semantics on a **network filesystem** (NFS, Lustre with ``-o flock``, HPC shared storage).
-- You need cross-host stale detection so a crash on one compute node does not wedge readers on other nodes.
-- You are running on a multi-node slurm/HPC cluster.
+- You need reader/writer semantics on a tested shared filesystem.
+- Callers can stop protected work when heartbeat expiry permits another holder to enter.
 
 Lock selection flowchart:
 
@@ -205,12 +202,16 @@ Lock selection flowchart:
     flowchart TD
         start["Choose a lock type"] --> question1{"Read-heavy workload?"}
         question1 -->|Yes| questionRwNet{"Network<br/>filesystem?"}
-        questionRwNet -->|Yes| srw["Use SoftReadWriteLock"]
+        questionRwNet -->|Yes| questionRwFs{"Verified marker and<br/>cache behavior?"}
+        questionRwFs -->|Yes| srw["Use SoftReadWriteLock"]
+        questionRwFs -->|No| service["Use a lock service"]
         questionRwNet -->|No| questionAsync{"Async code?"}
         questionAsync -->|Yes| arw["Use AsyncReadWriteLock"]
         questionAsync -->|No| rw["Use ReadWriteLock"]
         question1 -->|No| question2{"Need network<br/>filesystem support?"}
-        question2 -->|Yes| soft["Use SoftFileLock"]
+        question2 -->|Yes| questionSoftFs{"Verified exclusive create<br/>and cache behavior?"}
+        questionSoftFs -->|Yes| soft["Use SoftFileLock"]
+        questionSoftFs -->|No| service
         question2 -->|No| question3{"Need platform<br/>specific control?"}
         question3 -->|Yes| platform["Use UnixFileLock<br/>or WindowsFileLock"]
         question3 -->|No| default["Use FileLock<br/>(recommended)"]
@@ -337,18 +338,14 @@ On older platforms without ``O_NOFOLLOW``, prefer :class:`UnixFileLock <filelock
             data = open("data.txt").read()
 
 **Locks on network filesystems**
-    OS-level locks (FileLock on Windows/Unix) are unreliable on network filesystems (NFS, SMB). Network filesystems do
-    not reliably support locking semantics.
-
-    For **exclusive locking** on NFS, use :class:`SoftFileLock <filelock.SoftFileLock>`. For **reader/writer
-    locking** (shared readers + exclusive writers) on NFS, use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>`,
-    which is the only variant in filelock that also handles cross-host stale detection. ``ReadWriteLock`` is SQLite-backed
-    and is unsafe on NFS because SQLite itself warns against running on network filesystems.
+    NFS and SMB behavior depends on protocol versions, mount options, servers, and client caching. filelock does not
+    promise one backend across those configurations. Use a soft lock only after verifying exclusive creation, rename,
+    unlink, timestamps, and cache visibility on the target mount. Keep SQLite-backed ``ReadWriteLock`` on a local
+    filesystem supported by the active SQLite VFS.
 
 **Locks across different machines**
-    A lock on one machine doesn't stop another machine from accessing the resource unless they use a centralized locking
-    service, or a shared filesystem plus filelock's soft locks. On a multi-node slurm/HPC cluster,
-    :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` is correct across compute nodes sharing an NFS mount.
+    Separate machines need a central lock service or a shared filesystem with a tested contract. A shared pathname
+    alone does not establish cross-host correctness.
 
 **Read-write semantics**
     FileLock is exclusive only; readers block writers and vice versa. If you need multiple readers with occasional
@@ -374,8 +371,8 @@ On older platforms without ``O_NOFOLLOW``, prefer :class:`UnixFileLock <filelock
 Why not use OS-level locks everywhere?
 ======================================
 
-OS-level locks (FileLock on Windows/Unix) are fast and enforced by the kernel. But they don't work on all network
-filesystems. For portability, filelock includes SoftFileLock as a fallback.
+OS-level locks are fast and enforced by the kernel. Their network-filesystem behavior depends on the server, protocol,
+mount, and client. ``SoftFileLock`` provides a cooperative fallback when its filesystem operations have been verified.
 
 Why does SoftFileLock use a separate file instead of just checking a directory?
 ===============================================================================
@@ -386,13 +383,10 @@ A directory can't reliably be atomically created and deleted across platforms. A
 How does stale lock detection work across platforms?
 ====================================================
 
-Stale lock detection requires: 1. Knowing the PID of the lock holder 2. A way to check if that process is still alive
-3. A way to atomically break the stale lock without corruption.
-
-On Unix/macOS, ``kill(pid, 0)`` checks process liveness and ``rename()`` atomically replaces the lock file. On Windows,
-``OpenProcess`` checks liveness and the lock file additionally stores the process creation time (via
-``GetProcessTimes``) to guard against PID recycling. If the PID is alive but the creation time doesn't match what was
-stored, the lock is recognized as stale from a recycled PID and evicted.
+On Unix and macOS, ``kill(pid, 0)`` checks whether a same-host PID exists. Windows uses ``OpenProcess`` and stores the
+process creation time from ``GetProcessTimes`` to distinguish a reused PID. A valid owner record remains when process
+liveness is ambiguous. A malformed or unparsable record follows a separate rule: a waiter may remove it after two
+seconds, so unknown records do not fail closed.
 
 Why is ReadWriteLock backed by SQLite?
 ======================================
@@ -408,13 +402,14 @@ implementation. Because Python's :mod:`sqlite3` module has no async API, all blo
 thread pool via ``loop.run_in_executor``. This is the same approach used by :class:`BaseAsyncFileLock
 <filelock.BaseAsyncFileLock>`.
 
-How does SoftReadWriteLock work on NFS?
-=======================================
+How does SoftReadWriteLock work on shared filesystems?
+======================================================
 
-:class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` fills the gap left by ``ReadWriteLock`` on network filesystems.
-It stores state as a small directory tree next to the lock file:
+:class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` uses a marker directory tree. Deploy it on a shared filesystem
+only after verifying its required operations and cache behavior:
 
-- ``<path>.state`` is a short-held :class:`SoftFileLock <filelock.SoftFileLock>` used as the state mutex during transitions.
+- ``<path>.state`` is a short-held :class:`SoftFileLock <filelock.SoftFileLock>` used as the state mutex during
+  transitions.
 - ``<path>.write`` is the writer marker; its presence blocks readers and other writers.
 - ``<path>.readers/<host>.<pid>.<uuid>`` is one marker file per active reader.
 
@@ -424,8 +419,7 @@ check plus a dirfd-relative open to close symlink races (which ``mkdir`` alone c
 
 Writer acquisition is two-phase and writer-preferring: phase one atomically claims ``<path>.write`` (which blocks
 any new reader as soon as it exists), phase two polls the ``readers/`` directory until every reader has exited.
-Writer starvation is impossible even under read-heavy workloads such as the 99/1 reader-to-writer mix
-typical of slurm job queues.
+New readers wait behind an observed writer marker, which gives writers preference among cooperating participants.
 
 Cross-host stale detection
 ==========================
@@ -436,8 +430,7 @@ uses a **TTL with a heartbeat** rather than ``SoftFileLock``'s PID-alive check:
 
 - Each lock instance starts a daemon thread on acquire. The thread refreshes the marker's ``mtime`` every
   ``heartbeat_interval`` seconds (default 30 s).
-- Any process on any host may evict a marker whose ``mtime`` has not advanced in ``stale_threshold`` seconds
-  (default 90 s, ratio borrowed from etcd's ``LeaseKeepAlive``).
+- A peer may evict a marker whose ``mtime`` has not advanced in ``stale_threshold`` seconds (default 90 s).
 - Eviction is atomic: read → rename to a unique ``.break.<pid>.<nonce>`` file → re-verify token and mtime →
   unlink. On verification failure the ``.break.*`` file stays for TTL or atexit cleanup; rollback-rename is itself
   racy and is not attempted.
@@ -445,8 +438,8 @@ uses a **TTL with a heartbeat** rather than ``SoftFileLock``'s PID-alive check:
   never gets accidentally refreshed.
 
 The trade-off: ``stale_threshold`` must be larger than any realistic pause a holder might hit (GC, syscall delay,
-NFS hiccup). Pick it generously. We assume clock synchronization across compute nodes; HPC clusters run
-NTP or chrony, so this is not an additional constraint in the target environment.
+filesystem delay). Pick it generously, synchronize participating clocks, and fence protected writes if an expired
+holder can resume.
 
 Fork semantics
 ==============
@@ -459,10 +452,9 @@ fresh ones and marks the instance fork-invalidated. ``release()`` on an invalida
 inherited ``with lock.read_lock():`` block can unwind in the child without raising. The child must construct a
 fresh ``SoftReadWriteLock(path)`` before it can acquire again. This matches PyMongo's connection-pool semantics.
 
-**Trust boundary.** The class protects against same-UID non-cooperating processes (one host or cross-host) and
-same-host different-UID users via the ``0o600`` / ``0o700`` permissions on markers and the readers directory.
-It does not protect against root compromise, NTP tampering on same-UID cross-host nodes, or multi-tenant mounts
-where hostile co-tenants share the UID.
+**Trust boundary.** The class coordinates cooperating processes. Directory ownership, ACLs, and ``0o600`` / ``0o700``
+permissions can exclude another UID. A process with the same effective UID can alter the markers. Clock errors and
+filesystem cache behavior can also trigger expiry while a holder remains active.
 
 ****************************
  File permissions and mode

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -343,17 +343,14 @@ filelock cannot make that operation safe.
 
 .. _fork guidance: https://www.sqlite.org/howtocorrupt.html#_carrying_an_open_database_connection_across_a_fork_
 
-***************************************************
- Use read/write locks on network filesystems (NFS)
-***************************************************
+********************************************
+ Use read/write locks on shared filesystems
+********************************************
 
-:class:`ReadWriteLock <filelock.ReadWriteLock>` is SQLite-backed and requires a local filesystem: SQLite's own
-docs warn against running on NFS because POSIX ``fcntl`` locks are unreliable there. For HPC clusters, slurm
-deployments, or any multi-host shared storage, use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>`
-instead. It is built on :class:`SoftFileLock <filelock.SoftFileLock>` primitives (atomic
-``O_CREAT | O_EXCL | O_NOFOLLOW``) and runs a daemon heartbeat thread that refreshes each held marker's ``mtime`` so any
-host on any node can evict a stale
-marker when the holder crashes.
+:class:`ReadWriteLock <filelock.ReadWriteLock>` is SQLite-backed and requires a local filesystem supported by the active
+SQLite VFS. On a shared filesystem, use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` only after verifying
+exclusive creation, rename, unlink, timestamps, and cache visibility across participating hosts. Its heartbeat permits
+a peer to evict a marker after ``stale_threshold`` even if the old holder later resumes.
 
 .. code-block:: python
 
@@ -379,24 +376,22 @@ that hold locks for seconds-to-minutes. Tune them for your deployment:
         poll_interval=0.25,      # how long to sleep between acquire retries
     )
 
-Pick ``stale_threshold`` larger than any realistic pause a holder could experience (GC, disk flush, kernel
-preemption). ``heartbeat_interval`` should be roughly ``stale_threshold / 3``; that is the ratio etcd uses for
-its ``LeaseKeepAlive``. Lower ``poll_interval`` reduces acquire latency under contention at the cost of more
-NFS ``stat`` calls per waiting client.
+Pick ``stale_threshold`` larger than any realistic process or filesystem pause. ``heartbeat_interval`` should be
+roughly ``stale_threshold / 3``. Lower ``poll_interval`` reduces acquisition latency at the cost of more filesystem
+metadata calls. Synchronize participating clocks and fence protected writes if an expired holder can resume.
 
 Writer acquisition is two-phase and writer-preferring: phase one claims the writer marker (which blocks any
 new reader), phase two waits for existing readers to drain. This rules out writer starvation under read-heavy
 workloads. See :doc:`concepts` for the full model.
 
 **Fork caveat.** A process that forks while holding a ``SoftReadWriteLock`` loses the lock in the child. filelock marks
-the inherited instance fork-invalidated; ``release()`` on it becomes a no-op, and the child must call
-``SoftReadWriteLock(path)`` again to get a fresh instance before acquiring. Matches the semantics of
-:class:`threading.Lock` and PyMongo's connection pools.
+the inherited instance fork-invalidated; ``release()`` on it becomes a no-op, and the child must construct a fresh
+``SoftReadWriteLock(path)`` before acquiring. This follows the invalidation approach used by PyMongo's connection
+pools.
 
-**Trust boundary.** The class protects against same-UID non-cooperating processes on one host, cross-host
-same-UID processes, and same-host different-UID users (via ``0o600`` / ``0o700`` permissions). It does not
-protect against root compromise, NTP tampering on same-UID cross-host nodes, or multi-tenant mounts where
-hostile co-tenants share the UID.
+**Trust boundary.** The class coordinates cooperating processes. Directory ownership, ACLs, and ``0o600`` / ``0o700``
+permissions can exclude another UID. A process with the same effective UID can alter the markers, and incorrect clocks
+or cache behavior can trigger expiry while a holder remains active.
 
 ***********************************
  Use async read / write locks
@@ -440,7 +435,8 @@ Low-level ``acquire_read``/``acquire_write``/``release`` methods are also availa
 The same reentrancy and upgrade/downgrade rules as the synchronous :class:`ReadWriteLock <filelock.ReadWriteLock>`
 apply. See :ref:`how-to:Use shared read / exclusive write locks` for details.
 
-For network filesystems, use :class:`AsyncSoftReadWriteLock <filelock.AsyncSoftReadWriteLock>`, which wraps
+For a shared filesystem whose marker and cache behavior has been verified, use
+:class:`AsyncSoftReadWriteLock <filelock.AsyncSoftReadWriteLock>`, which wraps
 :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` the same way:
 
 .. code-block:: python
@@ -456,8 +452,8 @@ For network filesystems, use :class:`AsyncSoftReadWriteLock <filelock.AsyncSoftR
  Detect stale locks (soft locks only)
 **************************************
 
-:class:`SoftFileLock <filelock.SoftFileLock>` stores the PID and hostname of the lock holder. It can detect when the
-holding process has died and break stale locks on all platforms.
+:class:`SoftFileLock <filelock.SoftFileLock>` stores the PID and hostname of the lock holder. A same-host contender may
+remove the marker when it can prove that PID does not exist.
 
 This happens automatically. You don't need to do anything special:
 
@@ -472,10 +468,11 @@ This happens automatically. You don't need to do anything special:
         # another process will automatically clean up the stale lock
         pass
 
-Stale lock detection only detects locks from the same host. Cross-host stale locks still require manual removal.
+Cross-host records remain because their PID cannot be interpreted locally. On platforms without process-start identity,
+a reused PID can also keep a dead owner's marker in place.
 
-On Windows, the lock file additionally stores the process creation time to guard against PID recycling. filelock evicts
-malformed lock files (empty or corrupted) after a brief safety window.
+On Windows, the marker also stores process creation time to guard against PID recycling. Malformed records follow a
+different rule: a waiter may evict them after two seconds. That recovery path is not fail closed.
 
 *****************************************
  Inspect and manage PID locks
@@ -537,31 +534,50 @@ library:
     handler = logging.StreamHandler()
     logging.getLogger("filelock").addHandler(handler)
 
-*******************
- Set lock lifetime
-*******************
+***********************************
+ Configure legacy age-based expiry
+***********************************
 
-Only :class:`SoftFileLock <filelock.SoftFileLock>` honors ``lifetime``. A waiting process breaks a lock file whose
-modification time is older than ``lifetime`` seconds, even if the holder is still alive:
+Only :class:`SoftFileLock <filelock.SoftFileLock>` honors ``lifetime``. The value sets the marker age that permits
+removal. A waiter may enter after that age even while the previous holder continues its protected operation:
 
 .. code-block:: python
 
     from filelock import SoftFileLock
 
-    # Lock expires after 3600 seconds (1 hour)
+    # A waiter may remove this marker after one hour.
     lock = SoftFileLock("work.lock", lifetime=3600)
 
     with lock:
-        # Lock is held; a waiter may break it once the lock file is older than 1 hour
+        # This operation can overlap a successor after the marker expires.
         pass
 
-This helps distributed systems where a process might crash and leave a lock behind. After the lifetime expires, other
-processes can acquire it.
+Constructing or assigning a non-``None`` value emits
+:class:`SoftFileLockLifetimeWarning <filelock.SoftFileLockLifetimeWarning>`. Migrate to ``SoftFileLease`` when expiry
+is required or ``StrictSoftFileLock`` when unknown and stale claims must fail closed. Async callers use
+``AsyncSoftFileLease`` or ``AsyncStrictSoftFileLock``. ``lifetime=None`` disables age-based removal; same-host dead-PID
+and malformed-record recovery still apply.
 
-Native locks (:class:`FileLock <filelock.FileLock>`, :class:`UnixFileLock <filelock.UnixFileLock>`,
-:class:`WindowsFileLock <filelock.WindowsFileLock>`) ignore a non-``None`` ``lifetime`` and emit a warning. A kernel
-lock lives on the inode, so unlinking the pathname by age cannot revoke it, and a contender would lock a fresh inode
-while the holder is still live. Use ``SoftFileLock`` when you need age-based expiry.
+.. list-table:: ``lifetime`` behavior
+    :header-rows: 1
+
+    - - Backend and value
+      - Behavior
+      - Mutual-exclusion limit
+    - - ``SoftFileLock``, ``None``
+      - Disables age-based removal.
+      - Shared-marker recovery and forced breaking can still remove the marker.
+    - - ``SoftFileLock``, non-``None``
+      - Removes a marker after the configured age.
+      - A live holder may overlap its successor.
+    - - Native lock, non-``None``
+      - Emits a warning and ignores the value.
+      - Kernel lock ownership is unchanged.
+
+Native locks (:class:`UnixFileLock <filelock.UnixFileLock>` and
+:class:`WindowsFileLock <filelock.WindowsFileLock>`) ignore a non-``None`` value and emit a warning. The same is true
+when :class:`FileLock <filelock.FileLock>` selects one of those backends; on a build without ``fcntl``, ``FileLock`` may
+instead alias ``SoftFileLock``. A kernel lock lives on the inode, so pathname age cannot revoke it.
 
 **************************
  Cancel lock acquisition
@@ -726,18 +742,18 @@ cleanup after a close error.
  Fail closed instead of downgrading to soft
 ***********************************************
 
-On Unix, when the filesystem's ``flock`` returns ``ENOSYS`` (some network mounts), :class:`FileLock
-<filelock.FileLock>` switches to :class:`SoftFileLock <filelock.SoftFileLock>` semantics by default, trading
-kernel-enforced locking for cooperative existence locking. If your code needs kernel enforcement, pass
-``fallback_to_soft=False`` so the ``ENOSYS`` propagates instead of a silent downgrade to soft locking:
+On Unix, when ``flock`` returns ``ENOSYS``, :class:`UnixFileLock <filelock.UnixFileLock>` switches to
+:class:`SoftFileLock <filelock.SoftFileLock>` semantics by default. If the application requires the native backend,
+construct ``UnixFileLock`` with ``fallback_to_soft=False`` so ``ENOSYS`` propagates:
 
 .. code-block:: python
 
-    from filelock import FileLock
+    from filelock import UnixFileLock
 
-    lock = FileLock("work.lock", fallback_to_soft=False)
+    lock = UnixFileLock("work.lock", fallback_to_soft=False)
 
-It has no effect on Windows or :class:`SoftFileLock <filelock.SoftFileLock>`.
+This option does not change ``FileLock`` on a build where the alias is already ``SoftFileLock`` because ``fcntl`` is
+unavailable. It has no effect on Windows or an explicitly constructed ``SoftFileLock``.
 
 *********************************
  Keep the lock file on release

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -565,8 +565,12 @@ holder, the protected resource must be linearizable and fence on a monotonic gen
 
 Every contender for a path must agree on ``lease_duration``; one that disagrees raises
 :class:`LeaseSettingsMismatch <filelock.LeaseSettingsMismatch>` instead of applying its own expiry to a peer that never
-agreed to it. Native locks reject lease settings outright, because pathname age cannot revoke a kernel lock on an inode.
-Async callers use ``AsyncStrictSoftFileLock`` and ``AsyncSoftFileLease``.
+agreed to it. Native locks reject lease settings, because pathname age cannot revoke a kernel lock on an inode. Async
+callers use ``AsyncStrictSoftFileLock`` and ``AsyncSoftFileLease``.
+
+Windows refuses to rename or delete a file another process holds open, so a peer takes an expired claim there only once
+the previous holder's process exits and its handle closes. A holder that keeps running but stops refreshing keeps its
+marker on Windows, while Unix lets a peer reclaim it after ``lease_duration``.
 
 **Do not mix contracts on one path.** Both classes publish a protocol 2 record.
 :class:`SoftFileLock <filelock.SoftFileLock>` reads that record as malformed and evicts it once past its grace period,

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -534,6 +534,58 @@ library:
     handler = logging.StreamHandler()
     logging.getLogger("filelock").addHandler(handler)
 
+*******************************
+ Choose a soft-lock contract
+*******************************
+
+:class:`StrictSoftFileLock <filelock.StrictSoftFileLock>` never reclaims a marker. A malformed record, an owner on
+another host, a dead PID and an old marker all read as held, so acquisition waits rather than overlap a holder that may
+still be alive. A crashed holder leaves a marker no contender removes; clear it with
+:meth:`force_break <filelock.MarkerSoftFileLock.force_break>`, which voids mutual exclusion for whoever is still
+running.
+
+:class:`SoftFileLease <filelock.SoftFileLease>` trades exclusion for progress. The holder refreshes its claim, and a
+peer takes the marker once it is ``lease_duration`` seconds stale. The expired holder keeps running and keeps using
+whatever the lock protects, so a lease says who *should* be working, not who alone is. ``on_compromise`` fires when the
+claim is lost. :attr:`token <filelock.SoftFileLease.token>` names a claim but does not fence one: to reject a superseded
+holder, the protected resource must be linearizable and fence on a monotonic generation it controls.
+
+.. code-block:: python
+
+    from filelock import SoftFileLease, StrictSoftFileLock
+
+    with StrictSoftFileLock("work.lock", timeout=30):
+        pass  # no peer enters while this holder lives
+
+    def stop_working(compromise):
+        print("lost the claim:", compromise.reason)
+
+    with SoftFileLease("work.lock", lease_duration=60, on_compromise=stop_working):
+        pass  # a peer may enter 60s after the last refresh
+
+Every contender for a path must agree on ``lease_duration``; one that disagrees raises
+:class:`LeaseSettingsMismatch <filelock.LeaseSettingsMismatch>` instead of applying its own expiry to a peer that never
+agreed to it. Native locks reject lease settings outright, because pathname age cannot revoke a kernel lock on an inode.
+Async callers use ``AsyncStrictSoftFileLock`` and ``AsyncSoftFileLease``.
+
+**Do not mix contracts on one path.** Both classes publish a protocol 2 record.
+:class:`SoftFileLock <filelock.SoftFileLock>` reads that record as malformed and evicts it once past its grace period,
+so a legacy contender can delete a live strict marker or a live lease. Only these combinations hold:
+
+.. list-table:: Mutual exclusion between contenders
+    :header-rows: 1
+
+    - - Contenders on one path
+      - Holds?
+    - - ``StrictSoftFileLock`` with ``StrictSoftFileLock``
+      - Yes.
+    - - ``SoftFileLease`` with ``SoftFileLease``, same ``lease_duration``
+      - Until a claim expires; then the old holder overlaps its successor.
+    - - ``SoftFileLock`` with ``StrictSoftFileLock`` or ``SoftFileLease``
+      - No. The legacy contender evicts the protocol 2 marker.
+    - - ``StrictSoftFileLock`` with ``SoftFileLease``
+      - The lease waits out a strict holder, but a strict contender never reclaims an expired lease.
+
 ***********************************
  Configure legacy age-based expiry
 ***********************************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,7 @@ Choose the right lock for your use case:
     .. grid-item-card::
         **FileLock**
 
-        Platform-aware alias. Uses OS-level locking (``fcntl``/``LockFileEx``) with automatic fallback to soft locks.
+        Platform-aware alias. Selects a native backend where available and a soft marker otherwise.
 
         - ✓ Recommended default
         - ✓ Cancellable acquire
@@ -74,11 +74,11 @@ Choose the right lock for your use case:
     .. grid-item-card::
         **SoftFileLock**
 
-        File-existence based locking. Works on any filesystem including network mounts.
+        Cooperative file-existence marker. Verify shared-filesystem semantics before deployment.
 
-        - ✓ Network filesystems
-        - ✓ Stale detection
-        - ✓ Lifetime expiration, cancellable acquire
+        - ✓ No native locking API required
+        - ✓ Same-host PID inspection
+        - ✓ Optional age-based expiry, with overlap risk
 
     .. grid-item-card::
         **ReadWriteLock**
@@ -92,11 +92,11 @@ Choose the right lock for your use case:
     .. grid-item-card::
         **SoftReadWriteLock**
 
-        NFS and HPC-cluster reader/writer lock with TTL-based cross-host stale detection.
+        Reader/writer marker lease for tested shared filesystems.
 
-        - ✓ Works on NFS / Lustre / shared storage
-        - ✓ Cross-host stale detection via heartbeat
-        - ✓ Writer-preferring, starvation-free
+        - ✓ Heartbeat-based marker expiry
+        - ✓ Writer preference
+        - ✓ Explicit clock and filesystem requirements
         - ✓ Async via AsyncSoftReadWriteLock
 
     .. grid-item-card::
@@ -134,10 +134,10 @@ Choose the right lock for your use case:
     .. grid-item-card::
         **Other Platforms**
 
-        Automatic fallback to ``SoftFileLock``. Portable across all filesystems.
+        Automatic fallback to the cooperative ``SoftFileLock`` marker protocol.
 
-        - ✓ Full compatibility
-        - ✓ Network filesystems
+        - ✓ No native locking API required
+        - ✓ Usable where creation and cache behavior have been verified
 
 *******************
  Similar libraries

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -183,8 +183,9 @@ See :ref:`how-to:Use locks with multiple threads` for practical examples of cont
  Migrating from lockfile.PIDLockFile
 ***************************************
 
-If you're migrating from the deprecated `lockfile <https://pypi.org/project/lockfile/>`_ library, :class:`SoftFileLock <filelock.SoftFileLock>` is the
-direct replacement for ``PIDLockFile``. It writes the process ID to the lock file and can detect stale locks.
+If you're migrating from the deprecated `lockfile <https://pypi.org/project/lockfile/>`_ library,
+:class:`SoftFileLock <filelock.SoftFileLock>` is the direct replacement for ``PIDLockFile``. It writes the process ID to
+the lock file and can detect stale locks.
 
 .. code-block:: python
 
@@ -214,15 +215,14 @@ Key differences from ``PIDLockFile``:
 - Stale lock detection happens automatically on acquire (all platforms)
 - Supports context managers, reentrant locking, timeouts, and all other filelock features
 
-*************************************
- Reader/writer locks on a shared NFS
-*************************************
+*******************************************
+ Reader/writer locks on shared filesystems
+*******************************************
 
-If your lock file lives on a network filesystem (a slurm-mounted home directory, a Lustre cluster scratch space, or any
-NFS share), use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` rather than
-:class:`ReadWriteLock <filelock.ReadWriteLock>`. ``ReadWriteLock`` is SQLite-backed and unsafe on NFS.
-``SoftReadWriteLock`` is built on :class:`SoftFileLock <filelock.SoftFileLock>` primitives and handles cross-host stale detection via a
-background heartbeat thread.
+Keep SQLite-backed :class:`ReadWriteLock <filelock.ReadWriteLock>` on a local filesystem supported by the active SQLite
+VFS. On a shared filesystem, use :class:`SoftReadWriteLock <filelock.SoftReadWriteLock>` only after verifying exclusive
+creation, rename, unlink, timestamps, and cache visibility across participating hosts. Heartbeat expiry permits another
+holder to enter if an old process pauses and later resumes.
 
 .. code-block:: python
 
@@ -231,11 +231,11 @@ background heartbeat thread.
     rw = SoftReadWriteLock("/shared/nfs/work.lock")
 
     with rw.read_lock():
-        # Any number of processes on any host can be here at the same time.
+        # Cooperating readers can hold the lock together.
         data = open("/shared/nfs/data.json").read()
 
     with rw.write_lock():
-        # Exactly one process anywhere can be here. New readers wait behind a pending writer.
+        # New readers wait behind an observed writer marker.
         open("/shared/nfs/data.json", "w").write(new_data)
 
 While the lock is held, you will see a few sidecar files on disk next to ``work.lock``:
@@ -246,10 +246,9 @@ While the lock is held, you will see a few sidecar files on disk next to ``work.
     work.lock.write         # writer marker, exists while a writer is claiming or holding
     work.lock.readers/      # directory with one file per active reader
 
-A daemon heartbeat thread refreshes each marker's ``mtime`` every ``heartbeat_interval`` seconds (default 30).
-If a compute node crashes while holding a lock, any other node will evict the stale marker after
-``stale_threshold`` seconds of no refresh (default 90, following etcd's ``LeaseKeepAlive`` convention of
-``TTL / 3``). Both values are constructor arguments, so HPC deployments that hold locks for hours can raise them:
+A daemon heartbeat thread refreshes each marker's ``mtime`` every ``heartbeat_interval`` seconds. A peer may evict a
+marker after ``stale_threshold`` seconds without a refresh. Set the threshold above expected process and filesystem
+pauses, synchronize participating clocks, and fence protected writes if an expired process can resume:
 
 .. code-block:: python
 

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Final
 
 from ._api import AcquireReturnProxy, BaseFileLock, CloseErrorPolicy, ContextErrorPolicy
 from ._descriptor import lock_descriptor, unlock_descriptor
-from ._error import Timeout
+from ._error import SoftFileLockLifetimeWarning, Timeout
 
 if TYPE_CHECKING:
     from ._async_read_write import (
@@ -87,6 +87,7 @@ __all__ = [
     "FileLock",
     "ReadWriteLock",
     "SoftFileLock",
+    "SoftFileLockLifetimeWarning",
     "SoftReadWriteLock",
     "Timeout",
     "UnixFileLock",

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -12,9 +12,11 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Final
 
-from ._api import AcquireReturnProxy, BaseFileLock, CloseErrorPolicy, ContextErrorPolicy
+from ._api import AcquireReturnProxy, BaseFileLock, CloseErrorPolicy, ContextErrorPolicy, LockOptions
 from ._descriptor import lock_descriptor, unlock_descriptor
-from ._error import SoftFileLockLifetimeWarning, Timeout
+from ._error import LeaseSettingsMismatch, SoftFileLockLifetimeWarning, Timeout
+from ._lease import LeaseCompromise, SoftFileLease
+from ._marker import MarkerSoftFileLock, OwnerRecord
 
 if TYPE_CHECKING:
     from ._async_read_write import (
@@ -33,11 +35,14 @@ else:
 
 from ._soft import SoftFileLock
 from ._soft_rw import AsyncAcquireSoftReadWriteReturnProxy, AsyncSoftReadWriteLock, SoftReadWriteLock
+from ._strict import StrictSoftFileLock
 from ._unix import UnixFileLock, has_fcntl
 from ._windows import WindowsFileLock
 from .asyncio import (
     AsyncAcquireReturnProxy,
+    AsyncSoftFileLease,
     AsyncSoftFileLock,
+    AsyncStrictSoftFileLock,
     AsyncUnixFileLock,
     AsyncWindowsFileLock,
     BaseAsyncFileLock,
@@ -76,8 +81,10 @@ __all__ = [
     "AsyncAcquireSoftReadWriteReturnProxy",
     "AsyncFileLock",
     "AsyncReadWriteLock",
+    "AsyncSoftFileLease",
     "AsyncSoftFileLock",
     "AsyncSoftReadWriteLock",
+    "AsyncStrictSoftFileLock",
     "AsyncUnixFileLock",
     "AsyncWindowsFileLock",
     "BaseAsyncFileLock",
@@ -85,10 +92,17 @@ __all__ = [
     "CloseErrorPolicy",
     "ContextErrorPolicy",
     "FileLock",
+    "LeaseCompromise",
+    "LeaseSettingsMismatch",
+    "LockOptions",
+    "MarkerSoftFileLock",
+    "OwnerRecord",
     "ReadWriteLock",
+    "SoftFileLease",
     "SoftFileLock",
     "SoftFileLockLifetimeWarning",
     "SoftReadWriteLock",
+    "StrictSoftFileLock",
     "Timeout",
     "UnixFileLock",
     "WindowsFileLock",

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -17,7 +17,7 @@ from threading import Condition, RLock, get_ident, local
 from typing import TYPE_CHECKING, Final, Literal, NoReturn, TypeVar, cast
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
-from ._error import Timeout
+from ._error import SoftFileLockLifetimeWarning, Timeout
 from ._util import break_lock_file
 
 #: No explicit file permission mode was passed. Lock files then open with 0o666 so umask and default ACLs pick
@@ -335,7 +335,13 @@ class FileLockMeta(ABCMeta):
         **kwargs: _ExtraValue,
     ) -> _T:
         _ensure_current_process()
-        lifetime = _resolve_lifetime(lifetime, supported=cls._lifetime_supported, cls_name=cls.__name__)
+        lifetime = _resolve_lifetime(
+            lifetime,
+            supported=cls._lifetime_supported,
+            replacements=cls._lifetime_replacements,
+            cls_name=cls.__name__,
+            stacklevel=cls._constructor_lifetime_warning_stacklevel,
+        )
         # Validate before building the instance: a raise inside __init__ would leave a half-constructed object whose
         # __del__ then trips over the missing context.
         context_error_policy = _resolve_context_error_policy(context_error_policy)
@@ -474,15 +480,22 @@ class _InitParameterModel:
     default_params: dict[str, inspect.Parameter]
 
 
-def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str) -> float | None:
+def _resolve_lifetime(
+    lifetime: float | None,
+    *,
+    supported: bool,
+    replacements: tuple[str, str] | None,
+    cls_name: str,
+    stacklevel: int,
+) -> float | None:
     """
     Validate ``lifetime`` and drop a value the backend cannot honor.
 
     ``lifetime`` is a deliberate age-based lease: a lock file older than ``lifetime`` is broken even while its holder is
-    still alive. That is only safe for existence locks (:class:`SoftFileLock`), where breaking means unlinking a
-    pathname the protocol already treats as reclaimable. A native OS lock lives on the inode, so unlinking the pathname
-    by age cannot revoke the kernel lock; a contender would lock a fresh inode and overlap the live holder (#590).
-    Ignore the request with a warning rather than accept a setting that breaks mutual exclusion.
+    still alive. Existence locks (:class:`SoftFileLock`) implement that behavior by unlinking a reclaimable pathname,
+    which can overlap a live holder. A native OS lock lives on the inode, so unlinking the pathname by age cannot revoke
+    the kernel lock; a contender would lock a fresh inode and overlap the live holder (#590). Ignore the request with a
+    warning rather than accept a setting that breaks mutual exclusion.
     """
     if lifetime is not None:
         if isinstance(lifetime, bool) or not isinstance(lifetime, (int, float)):
@@ -495,9 +508,17 @@ def _resolve_lifetime(lifetime: float | None, *, supported: bool, cls_name: str)
         warnings.warn(
             f"lifetime is ignored for {cls_name}: a native OS lock cannot be broken safely by file age; "
             f"only SoftFileLock supports lifetime-based expiry",
-            stacklevel=3,
+            stacklevel=stacklevel,
         )
         return None
+    if lifetime is not None and replacements is not None:
+        strict_lock, lease = replacements
+        warnings.warn(
+            f"{cls_name}(lifetime=...) uses age-based expiry and can overlap a live holder; "
+            f"use {lease} for expiry or {strict_lock} for fail-closed locking",
+            SoftFileLockLifetimeWarning,
+            stacklevel=stacklevel,
+        )
     return lifetime
 
 
@@ -554,9 +575,9 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     """
     Abstract base class for a file lock object.
 
-    Provides a reentrant, cross-process exclusive lock backed by OS-level primitives. Subclasses implement the actual
-    locking mechanism (:class:`UnixFileLock <filelock.UnixFileLock>`, :class:`WindowsFileLock
-    <filelock.WindowsFileLock>`, :class:`SoftFileLock <filelock.SoftFileLock>`).
+    Provides the common reentrant API and state management. Subclasses implement the locking mechanism
+    (:class:`UnixFileLock <filelock.UnixFileLock>`, :class:`WindowsFileLock <filelock.WindowsFileLock>`,
+    :class:`SoftFileLock <filelock.SoftFileLock>`).
 
     """
 
@@ -570,6 +591,12 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     #: Whether an age-based :attr:`lifetime` lease may break this lock. Only existence locks set it (they reclaim by
     #: unlinking a pathname); native OS locks leave it ``False`` since a kernel lock cannot be revoked by file age.
     _lifetime_supported: bool = False
+
+    #: Strict-lock and lease replacements for a backend with legacy age-based expiry.
+    _lifetime_replacements: tuple[str, str] | None = None
+
+    #: Async construction adds one metaclass frame before lifetime validation.
+    _constructor_lifetime_warning_stacklevel: int = 3
 
     #: Whether :attr:`preserve_lock_file` may be ``True``. Native locks keep the pathname on release, so they support
     #: it; existence locks unlink their marker to release and reject it.
@@ -632,10 +659,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             same object around.
         :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback value
             in the acquire method, if no poll_interval value (``None``) is given.
-        :param lifetime: for :class:`SoftFileLock`, the maximum time in seconds a lock may be held before it expires: a
-            waiting process breaks a lock file whose modification time is older than ``lifetime`` seconds, even if the
-            holder is still alive. ``None`` (the default) means locks never expire. Native OS locks (:class:`FileLock`)
-            cannot be revoked by file age and ignore a non-``None`` ``lifetime`` with a warning.
+        :param lifetime: for :class:`SoftFileLock`, the age in seconds after which a waiting process may delete the
+            marker, even while its holder remains alive. This legacy expiry mode does not provide strict mutual
+            exclusion. ``None`` (the default) disables age-based expiry. Native OS locks (:class:`FileLock`) cannot be
+            revoked by file age and ignore a non-``None`` ``lifetime`` with a warning.
         :param context_error_policy: how a context manager reconciles a failure in its body with a failure while
             releasing on exit. ``"chain"`` (the default) keeps Python's behavior: the release error propagates with the
             body error in its ``__context__``. ``"group"`` raises a :class:`BaseExceptionGroup` holding the body error
@@ -833,7 +860,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     @property
     def lifetime(self) -> float | None:
         """
-        The lock lifetime in seconds, or ``None`` if the lock never expires.
+        The soft marker age in seconds that permits expiry, or ``None`` to disable age-based expiry.
+
+        A non-``None`` value permits a waiter to enter while the previous holder remains active, so it does not provide
+        strict mutual exclusion. Native locks ignore the value with a warning.
 
         .. versionadded:: 3.24.0
 
@@ -843,7 +873,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     @lifetime.setter
     def lifetime(self, value: float | None) -> None:
         """
-        Change the lock lifetime.
+        Change the legacy age-based expiry threshold.
 
         :param value: the new value in seconds, or ``None`` to disable expiration
 
@@ -852,7 +882,11 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
 
         """
         self._context.lifetime = _resolve_lifetime(
-            value, supported=self._lifetime_supported, cls_name=type(self).__name__
+            value,
+            supported=self._lifetime_supported,
+            replacements=self._lifetime_replacements,
+            cls_name=type(self).__name__,
+            stacklevel=3,
         )
 
     @property

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import count, starmap
 from threading import Condition, RLock, get_ident, local
-from typing import TYPE_CHECKING, Final, Literal, NoReturn, TypeVar, cast
+from typing import TYPE_CHECKING, Final, Literal, NoReturn, TypedDict, TypeVar, cast
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
 from ._error import SoftFileLockLifetimeWarning, Timeout
@@ -72,6 +72,23 @@ _ExtraValue = TypeVar("_ExtraValue")
 _MarkerValue = TypeVar("_MarkerValue")
 _SubclassValue = TypeVar("_SubclassValue")
 _LockInitValue = float | int | bool | str | None | Callable[[int], None]
+
+
+class LockOptions(TypedDict, total=False):
+    """Every option the metaclass forwards, so a subclass adding its own can still type what it passes through."""
+
+    timeout: float
+    mode: int
+    thread_local: bool
+    blocking: bool
+    is_singleton: bool
+    poll_interval: float
+    lifetime: float | None
+    context_error_policy: ContextErrorPolicy
+    close_error_policy: CloseErrorPolicy
+    fallback_to_soft: bool
+    preserve_lock_file: bool
+    on_acquired: Callable[[int], None] | None
 
 
 def _exception_group_cls() -> type[BaseException]:
@@ -339,6 +356,7 @@ class FileLockMeta(ABCMeta):
             lifetime,
             supported=cls._lifetime_supported,
             replacements=cls._lifetime_replacements,
+            reason=cls._lifetime_unsupported_reason,
             cls_name=cls.__name__,
             stacklevel=cls._constructor_lifetime_warning_stacklevel,
         )
@@ -480,11 +498,12 @@ class _InitParameterModel:
     default_params: dict[str, inspect.Parameter]
 
 
-def _resolve_lifetime(
+def _resolve_lifetime(  # noqa: PLR0913
     lifetime: float | None,
     *,
     supported: bool,
     replacements: tuple[str, str] | None,
+    reason: str,
     cls_name: str,
     stacklevel: int,
 ) -> float | None:
@@ -506,8 +525,7 @@ def _resolve_lifetime(
             raise ValueError(msg)
     if lifetime is not None and not supported:
         warnings.warn(
-            f"lifetime is ignored for {cls_name}: a native OS lock cannot be broken safely by file age; "
-            f"only SoftFileLock supports lifetime-based expiry",
+            f"lifetime is ignored for {cls_name}: {reason}; only SoftFileLock supports lifetime-based expiry",
             stacklevel=stacklevel,
         )
         return None
@@ -594,6 +612,9 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
 
     #: Strict-lock and lease replacements for a backend with legacy age-based expiry.
     _lifetime_replacements: tuple[str, str] | None = None
+
+    #: Why a backend that refuses ``lifetime`` cannot honor it, named in the warning that drops the value.
+    _lifetime_unsupported_reason: str = "a native OS lock cannot be broken safely by file age"
 
     #: Async construction adds one metaclass frame before lifetime validation.
     _constructor_lifetime_warning_stacklevel: int = 3
@@ -885,6 +906,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             value,
             supported=self._lifetime_supported,
             replacements=self._lifetime_replacements,
+            reason=self._lifetime_unsupported_reason,
             cls_name=type(self).__name__,
             stacklevel=3,
         )
@@ -1700,6 +1722,7 @@ __all__ = [
     "ContextErrorPolicy",
     "FileLockContext",
     "FileLockMeta",
+    "LockOptions",
     "_append_exception_context",
     "_canonical",
     "_ensure_current_process",

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -24,6 +24,11 @@ class Timeout(TimeoutError):  # noqa: N818
         return self._lock_file
 
 
+class SoftFileLockLifetimeWarning(DeprecationWarning):
+    """The configured soft-lock lifetime permits overlapping live holders after expiry."""
+
+
 __all__ = [
+    "SoftFileLockLifetimeWarning",
     "Timeout",
 ]

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -28,7 +28,12 @@ class SoftFileLockLifetimeWarning(DeprecationWarning):
     """The configured soft-lock lifetime permits overlapping live holders after expiry."""
 
 
+class LeaseSettingsMismatch(ValueError):  # noqa: N818
+    """A lease contender disagrees with the published claim about how long the lease lasts."""
+
+
 __all__ = [
+    "LeaseSettingsMismatch",
     "SoftFileLockLifetimeWarning",
     "Timeout",
 ]

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -55,6 +55,10 @@ class SoftFileLease(MarkerSoftFileLock):
     different duration raises :class:`LeaseSettingsMismatch <filelock.LeaseSettingsMismatch>` rather than apply its own
     expiry to a peer that never agreed to it.
 
+    Expiry reclaims less on Windows, which refuses to rename or delete a file another process holds open. A peer there
+    takes an expired claim only once the previous holder's process exits and its handle closes; a holder that lives on
+    but stops refreshing keeps the marker. Unix reclaims the marker either way.
+
     ``on_compromise`` fires from the heartbeat thread when a refresh fails, or when the marker vanishes or names another
     owner. The holder should stop touching the protected resource when it runs. Because it runs on that thread, a
     ``release()`` inside it only takes effect when the lease was built with ``thread_local=False``; the default
@@ -176,11 +180,14 @@ class SoftFileLease(MarkerSoftFileLock):
                 f"{self._lease_duration!r}s; every contender for a path must agree on lease_duration"
             )
             raise LeaseSettingsMismatch(msg)
-        if owner.hostname == socket.gethostname() and not self._is_process_alive(owner.pid):
-            break_lock_file(self.lock_file, mtime, ino)
-            return
-        if time.time() - mtime >= self._lease_duration:
-            break_lock_file(self.lock_file, mtime, ino)
+        # A break can fail for reasons a contender must ride out rather than raise on: a peer broke the marker first,
+        # or Windows refuses to rename a file whose holder still has it open. Poll again instead.
+        with suppress(OSError):
+            if owner.hostname == socket.gethostname() and not self._is_process_alive(owner.pid):
+                break_lock_file(self.lock_file, mtime, ino)
+                return
+            if time.time() - mtime >= self._lease_duration:
+                break_lock_file(self.lock_file, mtime, ino)
 
     def _read_peer(self) -> tuple[OwnerRecord, float, int] | None:
         with suppress(OSError, ValueError):

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import os
+import secrets
+import socket
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from threading import Event, Thread, current_thread
+from typing import TYPE_CHECKING, Literal
+
+from ._error import LeaseSettingsMismatch
+from ._marker import MarkerSoftFileLock, OwnerMode, OwnerRecord, parse_marker
+from ._soft import _read_lock_file
+from ._util import break_lock_file, touch
+
+if TYPE_CHECKING:
+    import sys
+    from collections.abc import Callable
+
+    from ._api import LockOptions
+
+    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+        from typing import Unpack
+    else:  # pragma: no cover (<py311)
+        from typing_extensions import Unpack
+
+CompromiseReason = Literal["marker-missing", "owner-changed", "refresh-failed"]
+
+
+@dataclass(frozen=True)
+class LeaseCompromise:
+    """Why a held lease stopped being this process's to hold."""
+
+    lock_file: str
+    token: str
+    reason: CompromiseReason
+    error: OSError | None = None
+
+
+class SoftFileLease(MarkerSoftFileLock):
+    """
+    Existence lock whose claim expires, so a peer may take it while the previous holder still runs.
+
+    A lease trades mutual exclusion for progress. The holder publishes a claim and refreshes it every
+    ``heartbeat_interval`` seconds; a contender takes the marker once it is ``lease_duration`` seconds stale. Nothing
+    stops the expired holder: it keeps running, and it keeps using whatever the lock protects. Treat the lease as a hint
+    about who *should* be working, not as a guarantee that only one worker is.
+
+    To make a protected resource reject a superseded holder, that resource must be linearizable and must fence on a
+    monotonic generation it controls. :attr:`token` names a claim; it does not fence one. Where overlap is unacceptable,
+    use :class:`StrictSoftFileLock <filelock.StrictSoftFileLock>` instead.
+
+    Every contender for a path must agree on ``lease_duration``. A contender that finds a claim published under a
+    different duration raises :class:`LeaseSettingsMismatch <filelock.LeaseSettingsMismatch>` rather than apply its own
+    expiry to a peer that never agreed to it.
+
+    ``on_compromise`` fires from the heartbeat thread when a refresh fails, or when the marker vanishes or names another
+    owner. The holder should stop touching the protected resource when it runs. Because it runs on that thread, a
+    ``release()`` inside it only takes effect when the lease was built with ``thread_local=False``; the default
+    thread-local context hides the claim from every thread but the one that acquired it, so the release does nothing.
+    Signal the acquiring thread instead when the context stays thread-local.
+
+    .. versionadded:: 3.30.0
+
+    """
+
+    _owner_mode: OwnerMode = "lease"
+
+    #: lease_duration replaces the legacy age-based lifetime, so accepting both would give one lock two expiry clocks.
+    _lifetime_supported: bool = False
+    _lifetime_unsupported_reason: str = "lease_duration sets when a lease expires"
+
+    def __init__(
+        self,
+        lock_file: str | os.PathLike[str],
+        *,
+        lease_duration: float = 30.0,
+        heartbeat_interval: float | None = None,
+        on_compromise: Callable[[LeaseCompromise], None] | None = None,
+        **kwargs: Unpack[LockOptions],
+    ) -> None:
+        """
+        Create a lease.
+
+        :param lease_duration: seconds of marker staleness after which a contender may take the claim. Every contender
+            for the path must pass the same value.
+        :param heartbeat_interval: seconds between refreshes. Defaults to a third of ``lease_duration``, leaving room
+            for two missed refreshes before a peer may take the claim. Must be shorter than ``lease_duration``.
+        :param on_compromise: called from the heartbeat thread with a :class:`LeaseCompromise` when the claim is lost.
+        :param kwargs: every other :class:`BaseFileLock <filelock.BaseFileLock>` option, ``timeout`` and ``mode`` among
+            them. The metaclass passes them all by keyword, and taking them here lets
+            :class:`AsyncSoftFileLease <filelock.AsyncSoftFileLease>` add the async plumbing a fixed signature would
+            hide.
+
+        """
+        if lease_duration <= 0:
+            msg = f"lease_duration must be positive, got {lease_duration!r}"
+            raise ValueError(msg)
+        if heartbeat_interval is None:
+            heartbeat_interval = lease_duration / 3
+        if not 0 < heartbeat_interval < lease_duration:
+            msg = f"heartbeat_interval must be positive and below lease_duration, got {heartbeat_interval!r}"
+            raise ValueError(msg)
+        super().__init__(lock_file, **kwargs)
+        self._lease_duration = lease_duration
+        self._heartbeat_interval = heartbeat_interval
+        self._on_compromise = on_compromise
+        self._token: str | None = None
+        self._compromise: LeaseCompromise | None = None
+        self._heartbeat_stop = Event()
+        self._heartbeat: Thread | None = None
+
+    @property
+    def lease_duration(self) -> float:
+        """The staleness in seconds after which a contender may take this claim."""
+        return self._lease_duration
+
+    @property
+    def token(self) -> str | None:
+        """
+        The token naming the claim this process published.
+
+        :returns: the token while the lease is held, ``None`` otherwise. It identifies a claim; it does not fence one.
+
+        """
+        return self._token
+
+    @property
+    def compromise(self) -> LeaseCompromise | None:
+        """
+        The loss of claim the heartbeat observed.
+
+        :returns: the :class:`LeaseCompromise`, or ``None`` while the claim still holds
+
+        """
+        return self._compromise
+
+    def _acquire(self) -> None:
+        self._stop_heartbeat()  # no earlier claim's heartbeat outlives the acquisition of the next one
+        self._token = secrets.token_hex(16)
+        self._compromise = None
+        super()._acquire()
+        # The context is thread-local by default, so the heartbeat thread cannot read the descriptor this one just
+        # published. Hand it the fd and the inode it verified instead.
+        if (fd := self._context.lock_file_fd) is not None and (
+            identity := self._context.lock_file_fd_identity
+        ) is not None:
+            self._start_heartbeat(fd, identity, self._token)
+
+    def _release(self) -> None:
+        self._stop_heartbeat()
+        self._token = None
+        super()._release()
+
+    def _published_record(self) -> OwnerRecord:
+        return OwnerRecord(
+            pid=os.getpid(),
+            hostname=socket.gethostname(),
+            mode="lease",
+            token=self._token,
+            lease_duration=self._lease_duration,
+        )
+
+    def _try_break_stale_lock(self) -> None:
+        if (peer := self._read_peer()) is None:
+            return
+        owner, mtime, ino = peer
+        # A malformed, legacy or strict record is never reclaimed by age: only a peer that published a lease agreed to
+        # be superseded by one. Raise the mismatch outside the read so the suppression cannot swallow it.
+        if owner.mode != "lease":
+            return
+        if owner.lease_duration != self._lease_duration:
+            msg = (
+                f"{self.lock_file} holds a lease of {owner.lease_duration!r}s but this contender configured "
+                f"{self._lease_duration!r}s; every contender for a path must agree on lease_duration"
+            )
+            raise LeaseSettingsMismatch(msg)
+        if owner.hostname == socket.gethostname() and not self._is_process_alive(owner.pid):
+            break_lock_file(self.lock_file, mtime, ino)
+            return
+        if time.time() - mtime >= self._lease_duration:
+            break_lock_file(self.lock_file, mtime, ino)
+
+    def _read_peer(self) -> tuple[OwnerRecord, float, int] | None:
+        with suppress(OSError, ValueError):
+            content, mtime, ino = _read_lock_file(self.lock_file)
+            if (owner := parse_marker(content)) is not None:
+                return owner, mtime, ino
+        return None
+
+    def _start_heartbeat(self, fd: int, identity: tuple[int, int], token: str) -> None:
+        self._heartbeat_stop = Event()
+        self._heartbeat = Thread(
+            target=self._refresh_until_stopped,
+            args=(fd, identity, token),
+            name=f"filelock-lease-{os.getpid()}",
+            daemon=True,
+        )
+        self._heartbeat.start()
+
+    def _stop_heartbeat(self) -> None:
+        if (heartbeat := self._heartbeat) is None:
+            return
+        self._heartbeat_stop.set()
+        self._heartbeat = None
+        # on_compromise runs on the heartbeat thread and may release the lease, which lands back here.
+        if heartbeat is not current_thread():
+            heartbeat.join(timeout=self._heartbeat_interval)
+
+    def _refresh_until_stopped(self, fd: int, identity: tuple[int, int], token: str) -> None:
+        # The loop ends at the first loss of the claim, so the holder hears about it once.
+        while not self._heartbeat_stop.wait(self._heartbeat_interval):
+            if not self._refresh_claim(fd, identity, token):
+                return
+
+    def _refresh_claim(self, fd: int, identity: tuple[int, int], token: str) -> bool:
+        try:
+            st = os.lstat(self.lock_file)
+        except OSError as error:
+            self._report_compromise("marker-missing", error, token)
+            return False
+        # A peer that took the expired claim replaced the marker, so the pathname now names its inode, not ours.
+        if (st.st_dev, st.st_ino) != identity:
+            self._report_compromise("owner-changed", None, token)
+            return False
+        try:
+            touch(self.lock_file, fd=fd)
+        except OSError as error:
+            self._report_compromise("refresh-failed", error, token)
+            return False
+        return True
+
+    def _report_compromise(self, reason: CompromiseReason, error: OSError | None, token: str) -> None:
+        # The token is the one this thread published, not self._token, which a release may already have cleared.
+        self._compromise = LeaseCompromise(lock_file=self.lock_file, token=token, reason=reason, error=error)
+        if self._on_compromise is not None:
+            self._on_compromise(self._compromise)
+
+
+__all__ = [
+    "CompromiseReason",
+    "LeaseCompromise",
+    "SoftFileLease",
+]

--- a/src/filelock/_marker.py
+++ b/src/filelock/_marker.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import os
+import socket
+from contextlib import suppress
+from typing import Final, Literal, NamedTuple
+
+from ._soft import SoftFileLock, _read_lock_file
+from ._util import write_all
+
+#: Protocol 1 is the legacy ``<pid>\n<hostname>\n[<creation_time>\n]`` marker that :class:`SoftFileLock` still writes.
+#: Protocol 2 carries the owner mode and the lease claim. A protocol 1 reader treats a protocol 2 marker as malformed
+#: and evicts it after its grace period, so the two never guarantee mutual exclusion against each other.
+_PROTOCOL: Final[str] = "filelock/2"
+
+_MAX_PID: Final[int] = 2**31 - 1
+
+OwnerMode = Literal["strict", "lease"]
+
+
+class OwnerRecord(NamedTuple):
+    """The owner published in a protocol 2 marker."""
+
+    pid: int
+    hostname: str
+    mode: OwnerMode
+    token: str | None = None
+    lease_duration: float | None = None
+
+
+class MarkerSoftFileLock(SoftFileLock):
+    """An existence lock whose marker carries a protocol 2 owner record."""
+
+    #: Filled in by each mode so the published record states the contract its holder acquired under.
+    _owner_mode: OwnerMode
+
+    @property
+    def owner(self) -> OwnerRecord | None:
+        """
+        The owner named by the marker on disk.
+
+        :returns: the published record, or ``None`` when no marker exists or its record is malformed or protocol 1
+
+        """
+        return self._read_owner()
+
+    @property
+    def pid(self) -> int | None:
+        """
+        The PID of the process holding this lock, read from the marker.
+
+        :returns: the PID, or ``None`` when no marker exists or its record is unreadable
+
+        """
+        return None if (owner := self._read_owner()) is None else owner.pid
+
+    @property
+    def is_lock_held_by_us(self) -> bool:
+        """
+        Whether the marker on disk names this process.
+
+        :returns: ``True`` when the marker's PID and hostname match this process
+
+        """
+        owner = self._read_owner()
+        return owner is not None and owner.pid == os.getpid() and owner.hostname == socket.gethostname()
+
+    def force_break(self) -> None:
+        """
+        Remove the marker whoever holds it, so a later contender can acquire.
+
+        Forced breaking voids mutual exclusion: the previous holder keeps running and keeps using whatever the lock
+        protects. Reserve it for an operator clearing a marker whose holder is known to be gone.
+        """
+        self.break_lock()
+
+    def _read_owner(self) -> OwnerRecord | None:
+        with suppress(OSError, ValueError):
+            return parse_marker(_read_lock_file(self.lock_file)[0])
+        return None
+
+    def _write_lock_info(self, fd: int) -> None:
+        write_all(fd, encode_marker(self._published_record()))
+
+    def _published_record(self) -> OwnerRecord:
+        return OwnerRecord(pid=os.getpid(), hostname=socket.gethostname(), mode=self._owner_mode)
+
+
+def encode_marker(record: OwnerRecord) -> bytes:
+    """Render an owner record as the bytes a protocol 2 marker holds."""
+    lines = [_PROTOCOL, f"pid={record.pid}", f"host={record.hostname}", f"mode={record.mode}"]
+    if record.token is not None:
+        lines.append(f"token={record.token}")
+    if record.lease_duration is not None:
+        lines.append(f"duration={record.lease_duration!r}")
+    return "".join(f"{line}\n" for line in lines).encode()
+
+
+def parse_marker(content: str | None) -> OwnerRecord | None:
+    """Return the owner a protocol 2 marker names, or ``None`` when the record is malformed or protocol 1."""
+    if not content or not (lines := content.strip().splitlines()) or lines[0] != _PROTOCOL:
+        return None
+    fields: dict[str, str] = {}
+    for line in lines[1:]:
+        key, separator, value = line.partition("=")
+        if not separator:
+            return None
+        fields[key] = value
+    return _build_record(fields)
+
+
+def _build_record(fields: dict[str, str]) -> OwnerRecord | None:
+    mode: OwnerMode
+    # An unknown key is a field a newer filelock published, so ignore it rather than read the record as malformed.
+    if (published := fields.get("mode")) == "strict":
+        mode = "strict"
+    elif published == "lease":
+        mode = "lease"
+    else:
+        return None
+    hostname = fields.get("host")
+    if not hostname or "pid" not in fields:
+        return None
+    try:
+        pid = int(fields["pid"])
+        duration = float(fields["duration"]) if "duration" in fields else None
+    except ValueError:
+        return None
+    if not 1 <= pid <= _MAX_PID:
+        return None
+    token = fields.get("token")
+    if mode == "lease" and (token is None or duration is None or duration <= 0):
+        return None
+    return OwnerRecord(pid=pid, hostname=hostname, mode=mode, token=token, lease_duration=duration)
+
+
+__all__ = [
+    "MarkerSoftFileLock",
+    "OwnerMode",
+    "OwnerRecord",
+    "encode_marker",
+    "parse_marker",
+]

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -42,20 +42,25 @@ _UNLINK_MAX_RETRIES: Final[int] = 10
 
 class SoftFileLock(BaseFileLock):
     """
-    Portable file lock based on file existence.
+    Cooperative file lock based on a shared existence marker.
 
     Unlike :class:`UnixFileLock <filelock.UnixFileLock>` and :class:`WindowsFileLock <filelock.WindowsFileLock>`, this
     lock does not use OS-level locking primitives. Instead, it creates the lock file with ``O_CREAT | O_EXCL`` and
-    treats its existence as the lock indicator. This makes it work on any filesystem but leaves stale lock files behind
-    if the process crashes without releasing the lock.
+    treats its existence as the lock indicator. The filesystem must provide coherent exclusive creation and directory
+    updates to each participating process. A crash can leave the marker behind.
 
-    To mitigate stale locks, the lock file contains the PID and hostname of the holding process. On contention, if the
-    holder is on the same host and its PID no longer exists, the stale lock is broken automatically.
+    The marker contains the holder's PID and hostname. A contender may remove it when it can no longer find a same-host
+    process with that PID. A configured :attr:`~filelock.BaseFileLock.lifetime` also permits removal based on marker
+    age, including while the holder remains alive. Age-based expiry can overlap protected operations and does not
+    provide strict mutual exclusion.
 
     """
 
     #: Existence locks reclaim by unlinking a pathname, so an age-based lease may break one; a native inode lock cannot.
     _lifetime_supported: bool = True
+
+    #: Age-based expiry preserves historical behavior but does not provide strict mutual exclusion.
+    _lifetime_replacements: tuple[str, str] | None = ("StrictSoftFileLock", "SoftFileLease")
 
     #: An existence lock unlinks its marker to release, so it cannot promise to keep the pathname.
     _preserve_lock_file_supported: bool = False

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -175,12 +175,11 @@ class SoftFileLock(BaseFileLock):
             _KERNEL32.CloseHandle(handle)
         return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
 
-    @staticmethod
-    def _write_lock_info(fd: int) -> None:
+    def _write_lock_info(self, fd: int) -> None:
         # No suppression: a write failure must reach the acquisition rollback so it never publishes a half-written
         # marker as held state.
         info = f"{os.getpid()}\n{socket.gethostname()}\n"
-        if sys.platform == "win32" and (ct := SoftFileLock._get_process_creation_time(os.getpid())) is not None:
+        if sys.platform == "win32" and (ct := self._get_process_creation_time(os.getpid())) is not None:
             info += f"{ct}\n"
         write_all(fd, info.encode())
 

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -31,7 +31,7 @@ from filelock._api import (
 )
 from filelock._error import Timeout
 from filelock._soft import SoftFileLock
-from filelock._util import ensure_directory_exists, write_all
+from filelock._util import ensure_directory_exists, touch, write_all
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -42,11 +42,6 @@ _BREAK_SUFFIX: Final[str] = ".break"
 _MAX_MARKER_SIZE: Final[int] = 1024
 _O_NOFOLLOW: Final[int] = getattr(os, "O_NOFOLLOW", 0)
 _O_NONBLOCK: Final[int] = getattr(os, "O_NONBLOCK", 0)
-# Retargeting os.utime to an open fd lets the heartbeat refresh the exact inode it just verified instead of
-# re-resolving the path; Windows read-only handles cannot set times that way, so keep it Unix-only.
-_SUPPORTS_UTIME_FD: Final[bool] = sys.platform != "win32" and os.utime in os.supports_fd
-# os.utime follows symlinks unless told not to; not every platform can refuse the follow, so probe support.
-_SUPPORTS_UTIME_NOFOLLOW: Final[bool] = os.utime in os.supports_follow_symlinks
 # dirfd-relative I/O is a Unix-only optimization; Windows cannot ``os.open()`` a directory at all, and
 # its ``os`` module skips dir_fd support entirely. When disabled, callers fall back to full-path ops.
 _SUPPORTS_DIR_FD: Final[bool] = sys.platform != "win32" and os.open in os.supports_dir_fd
@@ -569,7 +564,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             if info is None or not hmac.compare_digest(info.token, token):
                 return False
             with suppress(OSError):
-                _touch(self._paths.write, fd=fd)
+                touch(self._paths.write, fd=fd)
             return True
         finally:
             os.close(fd)
@@ -713,7 +708,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             # kill the heartbeat thread: the read above just confirmed the marker is still ours, so swallow the
             # error and retry on the next tick rather than letting the lease lapse while we still hold the lock.
             with suppress(OSError):
-                _touch(marker_name, fd=fd)
+                touch(marker_name, fd=fd)
             return True
         finally:
             os.close(fd)
@@ -893,17 +888,6 @@ def _same_file(name: str, identity: tuple[int, int], *, dir_fd: int | None) -> b
     except OSError:
         return False
     return (st.st_dev, st.st_ino) == identity
-
-
-def _touch(name: str, *, fd: int | None = None) -> None:
-    # Prefer the already-open, already-verified fd so a peer that swaps a symlink or a different file in at the
-    # path after our O_NOFOLLOW read cannot redirect the touch: utime then targets the inode behind the fd.
-    # Where the platform cannot utime an fd, fall back to a path-based touch that still refuses to follow a
-    # symlink where supported, matching the O_NOFOLLOW reads used elsewhere here.
-    if fd is not None and _SUPPORTS_UTIME_FD:
-        os.utime(fd, None)
-        return
-    os.utime(name, None, follow_symlinks=not _SUPPORTS_UTIME_NOFOLLOW)
 
 
 def _file_exists(path: str) -> bool:

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from ._marker import MarkerSoftFileLock, OwnerMode
+
+
+class StrictSoftFileLock(MarkerSoftFileLock):
+    """
+    Fail-closed existence lock: a marker this process did not publish always means contention.
+
+    :class:`SoftFileLock <filelock.SoftFileLock>` reclaims a marker whose holder it cannot find, and reclaims one by age
+    when :attr:`~filelock.BaseFileLock.lifetime` is set. Both let a contender enter while the previous holder keeps
+    running. This lock never reclaims. A malformed record, an unreadable record, an owner on another host, a dead PID
+    and an old marker all read as held, so acquisition waits or times out instead of overlapping a holder that may still
+    be alive.
+
+    A crashed holder therefore leaves a marker that no contender removes. Clear it with
+    :meth:`MarkerSoftFileLock.force_break <filelock.MarkerSoftFileLock.force_break>`, which states its own loss of
+    guarantee, once an operator knows the holder is gone.
+
+    The published record is protocol 2. A :class:`SoftFileLock <filelock.SoftFileLock>` contender reads it as malformed
+    and evicts it, so the two classes do not exclude each other; run one contract across all contenders for a path.
+
+    .. versionadded:: 3.30.0
+
+    """
+
+    _owner_mode: OwnerMode = "strict"
+
+    #: Age-based expiry is what this lock exists to refuse, so it drops lifetime rather than honor it.
+    _lifetime_supported: bool = False
+    _lifetime_unsupported_reason: str = "a strict lock never reclaims a marker by age"
+
+    def _try_break_stale_lock(self) -> None:
+        """Leave the marker alone: under a strict contract every existing marker is a live holder."""
+
+
+__all__ = [
+    "StrictSoftFileLock",
+]

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -6,6 +6,7 @@ import stat
 import sys
 from errno import EACCES, EIO, EISDIR
 from pathlib import Path
+from typing import Final
 
 
 def write_all(fd: int, data: bytes) -> None:
@@ -109,9 +110,28 @@ def break_lock_file(lock_file: str, mtime_before: float, ino_before: int) -> Non
     Path(break_path).unlink()
 
 
+def touch(name: str, *, fd: int | None = None) -> None:
+    # Prefer the already-open, already-verified fd so a peer that swaps a symlink or a different file in at the
+    # path after our O_NOFOLLOW read cannot redirect the touch: utime then targets the inode behind the fd.
+    # Where the platform cannot utime an fd, fall back to a path-based touch that still refuses to follow a
+    # symlink where supported, matching the O_NOFOLLOW reads used elsewhere here.
+    if fd is not None and _SUPPORTS_UTIME_FD:
+        os.utime(fd, None)
+        return
+    os.utime(name, None, follow_symlinks=not _SUPPORTS_UTIME_NOFOLLOW)
+
+
+# Retargeting os.utime to an open fd lets a heartbeat refresh the exact inode it verified instead of whatever the
+# pathname now names.
+_SUPPORTS_UTIME_FD: Final[bool] = sys.platform != "win32" and os.utime in os.supports_fd
+# os.utime follows symlinks unless told not to; not every platform can refuse the follow, so probe support.
+_SUPPORTS_UTIME_NOFOLLOW: Final[bool] = os.utime in os.supports_follow_symlinks
+
+
 __all__ = [
     "break_lock_file",
     "ensure_directory_exists",
     "raise_on_not_writable_file",
+    "touch",
     "write_all",
 ]

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -118,6 +118,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     """
 
     _deadlock_holder_desc: str = "BaseAsyncFileLock instance in this task"
+    _constructor_lifetime_warning_stacklevel: int = 4
 
     def __init__(  # noqa: PLR0913
         self,
@@ -161,11 +162,10 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             same object around.
         :param poll_interval: default interval for polling the lock file, in seconds. It will be used as fallback value
             in the acquire method, if no poll_interval value (``None``) is given.
-        :param lifetime: for :class:`AsyncSoftFileLock`, the maximum time in seconds a lock may be held before it
-            expires: a waiting process breaks a lock file whose modification time is older than ``lifetime`` seconds,
-            even if the holder is still alive. ``None`` (the default) means locks never expire. Native OS locks
-            (:class:`AsyncFileLock`) cannot be revoked by file age and ignore a non-``None`` ``lifetime``, with a
-            warning.
+        :param lifetime: for :class:`AsyncSoftFileLock`, the age in seconds after which a waiting process may delete
+            the marker, even while its holder remains alive. This legacy expiry mode does not provide strict mutual
+            exclusion. ``None`` (the default) disables age-based expiry. Native OS locks (:class:`AsyncFileLock`)
+            cannot be revoked by file age and ignore a non-``None`` ``lifetime`` with a warning.
         :param context_error_policy: how a context manager reconciles a failure in its body with a failure while
             releasing on exit. ``"chain"`` (the default) keeps Python's behavior: the release error propagates with the
             body error in its ``__context__``. ``"group"`` raises a :class:`BaseExceptionGroup` holding the body error
@@ -713,6 +713,8 @@ class AsyncAcquireReturnProxy:
 
 class AsyncSoftFileLock(SoftFileLock, BaseAsyncFileLock):
     """Simply watches the existence of the lock file."""
+
+    _lifetime_replacements: tuple[str, str] | None = ("AsyncStrictSoftFileLock", "AsyncSoftFileLease")
 
 
 class AsyncUnixFileLock(UnixFileLock, BaseAsyncFileLock):

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -21,6 +21,7 @@ from ._api import (
     FileLockMeta,
     _append_exception_context,
     _canonical,
+    _ExtraValue,
     _fork_transition,
     _grouped_errors,
     _raise_body_and_release,
@@ -40,7 +41,9 @@ from ._async import (
     _wait_until_done,
 )
 from ._error import Timeout
+from ._lease import SoftFileLease
 from ._soft import SoftFileLock
+from ._strict import StrictSoftFileLock
 from ._unix import UnixFileLock
 from ._windows import WindowsFileLock
 
@@ -66,7 +69,7 @@ _AT = TypeVar("_AT", bound="BaseAsyncFileLock")
 
 
 class AsyncFileLockMeta(FileLockMeta):
-    def __call__(  # ty: ignore[invalid-method-override]  # noqa: PLR0913
+    def __call__(  # noqa: PLR0913
         cls: type[_AT],  # noqa: N805
         lock_file: str | os.PathLike[str],
         timeout: float = -1,
@@ -85,11 +88,13 @@ class AsyncFileLockMeta(FileLockMeta):
         loop: asyncio.AbstractEventLoop | None = None,
         run_in_executor: bool = True,
         executor: futures.Executor | None = None,
+        **kwargs: _ExtraValue,
     ) -> _AT:
         if thread_local and run_in_executor:
             msg = "run_in_executor is not supported when thread_local is True"
             raise ValueError(msg)
-        return super().__call__(
+        return super().__call__(  # a subclass may add options of its own, as AsyncSoftFileLease does
+            **kwargs,
             lock_file=lock_file,
             timeout=timeout,
             mode=mode,
@@ -717,6 +722,14 @@ class AsyncSoftFileLock(SoftFileLock, BaseAsyncFileLock):
     _lifetime_replacements: tuple[str, str] | None = ("AsyncStrictSoftFileLock", "AsyncSoftFileLease")
 
 
+class AsyncStrictSoftFileLock(StrictSoftFileLock, BaseAsyncFileLock):
+    """Fail-closed existence lock: a marker this process did not publish always means contention."""
+
+
+class AsyncSoftFileLease(SoftFileLease, BaseAsyncFileLock):
+    """Existence lock whose claim expires, so a peer may take it while the previous holder still runs."""
+
+
 class AsyncUnixFileLock(UnixFileLock, BaseAsyncFileLock):
     """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
 
@@ -727,7 +740,9 @@ class AsyncWindowsFileLock(WindowsFileLock, BaseAsyncFileLock):
 
 __all__ = [
     "AsyncAcquireReturnProxy",
+    "AsyncSoftFileLease",
     "AsyncSoftFileLock",
+    "AsyncStrictSoftFileLock",
     "AsyncUnixFileLock",
     "AsyncWindowsFileLock",
     "BaseAsyncFileLock",

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Final, Literal
 import pytest
 
 from filelock import Timeout
+from filelock import _util as util_mod
 from filelock._soft_rw import SoftReadWriteLock
 from filelock._soft_rw import _sync as sync_mod
 
@@ -591,7 +592,7 @@ def test_heartbeat_survives_transient_touch_error(lock_file: str, monkeypatch: p
     try:
         hold = lock._hold
         assert hold is not None
-        monkeypatch.setattr(sync_mod, "_touch", boom)
+        monkeypatch.setattr(sync_mod, "touch", boom)
         time.sleep(0.2)  # ~10 ticks, every one failing the touch
         assert hold.heartbeat_thread.is_alive()
         assert not hold.heartbeat_stop.is_set()
@@ -736,13 +737,13 @@ def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:
     marker = Path(f"{lock_file}.write")
     marker.symlink_to(victim)
 
-    sync_mod._touch(str(marker))
+    util_mod.touch(str(marker))
 
     assert victim.stat().st_mtime == past
     assert victim.read_text() == "do-not-touch"
 
 
-@pytest.mark.skipif(not sync_mod._SUPPORTS_UTIME_FD, reason="os.utime cannot target an fd on this platform")
+@pytest.mark.skipif(not util_mod._SUPPORTS_UTIME_FD, reason="os.utime cannot target an fd on this platform")
 def test_refresh_touches_verified_fd_not_swapped_path(
     lock_file: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_async_soft_contracts.py
+++ b/tests/test_async_soft_contracts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import AsyncSoftFileLease, AsyncStrictSoftFileLock, LeaseCompromise, Timeout
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_DURATION: float = 0.9
+_HEARTBEAT: float = 0.1
+
+
+@pytest.fixture
+def marker(tmp_path: Path) -> Path:
+    return tmp_path / "a.lock"
+
+
+@pytest.mark.asyncio
+async def test_async_strict_treats_a_foreign_marker_as_contention(marker: Path) -> None:
+    await asyncio.to_thread(marker.write_text, "filelock/2\npid=999999\nhost=nowhere\nmode=strict\n", encoding="utf-8")
+    lock = AsyncStrictSoftFileLock(str(marker), timeout=0.2)
+
+    with pytest.raises(Timeout):
+        await lock.acquire()
+    assert await asyncio.to_thread(marker.exists)
+
+
+@pytest.mark.asyncio
+async def test_async_strict_publishes_its_owner(marker: Path) -> None:
+    lock = AsyncStrictSoftFileLock(str(marker))
+
+    async with lock:
+        owner = lock.owner
+
+    assert owner is not None
+    assert owner.mode == "strict"
+
+
+@pytest.mark.asyncio
+async def test_async_lease_heartbeat_keeps_a_live_claim(marker: Path) -> None:
+    lease = AsyncSoftFileLease(str(marker), lease_duration=_DURATION, heartbeat_interval=_HEARTBEAT)
+
+    async with lease:
+        await asyncio.sleep(_DURATION * 1.5)  # only a refreshing heartbeat keeps the claim past this
+        assert lease.compromise is None
+        assert lease.token is not None
+
+
+@pytest.mark.asyncio
+async def test_async_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:
+    seen: list[LeaseCompromise] = []
+    lease = AsyncSoftFileLease(
+        str(marker), lease_duration=_DURATION, heartbeat_interval=_HEARTBEAT, on_compromise=seen.append
+    )
+
+    async with lease:
+        await asyncio.to_thread(marker.unlink)
+        await asyncio.sleep(_HEARTBEAT * 5)
+
+    assert [c.reason for c in seen] == ["marker-missing"]

--- a/tests/test_async_soft_contracts.py
+++ b/tests/test_async_soft_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -50,6 +51,10 @@ async def test_async_lease_heartbeat_keeps_a_live_claim(marker: Path) -> None:
         assert lease.token is not None
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows keeps an open marker undeletable, so no peer can take it from a live holder",
+)
 @pytest.mark.asyncio
 async def test_async_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:
     seen: list[LeaseCompromise] = []

--- a/tests/test_lifetime_validation.py
+++ b/tests/test_lifetime_validation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Final, Literal, cast
 
 import pytest
 
@@ -8,6 +8,9 @@ from filelock import AsyncFileLock, AsyncSoftFileLock, FileLock, SoftFileLock
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+pytestmark: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings("ignore::filelock.SoftFileLockLifetimeWarning")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 _NATIVE_IGNORES: Final[str] = "lifetime is ignored"
+pytestmark: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings("ignore::filelock.SoftFileLockLifetimeWarning")
 
 
 def test_expired_soft_lock_is_broken(tmp_path: Path) -> None:
@@ -101,8 +102,10 @@ def test_lifetime_setter_rejects_negative_number(bad_value: float, tmp_path: Pat
         lock.lifetime = bad_value
 
 
-@pytest.mark.parametrize("bad_value", ["5", b"5", object(), [1], {1: 2}, complex(1, 0)])
-def test_lifetime_setter_rejects_non_numeric(bad_value: object, tmp_path: Path) -> None:
+@pytest.mark.parametrize("bad_value", ["5", b"5", [1], {1: 2}, complex(1, 0)])
+def test_lifetime_setter_rejects_non_numeric(
+    bad_value: str | bytes | list[int] | dict[int, int] | complex, tmp_path: Path
+) -> None:
     lock = FileLock(tmp_path / "test.lock")
     with pytest.raises(TypeError, match="lifetime must be"):
         lock.lifetime = bad_value  # ty: ignore[invalid-assignment]  # non-numeric input to hit the setter's TypeError

--- a/tests/test_marker_records.py
+++ b/tests/test_marker_records.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import SoftFileLease, StrictSoftFileLock, Timeout
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        pytest.param("filelock/1\npid=1\nhost=h\nmode=strict\n", id="wrong-protocol"),
+        pytest.param("filelock/2\npid=1\nhost=h\n", id="no-mode"),
+        pytest.param("filelock/2\npid=1\nhost=h\nmode=banana\n", id="unknown-mode"),
+        pytest.param("filelock/2\npid=1\nmode=strict\n", id="no-host"),
+        pytest.param("filelock/2\npid=1\nhost=\nmode=strict\n", id="empty-host"),
+        pytest.param("filelock/2\nhost=h\nmode=strict\n", id="no-pid"),
+        pytest.param("filelock/2\npid=nine\nhost=h\nmode=strict\n", id="pid-not-a-number"),
+        pytest.param("filelock/2\npid=0\nhost=h\nmode=strict\n", id="pid-below-range"),
+        pytest.param("filelock/2\npid=99999999999\nhost=h\nmode=strict\n", id="pid-above-range"),
+        pytest.param("filelock/2\npid=1\nhost=h\nmode=strict\nbare-line\n", id="field-without-value"),
+        pytest.param("filelock/2\npid=1\nhost=h\nmode=lease\nduration=5\n", id="lease-without-token"),
+        pytest.param("filelock/2\npid=1\nhost=h\nmode=lease\ntoken=t\n", id="lease-without-duration"),
+        pytest.param("filelock/2\npid=1\nhost=h\nmode=lease\ntoken=t\nduration=0\n", id="lease-duration-zero"),
+        pytest.param(
+            "filelock/2\npid=1\nhost=h\nmode=lease\ntoken=t\nduration=soon\n", id="lease-duration-not-a-number"
+        ),
+    ],
+)
+def test_unreadable_record_names_no_owner(tmp_path: Path, record: str) -> None:
+    marker = tmp_path / "a.lock"
+    marker.write_text(record, encoding="utf-8")
+
+    assert StrictSoftFileLock(str(marker)).owner is None
+
+
+def test_record_from_a_newer_filelock_still_names_its_owner(tmp_path: Path) -> None:
+    # An unknown key is a field this version does not model yet; the owner it publishes must still read back.
+    marker = tmp_path / "a.lock"
+    marker.write_text("filelock/2\npid=4242\nhost=somehost\nmode=strict\nstart-id=17\n", encoding="utf-8")
+
+    owner = StrictSoftFileLock(str(marker)).owner
+
+    assert owner is not None
+    assert (owner.pid, owner.hostname, owner.mode) == (4242, "somehost", "strict")
+
+
+def test_lease_treats_an_unreadable_record_as_contention(tmp_path: Path) -> None:
+    # Only a peer that published a lease agreed to be superseded by age, so an unreadable record is never reclaimed.
+    marker = tmp_path / "a.lock"
+    marker.write_text("filelock/2\npid=1\nhost=h\nmode=banana\n", encoding="utf-8")
+
+    with pytest.raises(Timeout):
+        SoftFileLease(str(marker), lease_duration=0.3, heartbeat_interval=0.1, timeout=0.5).acquire()
+
+    assert marker.exists()

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os
 import socket
+import sys
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Final, cast
 
 import pytest
 
@@ -25,6 +26,13 @@ if TYPE_CHECKING:
 #: Short enough to keep the suite quick, long enough that a loaded runner still refreshes twice before expiry.
 _DURATION: float = 0.9
 _HEARTBEAT: float = 0.1
+
+#: Windows refuses to rename or delete a file another process holds open, so a live holder's marker cannot be taken
+#: from it. A lease only reclaims there once the holder exits and its handle closes.
+_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows keeps an open marker undeletable, so no peer can take it from a live holder",
+)
 
 
 @pytest.fixture
@@ -82,6 +90,7 @@ def test_lease_heartbeat_keeps_a_live_claim_past_its_duration(marker: Path) -> N
             _lease(marker).acquire()
 
 
+@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
 def test_lease_peer_takes_an_expired_claim(marker: Path, mocker: MockerFixture) -> None:
     # A wedged holder: its marker stays on disk, but no refresh ever lands on it again, so the claim ages out.
     mocker.patch("filelock._lease.touch")
@@ -107,6 +116,7 @@ def test_lease_reclaims_a_dead_same_host_holder(marker: Path) -> None:
         assert lease.is_lock_held_by_us
 
 
+@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
 def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:
     seen: list[LeaseCompromise] = []
     lease = _lease(marker, on_compromise=seen.append)
@@ -119,6 +129,7 @@ def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None
     assert [(c.reason, c.token, c.lock_file) for c in seen] == [("marker-missing", token, str(marker))]
 
 
+@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
 def test_lease_reports_compromise_when_a_peer_takes_over(marker: Path) -> None:
     seen: list[LeaseCompromise] = []
     holder = _lease(marker, on_compromise=seen.append)
@@ -143,6 +154,7 @@ def test_lease_reports_compromise_when_a_refresh_fails(marker: Path, mocker: Moc
     assert [(c.reason, c.error) for c in seen] == [("refresh-failed", failure)]
 
 
+@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
 def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:
     seen: list[LeaseCompromise] = []
     lease = _lease(marker, on_compromise=seen.append)
@@ -154,6 +166,7 @@ def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:
     assert len(seen) == 1
 
 
+@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
 def test_lease_records_the_compromise_without_a_callback(marker: Path) -> None:
     lease = _lease(marker)
 
@@ -174,6 +187,7 @@ def test_lease_holds_an_uncompromised_claim(marker: Path) -> None:
         assert lease.compromise is None
 
 
+@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
 def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> None:
     # The callback runs on the heartbeat thread, so releasing from it needs a context that thread can see, and it must
     # not deadlock joining itself.
@@ -199,6 +213,7 @@ def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> Non
     assert not lease.is_locked
 
 
+@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
 def test_lease_release_from_the_callback_needs_a_shared_context(marker: Path) -> None:
     # With the default thread-local context the heartbeat thread sees no claim of its own, so its release() does
     # nothing. Pin the trap the docstring warns about.

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import os
+import socket
+import time
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from filelock import (
+    FileLock,
+    LeaseCompromise,
+    LeaseSettingsMismatch,
+    SoftFileLease,
+    StrictSoftFileLock,
+    Timeout,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+#: Short enough to keep the suite quick, long enough that a loaded runner still refreshes twice before expiry.
+_DURATION: float = 0.9
+_HEARTBEAT: float = 0.1
+
+
+@pytest.fixture
+def marker(tmp_path: Path) -> Path:
+    return tmp_path / "a.lock"
+
+
+def _lease(
+    marker: Path,
+    *,
+    lease_duration: float = _DURATION,
+    timeout: float = 0.3,
+    on_compromise: Callable[[LeaseCompromise], None] | None = None,
+) -> SoftFileLease:
+    return SoftFileLease(
+        str(marker),
+        timeout=timeout,
+        lease_duration=lease_duration,
+        heartbeat_interval=_HEARTBEAT,
+        on_compromise=on_compromise,
+    )
+
+
+def test_lease_publishes_its_claim(marker: Path) -> None:
+    lease = _lease(marker)
+
+    with lease:
+        owner = lease.owner
+        assert owner is not None
+        assert (owner.pid, owner.hostname, owner.mode, owner.lease_duration) == (
+            os.getpid(),
+            socket.gethostname(),
+            "lease",
+            _DURATION,
+        )
+        assert owner.token == lease.token
+
+
+def test_lease_token_names_the_claim_only_while_held(marker: Path) -> None:
+    lease = _lease(marker)
+
+    with lease:
+        held = lease.token
+
+    assert held is not None
+    assert lease.token is None
+
+
+def test_lease_heartbeat_keeps_a_live_claim_past_its_duration(marker: Path) -> None:
+    holder = _lease(marker)
+
+    with holder:
+        time.sleep(_DURATION * 1.5)  # only a refreshing heartbeat keeps the claim past this
+        with pytest.raises(Timeout):
+            _lease(marker).acquire()
+
+
+def test_lease_peer_takes_an_expired_claim(marker: Path, mocker: MockerFixture) -> None:
+    # A wedged holder: its marker stays on disk, but no refresh ever lands on it again, so the claim ages out.
+    mocker.patch("filelock._lease.touch")
+    holder = _lease(marker)
+    holder.acquire()
+
+    try:
+        peer = _lease(marker, timeout=_DURATION * 5)
+        with peer:
+            assert peer.is_lock_held_by_us
+            assert peer.token != holder.token
+    finally:
+        holder.release()
+
+
+def test_lease_reclaims_a_dead_same_host_holder(marker: Path) -> None:
+    marker.write_text(
+        f"filelock/2\npid=999999\nhost={socket.gethostname()}\nmode=lease\ntoken=abc\nduration={_DURATION!r}\n",
+        encoding="utf-8",
+    )
+
+    with _lease(marker) as lease:
+        assert lease.is_lock_held_by_us
+
+
+def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:
+    seen: list[LeaseCompromise] = []
+    lease = _lease(marker, on_compromise=seen.append)
+
+    with lease:
+        token = lease.token
+        marker.unlink()
+        time.sleep(_HEARTBEAT * 5)
+
+    assert [(c.reason, c.token, c.lock_file) for c in seen] == [("marker-missing", token, str(marker))]
+
+
+def test_lease_reports_compromise_when_a_peer_takes_over(marker: Path) -> None:
+    seen: list[LeaseCompromise] = []
+    holder = _lease(marker, on_compromise=seen.append)
+
+    with holder:
+        marker.unlink()
+        _lease(marker).acquire()  # a peer publishes a fresh marker at the same path
+        time.sleep(_HEARTBEAT * 5)
+
+    assert [c.reason for c in seen] == ["owner-changed"]
+
+
+def test_lease_reports_compromise_when_a_refresh_fails(marker: Path, mocker: MockerFixture) -> None:
+    seen: list[LeaseCompromise] = []
+    failure = OSError("cannot touch the marker")
+    mocker.patch("filelock._lease.touch", side_effect=failure)
+    lease = _lease(marker, on_compromise=seen.append)
+
+    with lease:
+        time.sleep(_HEARTBEAT * 5)
+
+    assert [(c.reason, c.error) for c in seen] == [("refresh-failed", failure)]
+
+
+def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:
+    seen: list[LeaseCompromise] = []
+    lease = _lease(marker, on_compromise=seen.append)
+
+    with lease:
+        marker.unlink()
+        time.sleep(_HEARTBEAT * 6)  # several refreshes fail, but the holder is told once
+
+    assert len(seen) == 1
+
+
+def test_lease_records_the_compromise_without_a_callback(marker: Path) -> None:
+    lease = _lease(marker)
+
+    with lease:
+        marker.unlink()
+        time.sleep(_HEARTBEAT * 5)
+        compromise = lease.compromise
+
+    assert compromise is not None
+    assert compromise.reason == "marker-missing"
+
+
+def test_lease_holds_an_uncompromised_claim(marker: Path) -> None:
+    lease = _lease(marker)
+
+    with lease:
+        time.sleep(_HEARTBEAT * 3)
+        assert lease.compromise is None
+
+
+def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> None:
+    # The callback runs on the heartbeat thread, so releasing from it needs a context that thread can see, and it must
+    # not deadlock joining itself.
+    holder: list[SoftFileLease] = []
+
+    def release_the_claim(_: LeaseCompromise) -> None:
+        holder[0].release()
+
+    lease = SoftFileLease(
+        str(marker),
+        thread_local=False,
+        lease_duration=_DURATION,
+        heartbeat_interval=_HEARTBEAT,
+        on_compromise=release_the_claim,
+    )
+    holder.append(lease)
+    lease.acquire()
+
+    marker.unlink()
+    time.sleep(_HEARTBEAT * 5)
+
+    assert lease.compromise is not None
+    assert not lease.is_locked
+
+
+def test_lease_release_from_the_callback_needs_a_shared_context(marker: Path) -> None:
+    # With the default thread-local context the heartbeat thread sees no claim of its own, so its release() does
+    # nothing. Pin the trap the docstring warns about.
+    holder: list[SoftFileLease] = []
+
+    def release_the_claim(_: LeaseCompromise) -> None:
+        holder[0].release()
+
+    lease = _lease(marker, on_compromise=release_the_claim)
+    holder.append(lease)
+    lease.acquire()
+
+    try:
+        marker.unlink()
+        time.sleep(_HEARTBEAT * 5)
+        assert lease.is_locked, "a thread-local release() from the heartbeat thread silently did nothing"
+    finally:
+        lease.release()
+
+
+def test_lease_rejects_a_peer_configured_with_another_duration(marker: Path) -> None:
+    holder = _lease(marker)
+
+    with holder, pytest.raises(LeaseSettingsMismatch, match="must agree on lease_duration"):
+        _lease(marker, lease_duration=_DURATION * 3).acquire()
+
+
+def test_lease_does_not_expire_a_strict_holder(marker: Path) -> None:
+    # A strict holder never agreed to be superseded by age, so a lease contender waits it out instead.
+    with StrictSoftFileLock(str(marker)):
+        with pytest.raises(Timeout):
+            _lease(marker, timeout=_DURATION * 2).acquire()
+        assert marker.exists()
+
+
+@pytest.mark.parametrize(
+    ("lease_duration", "heartbeat_interval", "message"),
+    [
+        pytest.param(0, None, "lease_duration must be positive", id="zero-duration"),
+        pytest.param(-1, None, "lease_duration must be positive", id="negative-duration"),
+        pytest.param(_DURATION, 0, "heartbeat_interval must be positive", id="zero-heartbeat"),
+        pytest.param(_DURATION, _DURATION, "below lease_duration", id="heartbeat-equals-duration"),
+        pytest.param(_DURATION, _DURATION * 2, "below lease_duration", id="heartbeat-over-duration"),
+    ],
+)
+def test_lease_rejects_incoherent_settings(
+    marker: Path, lease_duration: float, heartbeat_interval: float | None, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        SoftFileLease(str(marker), lease_duration=lease_duration, heartbeat_interval=heartbeat_interval)
+
+
+def test_lease_defaults_the_heartbeat_below_the_duration(marker: Path) -> None:
+    lease = SoftFileLease(str(marker), lease_duration=30)
+
+    assert lease.lease_duration == 30
+
+
+def test_lease_drops_lifetime_with_a_warning(marker: Path) -> None:
+    with pytest.warns(UserWarning, match="lease_duration sets when a lease expires"):
+        lease = SoftFileLease(str(marker), lease_duration=_DURATION, lifetime=5)
+
+    assert lease.lifetime is None
+
+
+def test_native_lock_rejects_a_lease_duration(marker: Path) -> None:
+    # A kernel lock lives on the inode, so no pathname age can revoke it; the option must not even be accepted. The
+    # rejection happens at runtime, so reach it the way a caller without a type checker would.
+    construct = cast("Callable[..., FileLock]", FileLock)
+
+    with pytest.raises(TypeError, match="does not support non-default lock options: lease_duration"):
+        construct(str(marker), lease_duration=5)

--- a/tests/test_soft_lifetime_warning.py
+++ b/tests/test_soft_lifetime_warning.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import sys
+import warnings
+from typing import TYPE_CHECKING, Literal
+
+import pytest
+
+from filelock import (
+    AsyncSoftFileLock,
+    AsyncUnixFileLock,
+    AsyncWindowsFileLock,
+    SoftFileLock,
+    SoftFileLockLifetimeWarning,
+    Timeout,
+    UnixFileLock,
+    WindowsFileLock,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    ("lock_type", "strict_lock", "lease"),
+    [
+        pytest.param(SoftFileLock, "StrictSoftFileLock", "SoftFileLease", id="sync"),
+        pytest.param(AsyncSoftFileLock, "AsyncStrictSoftFileLock", "AsyncSoftFileLease", id="async"),
+    ],
+)
+@pytest.mark.parametrize(
+    "entry_point",
+    [pytest.param("constructor", id="constructor"), pytest.param("setter", id="setter")],
+)
+def test_soft_lifetime_warning_identifies_caller(
+    lock_type: type[SoftFileLock | AsyncSoftFileLock],
+    strict_lock: str,
+    lease: str,
+    entry_point: Literal["constructor", "setter"],
+    tmp_path: Path,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        if entry_point == "constructor":
+            warning_line = sys._getframe().f_lineno + 1
+            lock_type(tmp_path / "test.lock", lifetime=10)
+        else:
+            lock = lock_type(tmp_path / "test.lock")
+            warning_line = sys._getframe().f_lineno + 1
+            lock.lifetime = 10
+
+    assert [(item.category, str(item.message), item.filename, item.lineno) for item in caught] == [
+        (
+            SoftFileLockLifetimeWarning,
+            (
+                f"{lock_type.__name__}(lifetime=...) uses age-based expiry and can overlap a live holder; "
+                f"use {lease} for expiry or {strict_lock} for fail-closed locking"
+            ),
+            __file__,
+            warning_line,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "lock_type",
+    [pytest.param(SoftFileLock, id="sync"), pytest.param(AsyncSoftFileLock, id="async")],
+)
+@pytest.mark.parametrize(
+    "entry_point",
+    [pytest.param("constructor", id="constructor"), pytest.param("setter", id="setter")],
+)
+def test_soft_lifetime_none_does_not_warn(
+    lock_type: type[SoftFileLock | AsyncSoftFileLock], entry_point: Literal["constructor", "setter"], tmp_path: Path
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        if entry_point == "constructor":
+            lock_type(tmp_path / "test.lock", lifetime=None)
+        else:
+            lock = lock_type(tmp_path / "test.lock")
+            lock.lifetime = None
+
+    assert caught == []
+
+
+@pytest.mark.parametrize(
+    "lock_type",
+    [pytest.param(SoftFileLock, id="sync"), pytest.param(AsyncSoftFileLock, id="async")],
+)
+@pytest.mark.parametrize(
+    "entry_point",
+    [pytest.param("constructor", id="constructor"), pytest.param("setter", id="setter")],
+)
+def test_invalid_soft_lifetime_does_not_warn(
+    lock_type: type[SoftFileLock | AsyncSoftFileLock], entry_point: Literal["constructor", "setter"], tmp_path: Path
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError, match="finite and non-negative"):
+            _set_invalid_lifetime(lock_type, entry_point, tmp_path / "test.lock")
+
+    assert caught == []
+
+
+@pytest.mark.parametrize(
+    "lock_type",
+    [
+        pytest.param(UnixFileLock, marks=pytest.mark.skipif(sys.platform == "win32", reason="Unix backend"), id="sync"),
+        pytest.param(
+            AsyncUnixFileLock,
+            marks=pytest.mark.skipif(sys.platform == "win32", reason="Unix backend"),
+            id="async",
+        ),
+        pytest.param(
+            WindowsFileLock, marks=pytest.mark.skipif(sys.platform != "win32", reason="Windows backend"), id="sync"
+        ),
+        pytest.param(
+            AsyncWindowsFileLock,
+            marks=pytest.mark.skipif(sys.platform != "win32", reason="Windows backend"),
+            id="async",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "entry_point",
+    [pytest.param("constructor", id="constructor"), pytest.param("setter", id="setter")],
+)
+def test_native_lifetime_warning_identifies_caller(
+    lock_type: type[UnixFileLock | AsyncUnixFileLock | WindowsFileLock | AsyncWindowsFileLock],
+    entry_point: Literal["constructor", "setter"],
+    tmp_path: Path,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        if entry_point == "constructor":
+            warning_line = sys._getframe().f_lineno + 1
+            lock_type(tmp_path / "test.lock", lifetime=10)
+        else:
+            lock = lock_type(tmp_path / "test.lock")
+            warning_line = sys._getframe().f_lineno + 1
+            lock.lifetime = 10
+
+    assert [(item.category, str(item.message), item.filename, item.lineno) for item in caught] == [
+        (
+            UserWarning,
+            (
+                f"lifetime is ignored for {lock_type.__name__}: a native OS lock cannot be broken safely by file age; "
+                "only SoftFileLock supports lifetime-based expiry"
+            ),
+            __file__,
+            warning_line,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "lock_type",
+    [pytest.param(SoftFileLock, id="sync"), pytest.param(AsyncSoftFileLock, id="async")],
+)
+def test_soft_lifetime_singleton_match_warns_for_each_configuration(
+    lock_type: type[SoftFileLock | AsyncSoftFileLock], tmp_path: Path
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        first = lock_type(tmp_path / "test.lock", lifetime=10, is_singleton=True)
+        second = lock_type(tmp_path / "test.lock", lifetime=10, is_singleton=True)
+
+    assert (first is second, len(caught)) == (True, 2)
+
+
+@pytest.mark.parametrize(
+    "lock_type",
+    [pytest.param(SoftFileLock, id="sync"), pytest.param(AsyncSoftFileLock, id="async")],
+)
+def test_soft_lifetime_singleton_mismatch_warns_before_rejection(
+    lock_type: type[SoftFileLock | AsyncSoftFileLock], tmp_path: Path
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        first = lock_type(tmp_path / "test.lock", lifetime=10, is_singleton=True)
+        with pytest.raises(ValueError, match="lifetime"):
+            lock_type(tmp_path / "test.lock", lifetime=20, is_singleton=True)
+
+    assert (first.lifetime, len(caught)) == (10, 2)
+
+
+def test_soft_lifetime_polling_does_not_repeat_warning(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    holder = SoftFileLock(lock_path)
+    with pytest.warns(SoftFileLockLifetimeWarning):
+        contender = SoftFileLock(lock_path, lifetime=60, poll_interval=0.001, timeout=0.01)
+
+    with holder, warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(Timeout):
+            contender.acquire()
+
+    assert caught == []
+
+
+@pytest.mark.asyncio
+async def test_async_soft_lifetime_polling_does_not_repeat_warning(tmp_path: Path) -> None:
+    lock_path = tmp_path / "test.lock"
+    holder = AsyncSoftFileLock(lock_path)
+    with pytest.warns(SoftFileLockLifetimeWarning):
+        contender = AsyncSoftFileLock(lock_path, lifetime=60, poll_interval=0.001, timeout=0.01)
+
+    async with holder:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(Timeout):
+                await contender.acquire()
+
+    assert caught == []
+
+
+def _set_invalid_lifetime(
+    lock_type: type[SoftFileLock | AsyncSoftFileLock],
+    entry_point: Literal["constructor", "setter"],
+    lock_path: Path,
+) -> None:
+    if entry_point == "constructor":
+        lock_type(lock_path, lifetime=-1)
+    else:
+        lock = lock_type(lock_path)
+        lock.lifetime = -1

--- a/tests/test_strict_soft_lock.py
+++ b/tests/test_strict_soft_lock.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+import socket
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import SoftFileLock, StrictSoftFileLock, Timeout
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ANCIENT: float = 0.0
+
+
+@pytest.fixture
+def marker(tmp_path: Path) -> Path:
+    return tmp_path / "a.lock"
+
+
+def _publish(marker: Path, content: str, *, age: float | None = None) -> None:
+    marker.write_text(content, encoding="utf-8")
+    if age is not None:
+        os.utime(marker, (age, age))
+
+
+@pytest.mark.parametrize(
+    ("record", "case"),
+    [
+        pytest.param(
+            "filelock/2\npid=999999\nhost=nowhere\nmode=strict\n", "owner-on-another-host", id="owner-unknown"
+        ),
+        pytest.param("not a marker at all\n", "malformed", id="malformed"),
+        pytest.param("4242\nsomehost\n", "legacy protocol 1", id="legacy"),
+        pytest.param("", "empty", id="empty"),
+    ],
+)
+def test_strict_treats_unreadable_marker_as_contention(marker: Path, record: str, case: str) -> None:
+    # A strict lock never reclaims: every one of these markers is old enough that SoftFileLock would evict it.
+    _publish(marker, record, age=_ANCIENT)
+    lock = StrictSoftFileLock(str(marker), timeout=0.2)
+
+    with pytest.raises(Timeout):
+        lock.acquire()
+    assert marker.exists(), f"strict acquisition removed a {case} marker"
+
+
+def test_strict_does_not_reclaim_a_dead_owner(marker: Path) -> None:
+    # SoftFileLock evicts a same-host marker whose PID is gone; a strict lock refuses to guess the holder died.
+    _publish(marker, f"filelock/2\npid=999999\nhost={socket.gethostname()}\nmode=strict\n")
+    lock = StrictSoftFileLock(str(marker), timeout=0.2)
+
+    with pytest.raises(Timeout):
+        lock.acquire()
+    assert marker.exists()
+
+
+def test_strict_does_not_reclaim_by_age(marker: Path) -> None:
+    _publish(marker, f"filelock/2\npid={os.getpid()}\nhost={socket.gethostname()}\nmode=strict\n", age=_ANCIENT)
+    lock = StrictSoftFileLock(str(marker), timeout=0.2)
+
+    with pytest.raises(Timeout):
+        lock.acquire()
+
+
+def test_strict_publishes_its_owner(marker: Path) -> None:
+    lock = StrictSoftFileLock(str(marker))
+
+    with lock:
+        owner = lock.owner
+
+    assert owner is not None
+    assert (owner.pid, owner.hostname, owner.mode, owner.token) == (
+        os.getpid(),
+        socket.gethostname(),
+        "strict",
+        None,
+    )
+
+
+def test_strict_reports_the_holding_process(marker: Path) -> None:
+    lock = StrictSoftFileLock(str(marker))
+
+    with lock:
+        assert (lock.pid, lock.is_lock_held_by_us) == (os.getpid(), True)
+
+
+def test_strict_reports_no_owner_without_a_marker(marker: Path) -> None:
+    lock = StrictSoftFileLock(str(marker))
+
+    assert (lock.owner, lock.pid, lock.is_lock_held_by_us) == (None, None, False)
+
+
+def test_strict_force_break_lets_a_contender_in(marker: Path) -> None:
+    _publish(marker, "filelock/2\npid=999999\nhost=nowhere\nmode=strict\n")
+    lock = StrictSoftFileLock(str(marker), timeout=0.2)
+    with pytest.raises(Timeout):
+        lock.acquire()
+
+    lock.force_break()
+
+    with lock:
+        assert lock.is_lock_held_by_us
+
+
+def test_strict_drops_lifetime_with_a_warning(marker: Path) -> None:
+    with pytest.warns(UserWarning, match="a strict lock never reclaims a marker by age"):
+        lock = StrictSoftFileLock(str(marker), lifetime=5)
+
+    assert lock.lifetime is None
+
+
+def test_soft_lock_evicts_a_strict_marker(marker: Path) -> None:
+    # Protocol 1 and protocol 2 do not exclude each other: a legacy contender reads the strict record as malformed and
+    # evicts it once past the malformed grace period. Documented in how-to; pinned here so the loss stays visible.
+    _publish(marker, "filelock/2\npid=999999\nhost=nowhere\nmode=strict\n", age=_ANCIENT)
+    legacy = SoftFileLock(str(marker), timeout=2)
+
+    with legacy:
+        assert legacy.is_lock_held_by_us
+
+    assert not marker.exists()


### PR DESCRIPTION
`SoftFileLock` offers one contract for two jobs. A contender reclaims a marker whose holder it cannot find, and reclaims one by age once a caller sets `lifetime`, so a caller who wanted fail-closed locking gets a lock that hands the path to a peer while the holder still runs. This adds the two modes #636 asks for and makes the deprecation warning honest, since it already named `StrictSoftFileLock` and `SoftFileLease` before either existed. Closes #636.

`StrictSoftFileLock` never reclaims. A malformed record, an owner on another host, a dead PID and an old marker all read as held, so acquisition waits instead of overlapping a holder that may still be alive. A crashed holder leaves a marker that only `force_break` clears, and that method states the mutual exclusion it costs.

`SoftFileLease` publishes a claim, refreshes it from a heartbeat, and lets a peer take the marker once it is `lease_duration` seconds stale. The expired holder keeps running and keeps using whatever the lock protects, so the lease reports the loss through `on_compromise` rather than pretend the claim survived. The reasons are `marker-missing`, `owner-changed` and `refresh-failed`. `token` names a claim but does not fence one: fencing needs a monotonic generation from the protected resource, and the docs say so. A contender configured with a different `lease_duration` raises `LeaseSettingsMismatch` before it can overlap a peer that never agreed to that expiry. Native locks reject lease settings. `AsyncStrictSoftFileLock` and `AsyncSoftFileLease` carry both contracts to asyncio.

Both modes publish a protocol 2 record, which is a real trade. A `SoftFileLock` contender reads that record as malformed and evicts it after its grace period, so mixing contracts on one path loses mutual exclusion. `how-to` states which combinations hold and which do not, and a test pins the loss so it cannot become silent. The alternative, a sidecar metadata file, would have preserved legacy exclusion at the cost of a second file to keep atomic.

Two constraints worth a reviewer's attention. `on_compromise` runs on the heartbeat thread, so a `release()` inside it only takes effect when the lease was built with `thread_local=False`; the default thread-local context hides the claim from every other thread, and a test pins that trap. The heartbeat also takes the descriptor and inode from the acquiring thread for the same reason: reading them from the thread-local context inside the heartbeat found nothing, which disabled both refresh and compromise reporting without raising.
