### PR TITLE
🐛 fix(soft): detect a reused PID via process start time

### DIFF
--- a/docs/changelog/660.bugfix.rst
+++ b/docs/changelog/660.bugfix.rst
@@ -1,0 +1,2 @@
+``SoftFileLock`` and ``SoftFileLease`` record the holder's process start time on every platform and reclaim a stale marker only when the recorded owner is provably gone.
+A reused PID on Unix no longer breaks a live lock or wedges acquisition, matching the recycled-PID detection Windows already had.

--- a/src/filelock/_identity.py
+++ b/src/filelock/_identity.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from contextlib import suppress
+from errno import EPERM, ESRCH
+from pathlib import Path
+from typing import Final
+
+
+def host_name() -> str:
+    """The hostname recorded alongside an owner, so a marker written on another machine is never probed here."""
+    return socket.gethostname()
+
+
+def owner_is_stale(pid: int, hostname: str, start_token: int | None) -> bool:
+    """
+    Whether the recorded owner is provably gone, so reclaiming its marker cannot detach a live holder.
+
+    Fail closed: return ``True`` only when this process can prove the exact recorded owner is dead. A marker from
+    another host cannot be probed; a live PID whose start token still matches, or whose token cannot be read, is the
+    holder or is indistinguishable from it; a live PID whose start token differs is a recycled PID, so the process that
+    wrote the marker is gone. PostgreSQL, Qt ``QLockFile`` and Mercurial all break a stale lock only on proof of death
+    and treat an unreadable or foreign owner as still holding.
+    """
+    if hostname != host_name():
+        return False
+    if not process_alive(pid):
+        return True
+    if start_token is None:
+        return False
+    current = process_start_token(pid)
+    return current is not None and current != start_token
+
+
+if sys.platform == "win32":  # pragma: win32 cover
+    import ctypes
+    from ctypes import wintypes
+
+    _KERNEL32: Final[ctypes.WinDLL] = ctypes.WinDLL("kernel32", use_last_error=True)
+    _KERNEL32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _KERNEL32.CloseHandle.restype = wintypes.BOOL
+    _KERNEL32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    _KERNEL32.OpenProcess.restype = wintypes.HANDLE
+    _KERNEL32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    _KERNEL32.GetProcessTimes.restype = wintypes.BOOL
+
+    _WIN_SYNCHRONIZE: Final[int] = 0x100000
+    _WIN_PROCESS_QUERY_LIMITED_INFORMATION: Final[int] = 0x1000
+    _WIN_ERROR_INVALID_PARAMETER: Final[int] = 87
+    _WIN_INHERIT_HANDLE: Final[bool] = False
+
+    def process_alive(pid: int) -> bool:
+        """Whether a process with this PID exists, treating an access denial as proof it does."""
+        handle = _KERNEL32.OpenProcess(_WIN_SYNCHRONIZE, _WIN_INHERIT_HANDLE, pid)
+        if handle:
+            _KERNEL32.CloseHandle(handle)
+            return True
+        return ctypes.get_last_error() != _WIN_ERROR_INVALID_PARAMETER
+
+    def process_start_token(pid: int) -> int | None:
+        """The process creation FILETIME as a 100ns tick count, or ``None`` when it cannot be read."""
+        handle = _KERNEL32.OpenProcess(_WIN_PROCESS_QUERY_LIMITED_INFORMATION, _WIN_INHERIT_HANDLE, pid)
+        if not handle:
+            return None
+        creation, exit_time, kernel_time, user_time = (wintypes.FILETIME() for _ in range(4))
+        try:
+            if not _KERNEL32.GetProcessTimes(
+                handle,
+                ctypes.byref(creation),
+                ctypes.byref(exit_time),
+                ctypes.byref(kernel_time),
+                ctypes.byref(user_time),
+            ):
+                return None
+        finally:
+            _KERNEL32.CloseHandle(handle)
+        return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
+
+else:  # pragma: win32 no cover
+
+    def process_alive(pid: int) -> bool:
+        """Whether a process with this PID exists, treating an access denial (``EPERM``) as proof it does."""
+        try:
+            os.kill(pid, 0)
+        except OSError as error:
+            if error.errno == ESRCH:
+                return False
+            if error.errno == EPERM:
+                return True
+            raise
+        return True
+
+    if sys.platform == "linux":  # pragma: linux cover
+        # comm (field 2) is wrapped in parentheses and may itself contain spaces or a ')', so the fixed fields start
+        # after the final ')'. starttime is field 22 overall, the twentieth of those trailing fields (index 19).
+        _STARTTIME_INDEX: Final[int] = 19
+
+        def process_start_token(pid: int) -> int | None:
+            """The ``starttime`` from ``/proc/<pid>/stat`` in clock ticks, or ``None`` when the process is gone."""
+            try:
+                data = Path(f"/proc/{pid}/stat").read_bytes()
+            except OSError:
+                return None
+            # starttime is measured in clock ticks since boot, so it changes when a PID is reused within a boot; a
+            # reused PID that happens to match survives as the recorded owner, which fails closed. psutil identifies a
+            # process by the same (pid, starttime) pair.
+            fields = data[data.rfind(b")") + 1 :].split()
+            if len(fields) <= _STARTTIME_INDEX:  # pragma: no cover  # a truncated /proc read, never seen in practice
+                return None
+            with suppress(ValueError):
+                return int(fields[_STARTTIME_INDEX])
+            return None  # pragma: no cover  # /proc always renders starttime as an integer
+
+    elif sys.platform == "darwin":  # pragma: darwin cover
+        import ctypes
+        import struct
+
+        _LIBC: Final[ctypes.CDLL] = ctypes.CDLL(None, use_errno=True)
+        _CTL_KERN: Final[int] = 1
+        _KERN_PROC: Final[int] = 14
+        _KERN_PROC_PID: Final[int] = 1
+        # kinfo_proc opens with kp_proc.p_starttime (a struct timeval) at offset 0: int64 seconds, int32 microseconds.
+        # The offset is fixed by the struct chain kinfo_proc -> extern_proc -> p_un, so a read at 0 is not a guess.
+        _TIMEVAL_AT_ZERO: Final[str] = "<qi"
+        _TIMEVAL_SIZE: Final[int] = struct.calcsize(_TIMEVAL_AT_ZERO)
+
+        def process_start_token(pid: int) -> int | None:
+            """The process start time in microseconds from ``sysctl(KERN_PROC_PID)``, or ``None`` when it is gone."""
+            mib = (ctypes.c_int * 4)(_CTL_KERN, _KERN_PROC, _KERN_PROC_PID, pid)
+            length = ctypes.c_size_t(0)
+            # The size probe reports the kinfo_proc size for any PID, so the read below, not the probe, tells a live
+            # process from a gone one: a gone PID leaves the fetch a zero-length success, so re-check the length after.
+            if _LIBC.sysctl(mib, 4, None, ctypes.byref(length), None, 0) != 0:
+                return None
+            buffer = (ctypes.c_char * length.value)()
+            if _LIBC.sysctl(mib, 4, buffer, ctypes.byref(length), None, 0) != 0 or length.value < _TIMEVAL_SIZE:
+                return None
+            seconds, microseconds = struct.unpack_from(_TIMEVAL_AT_ZERO, buffer.raw, 0)
+            return seconds * 1_000_000 + microseconds
+
+    else:  # pragma: no cover  # a POSIX platform without a proven start-time source falls back to fail-closed liveness
+
+        def process_start_token(pid: int) -> int | None:
+            """No proven start-time source, so the owner carries no token and liveness rests on the PID alone."""
+            del pid
+            return None
+
+
+__all__ = [
+    "host_name",
+    "owner_is_stale",
+    "process_alive",
+    "process_start_token",
+]

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import secrets
-import socket
 import time
 from contextlib import suppress
 from dataclasses import dataclass
@@ -10,6 +9,7 @@ from threading import Event, Thread, current_thread
 from typing import TYPE_CHECKING, Literal
 
 from ._error import LeaseSettingsMismatch
+from ._identity import owner_is_stale
 from ._marker import MarkerSoftFileLock, OwnerMode, OwnerRecord, parse_marker
 from ._soft import _read_lock_file
 from ._util import break_lock_file, touch
@@ -158,13 +158,7 @@ class SoftFileLease(MarkerSoftFileLock):
         super()._release()
 
     def _published_record(self) -> OwnerRecord:
-        return OwnerRecord(
-            pid=os.getpid(),
-            hostname=socket.gethostname(),
-            mode="lease",
-            token=self._token,
-            lease_duration=self._lease_duration,
-        )
+        return super()._published_record()._replace(token=self._token, lease_duration=self._lease_duration)
 
     def _try_break_stale_lock(self) -> None:
         if (peer := self._read_peer()) is None:
@@ -183,7 +177,9 @@ class SoftFileLease(MarkerSoftFileLock):
         # A break can fail for reasons a contender must ride out rather than raise on: a peer broke the marker first,
         # or Windows refuses to rename a file whose holder still has it open. Poll again instead.
         with suppress(OSError):
-            if owner.hostname == socket.gethostname() and not self._is_process_alive(owner.pid):
+            # A dead or recycled owner is reclaimed at once; a live owner past its lease duration is superseded on the
+            # schedule every contender agreed to.
+            if owner_is_stale(owner.pid, owner.hostname, owner.start):
                 break_lock_file(self.lock_file, mtime, ino)
                 return
             if time.time() - mtime >= self._lease_duration:

--- a/src/filelock/_marker.py
+++ b/src/filelock/_marker.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import os
-import socket
 from contextlib import suppress
 from typing import Final, Literal, NamedTuple
 
+from ._identity import host_name, process_start_token
 from ._soft import SoftFileLock, _read_lock_file
 from ._util import write_all
 
-#: Protocol 1 is the legacy ``<pid>\n<hostname>\n[<creation_time>\n]`` marker that :class:`SoftFileLock` still writes.
+#: Protocol 1 is the legacy ``<pid>\n<hostname>\n[<start_token>\n]`` marker that :class:`SoftFileLock` still writes.
 #: Protocol 2 carries the owner mode and the lease claim. A protocol 1 reader treats a protocol 2 marker as malformed
 #: and evicts it after its grace period, so the two never guarantee mutual exclusion against each other.
 _PROTOCOL: Final[str] = "filelock/2"
@@ -26,6 +26,7 @@ class OwnerRecord(NamedTuple):
     mode: OwnerMode
     token: str | None = None
     lease_duration: float | None = None
+    start: int | None = None
 
 
 class MarkerSoftFileLock(SoftFileLock):
@@ -63,7 +64,7 @@ class MarkerSoftFileLock(SoftFileLock):
 
         """
         owner = self._read_owner()
-        return owner is not None and owner.pid == os.getpid() and owner.hostname == socket.gethostname()
+        return owner is not None and owner.pid == os.getpid() and owner.hostname == host_name()
 
     def force_break(self) -> None:
         """
@@ -83,7 +84,12 @@ class MarkerSoftFileLock(SoftFileLock):
         write_all(fd, encode_marker(self._published_record()))
 
     def _published_record(self) -> OwnerRecord:
-        return OwnerRecord(pid=os.getpid(), hostname=socket.gethostname(), mode=self._owner_mode)
+        return OwnerRecord(
+            pid=os.getpid(),
+            hostname=host_name(),
+            mode=self._owner_mode,
+            start=process_start_token(os.getpid()),
+        )
 
 
 def encode_marker(record: OwnerRecord) -> bytes:
@@ -93,6 +99,8 @@ def encode_marker(record: OwnerRecord) -> bytes:
         lines.append(f"token={record.token}")
     if record.lease_duration is not None:
         lines.append(f"duration={record.lease_duration!r}")
+    if record.start is not None:
+        lines.append(f"start={record.start}")
     return "".join(f"{line}\n" for line in lines).encode()
 
 
@@ -124,6 +132,7 @@ def _build_record(fields: dict[str, str]) -> OwnerRecord | None:
     try:
         pid = int(fields["pid"])
         duration = float(fields["duration"]) if "duration" in fields else None
+        start = int(fields["start"]) if "start" in fields else None
     except ValueError:
         return None
     if not 1 <= pid <= _MAX_PID:
@@ -131,7 +140,7 @@ def _build_record(fields: dict[str, str]) -> OwnerRecord | None:
     token = fields.get("token")
     if mode == "lease" and (token is None or duration is None or duration <= 0):
         return None
-    return OwnerRecord(pid=pid, hostname=hostname, mode=mode, token=token, lease_duration=duration)
+    return OwnerRecord(pid=pid, hostname=hostname, mode=mode, token=token, lease_duration=duration, start=start)
 
 
 __all__ = [

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -1,41 +1,19 @@
 from __future__ import annotations
 
 import os
-import socket
 import stat
 import sys
 import time
 from contextlib import suppress
-from errno import EACCES, EEXIST, EPERM, ESRCH
+from errno import EACCES, EEXIST, EPERM
 from pathlib import Path
 from typing import Final
 
 from ._api import BaseFileLock, _raise_grouped_errors
+from ._identity import host_name, owner_is_stale, process_start_token
 from ._soft_protocol import STRICT_SOFT_SENTINEL_RECORD
 from ._util import break_lock_file, ensure_directory_exists, raise_on_not_writable_file, write_all
 
-if sys.platform == "win32":  # pragma: win32 cover
-    import ctypes
-    from ctypes import wintypes
-
-    _KERNEL32: Final[ctypes.WinDLL] = ctypes.WinDLL("kernel32", use_last_error=True)
-    _KERNEL32.CloseHandle.argtypes = [wintypes.HANDLE]
-    _KERNEL32.CloseHandle.restype = wintypes.BOOL
-    _KERNEL32.GetProcessTimes.argtypes = [
-        wintypes.HANDLE,
-        ctypes.POINTER(wintypes.FILETIME),
-        ctypes.POINTER(wintypes.FILETIME),
-        ctypes.POINTER(wintypes.FILETIME),
-        ctypes.POINTER(wintypes.FILETIME),
-    ]
-    _KERNEL32.GetProcessTimes.restype = wintypes.BOOL
-    _KERNEL32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
-    _KERNEL32.OpenProcess.restype = wintypes.HANDLE
-
-_WIN_SYNCHRONIZE: Final[int] = 0x100000
-_WIN_ERROR_INVALID_PARAMETER: Final[int] = 87
-_WIN_INHERIT_HANDLE: Final[bool] = False
-_WIN_PROCESS_QUERY_LIMITED_INFORMATION: Final[int] = 0x1000
 _MALFORMED_LOCK_AGE_THRESHOLD: Final[float] = 2.0
 _MAX_LOCK_FILE_SIZE: Final[int] = 1024
 _UNLINK_MAX_RETRIES: Final[int] = 10
@@ -114,76 +92,24 @@ class SoftFileLock(BaseFileLock):
             holder = _parse_lock_holder(content)
 
             if holder is None:
-                # Unparsable: wrong line count, a non-integer PID or creation time, empty, oversized or not UTF-8.
+                # Unparsable: wrong line count, a non-integer PID or start token, empty, oversized or not UTF-8.
                 # Self-heal only once the file is clearly not a half-written fresh lock (a peer between O_EXCL and
                 # _write_lock_info), so the brief create-then-write window is never mistaken for a stale lock.
                 if time.time() - mtime >= _MALFORMED_LOCK_AGE_THRESHOLD:
                     break_lock_file(self.lock_file, mtime, ino)
                 return
 
-            pid, hostname, creation_time = holder
-            if hostname != socket.gethostname():
-                return
-
-            if self._is_process_alive(pid):
-                if sys.platform != "win32" or creation_time is None:  # pragma: win32 no cover
-                    return  # same process, or no creation time to disambiguate a recycled PID, so don't evict
-                actual = self._get_process_creation_time(pid)  # pragma: win32 cover
-                if actual is None or actual == creation_time:  # pragma: win32 cover
-                    return  # same process or can't verify, so don't evict
-                # PID alive but creation time differs, so the PID was recycled and the lock is stale.
-
-            break_lock_file(self.lock_file, mtime, ino)
+            if owner_is_stale(*holder):
+                break_lock_file(self.lock_file, mtime, ino)
 
     @staticmethod
-    def _is_process_alive(pid: int) -> bool:
-        if sys.platform == "win32":  # pragma: win32 cover
-            handle = _KERNEL32.OpenProcess(_WIN_SYNCHRONIZE, _WIN_INHERIT_HANDLE, pid)
-            if handle:
-                _KERNEL32.CloseHandle(handle)
-                return True
-            return ctypes.get_last_error() != _WIN_ERROR_INVALID_PARAMETER
-        try:
-            os.kill(pid, 0)
-        except OSError as exc:
-            if exc.errno == ESRCH:
-                return False
-            if exc.errno == EPERM:
-                return True
-            raise
-        return True
-
-    @staticmethod
-    def _get_process_creation_time(pid: int) -> int | None:
-        """Return the process creation FILETIME as an integer on Windows, ``None`` otherwise."""
-        if sys.platform != "win32":  # pragma: win32 no cover
-            return None
-        handle = _KERNEL32.OpenProcess(_WIN_PROCESS_QUERY_LIMITED_INFORMATION, _WIN_INHERIT_HANDLE, pid)
-        if not handle:
-            return None
-        try:
-            creation = wintypes.FILETIME()
-            exit_time = wintypes.FILETIME()
-            kernel_time = wintypes.FILETIME()
-            user_time = wintypes.FILETIME()
-            if not _KERNEL32.GetProcessTimes(
-                handle,
-                ctypes.byref(creation),
-                ctypes.byref(exit_time),
-                ctypes.byref(kernel_time),
-                ctypes.byref(user_time),
-            ):
-                return None
-        finally:
-            _KERNEL32.CloseHandle(handle)
-        return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
-
-    def _write_lock_info(self, fd: int) -> None:
+    def _write_lock_info(fd: int) -> None:
         # No suppression: a write failure must reach the acquisition rollback so it never publishes a half-written
-        # marker as held state.
-        info = f"{os.getpid()}\n{socket.gethostname()}\n"
-        if sys.platform == "win32" and (ct := self._get_process_creation_time(os.getpid())) is not None:
-            info += f"{ct}\n"
+        # marker as held state. The optional third line is this process's start token, absent when the platform
+        # exposes no proven start time, in which case a reader falls back to PID-only liveness.
+        info = f"{os.getpid()}\n{host_name()}\n"
+        if (token := process_start_token(os.getpid())) is not None:
+            info += f"{token}\n"
         write_all(fd, info.encode())
 
     @property
@@ -212,7 +138,7 @@ class SoftFileLock(BaseFileLock):
             holder = _parse_lock_holder(_read_lock_file(self.lock_file)[0])
             if holder is not None:
                 pid, hostname, _ = holder
-                return pid == os.getpid() and hostname == socket.gethostname()
+                return pid == os.getpid() and hostname == host_name()
         return False
 
     def break_lock(self) -> None:
@@ -308,14 +234,15 @@ def _read_lock_file(path: str) -> tuple[str | None, float, int]:
 
 
 def _parse_lock_holder(content: str | None) -> tuple[int, str, int | None] | None:
-    # A well-formed lock file is "<pid>\n<hostname>\n" with an optional "<creation_time>\n" third line on Windows.
-    # Anything else (wrong line count, a non-integer PID or creation time, empty or unreadable content) is
-    # unparsable; returning None lets the caller treat it as a malformed lock to self-heal rather than a holder.
+    # A well-formed lock file is "<pid>\n<hostname>\n" with an optional "<start_token>\n" third line naming the
+    # holder's process start instant (a filelock 3.29 marker wrote this only on Windows; every platform writes it now).
+    # Anything else (wrong line count, a non-integer PID or start token, empty or unreadable content) is unparsable;
+    # returning None lets the caller treat it as a malformed lock to self-heal rather than a holder.
     if not content or len(lines := content.strip().splitlines()) not in {2, 3}:
         return None
     try:
         pid = int(lines[0])
-        creation_time = int(lines[2]) if len(lines) == 3 else None  # noqa: PLR2004
+        start_token = int(lines[2]) if len(lines) == 3 else None  # noqa: PLR2004
     except ValueError:
         return None
     # A pid outside the valid range is a malformed lock, not a holder. Without this, a non-positive pid
@@ -324,7 +251,7 @@ def _parse_lock_holder(content: str | None) -> tuple[int, str, int | None] | Non
     # (not OSError/ValueError) out of the self-heal path. _parse_marker_bytes already enforces this range.
     if not 1 <= pid <= 2**31 - 1:
         return None
-    return pid, lines[1], creation_time
+    return pid, lines[1], start_token
 
 
 __all__ = [

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import os
 import secrets
-import socket
 import stat
 import sys
 import tempfile
@@ -15,6 +14,7 @@ from typing import TYPE_CHECKING, Final, Literal, cast
 
 from ._api import BaseFileLock, _canonical, _raise_cleanup_errors
 from ._error import SoftFileLockProtocolError
+from ._identity import host_name, process_start_token
 from ._soft_protocol import STRICT_SOFT_SENTINEL_RECORD
 from ._util import ensure_directory_exists, write_all
 
@@ -238,6 +238,9 @@ class StrictSoftFileClaim:
     token: str
     pid: int
     hostname: str
+    #: The owner's process start token, or ``None`` when the platform exposes no proven start time. A strict lock never
+    #: reclaims a claim on its own, so this identifies the owner for tooling rather than driving any automatic break.
+    start: int | None = None
 
 
 class _PrivateRecordReclaimedError(Exception):
@@ -353,8 +356,9 @@ def _parse_claim(
     record: bytes,
 ) -> StrictSoftFileClaim:
     try:
-        magic, token, pid_text, hostname_hex, trailing = record.decode("ascii").split("\n")
+        magic, token, pid_text, hostname_hex, start_text, trailing = record.decode("ascii").split("\n")
         pid = int(pid_text)
+        start = int(start_text) if start_text else None
         hostname = bytes.fromhex(hostname_hex).decode("utf-8")
     except (UnicodeDecodeError, ValueError) as error:
         raise SoftFileLockProtocolError(lock_file, name, "malformed claim record") from error
@@ -364,12 +368,13 @@ def _parse_claim(
         token == name_parts[1],
         1 <= pid <= 2**32 - 1,
         str(pid) == pid_text,
+        start is None or (start >= 0 and str(start) == start_text),
         hostname.encode().hex() == hostname_hex
         and hostname.isprintable()
         and not any(character.isspace() for character in hostname),
     )):
         raise SoftFileLockProtocolError(lock_file, name, "malformed claim record")
-    return StrictSoftFileClaim(name=name, state=name_parts[0], token=token, pid=pid, hostname=hostname)
+    return StrictSoftFileClaim(name=name, state=name_parts[0], token=token, pid=pid, hostname=hostname, start=start)
 
 
 def _parse_claim_name(name: str) -> tuple[StrictSoftFileClaimState, str] | None:
@@ -393,8 +398,10 @@ def _claim_token_key(name: str) -> str:
 
 
 def _claim_record(token: str) -> bytes:
-    hostname_hex = socket.gethostname().encode().hex()
-    return f"{_CLAIM_MAGIC}\n{token}\n{os.getpid()}\n{hostname_hex}\n".encode("ascii")
+    hostname_hex = host_name().encode().hex()
+    start = process_start_token(os.getpid())
+    start_text = "" if start is None else str(start)
+    return f"{_CLAIM_MAGIC}\n{token}\n{os.getpid()}\n{hostname_hex}\n{start_text}\n".encode("ascii")
 
 
 def _publish_record(

--- a/tests/test_marker_records.py
+++ b/tests/test_marker_records.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import pytest
 
 from filelock import SoftFileLease, Timeout
+from filelock._identity import process_start_token
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 @pytest.mark.parametrize(
@@ -29,6 +33,7 @@ if TYPE_CHECKING:
         pytest.param(
             "filelock/2\npid=1\nhost=h\nmode=lease\ntoken=t\nduration=soon\n", id="lease-duration-not-a-number"
         ),
+        pytest.param("filelock/2\npid=1\nhost=h\nmode=strict\nstart=later\n", id="start-not-a-number"),
     ],
 )
 def test_unreadable_record_names_no_owner(tmp_path: Path, record: str) -> None:
@@ -36,6 +41,16 @@ def test_unreadable_record_names_no_owner(tmp_path: Path, record: str) -> None:
     marker.write_text(record, encoding="utf-8")
 
     assert SoftFileLease(str(marker), lease_duration=1).owner is None
+
+
+def test_record_start_token_reads_back(tmp_path: Path) -> None:
+    marker = tmp_path / "a.lock"
+    marker.write_text("filelock/2\npid=4242\nhost=somehost\nmode=strict\nstart=987654\n", encoding="utf-8")
+
+    owner = SoftFileLease(str(marker), lease_duration=1).owner
+
+    assert owner is not None
+    assert (owner.pid, owner.hostname, owner.mode, owner.start) == (4242, "somehost", "strict", 987654)
 
 
 def test_record_from_a_newer_filelock_still_names_its_owner(tmp_path: Path) -> None:
@@ -47,6 +62,23 @@ def test_record_from_a_newer_filelock_still_names_its_owner(tmp_path: Path) -> N
 
     assert owner is not None
     assert (owner.pid, owner.hostname, owner.mode) == (4242, "somehost", "strict")
+
+
+def test_held_lease_records_the_process_start_token(tmp_path: Path) -> None:
+    marker = tmp_path / "a.lock"
+    with SoftFileLease(str(marker), lease_duration=5) as lease:
+        assert lease.owner is not None
+        assert lease.owner.start == process_start_token(os.getpid())
+
+
+def test_marker_without_start_token_omits_it(tmp_path: Path, mocker: MockerFixture) -> None:
+    # A platform without a proven start time publishes no start field, and the record still reads back cleanly.
+    mocker.patch("filelock._marker.process_start_token", return_value=None)
+    marker = tmp_path / "a.lock"
+    with SoftFileLease(str(marker), lease_duration=5) as lease:
+        assert lease.owner is not None
+        assert lease.owner.start is None
+        assert "start=" not in marker.read_text(encoding="utf-8")
 
 
 def test_lease_treats_an_unreadable_record_as_contention(tmp_path: Path) -> None:

--- a/tests/test_process_identity.py
+++ b/tests/test_process_identity.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from errno import ENODEV, EPERM
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from filelock._identity import host_name, owner_is_stale, process_alive, process_start_token
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+_DEAD_PID: Final[int] = 2**22 + 1
+_POSIX_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform == "win32", reason="posix kill semantics")
+
+
+def test_host_name_matches_socket() -> None:
+    assert host_name() == socket.gethostname()
+
+
+def test_process_alive_true_for_self() -> None:
+    assert process_alive(os.getpid()) is True
+
+
+def test_process_alive_false_for_dead() -> None:
+    assert process_alive(_DEAD_PID) is False
+
+
+@_POSIX_ONLY
+def test_process_alive_reads_permission_denied_as_alive(mocker: MockerFixture) -> None:
+    mocker.patch("filelock._identity.os.kill", side_effect=OSError(EPERM, "operation not permitted"))
+    assert process_alive(_DEAD_PID) is True
+
+
+@_POSIX_ONLY
+def test_process_alive_reraises_unexpected_errno(mocker: MockerFixture) -> None:
+    mocker.patch("filelock._identity.os.kill", side_effect=OSError(ENODEV, "no such device"))
+    with pytest.raises(OSError, match="no such device"):
+        process_alive(_DEAD_PID)
+
+
+def test_process_start_token_is_int_for_self() -> None:
+    assert isinstance(process_start_token(os.getpid()), int)
+
+
+def test_process_start_token_none_for_dead() -> None:
+    assert process_start_token(_DEAD_PID) is None
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS sysctl probe")
+def test_darwin_sysctl_probe_failure_reads_no_token(mocker: MockerFixture) -> None:
+    mocker.patch("filelock._identity._LIBC.sysctl", return_value=-1)
+    assert process_start_token(os.getpid()) is None
+
+
+def test_owner_is_stale_foreign_host_never_reclaimed() -> None:
+    assert owner_is_stale(os.getpid(), "another-host.example.com", 1) is False
+
+
+def test_owner_is_stale_dead_process_reclaimed() -> None:
+    assert owner_is_stale(_DEAD_PID, host_name(), 1) is True
+
+
+def test_owner_is_stale_live_process_without_token_held() -> None:
+    assert owner_is_stale(os.getpid(), host_name(), None) is False
+
+
+def test_owner_is_stale_live_process_matching_token_held() -> None:
+    assert owner_is_stale(os.getpid(), host_name(), process_start_token(os.getpid())) is False
+
+
+def test_owner_is_stale_live_process_mismatched_token_reclaimed() -> None:
+    token = process_start_token(os.getpid())
+    assert token is not None
+    assert owner_is_stale(os.getpid(), host_name(), token + 1) is True
+
+
+def test_owner_is_stale_live_process_unreadable_token_held(mocker: MockerFixture) -> None:
+    # A live PID whose current start token cannot be read is indistinguishable from the recorded owner, so it holds.
+    mocker.patch("filelock._identity.process_start_token", return_value=None)
+    assert owner_is_stale(os.getpid(), host_name(), 987654) is False

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Final
 import pytest
 
 from filelock import CloseErrorPolicy, SoftFileLock
+from filelock._identity import process_start_token
 from filelock._soft import _MAX_LOCK_FILE_SIZE
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
@@ -40,18 +41,18 @@ def lock_path(tmp_path: Path) -> Path:
     return tmp_path / "test.lock"
 
 
-def _holder(pid: int, *, host: str = _HOST, creation_time: int | None = None) -> str:
-    return "\n".join([str(pid), host, *([] if creation_time is None else [str(creation_time)])]) + "\n"
+def _holder(pid: int, *, host: str = _HOST, start: int | None = None) -> str:
+    return "\n".join([str(pid), host, *([] if start is None else [str(start)])]) + "\n"
 
 
 def test_lock_writes_pid_and_hostname(lock_path: Path) -> None:
     with SoftFileLock(lock_path):
         lines = lock_path.read_text(encoding="utf-8").strip().splitlines()
-        if sys.platform == "win32":
-            assert lines[:2] == [str(os.getpid()), _HOST]
-            assert len(lines) == 3
-            int(lines[2])  # creation FILETIME must parse as int
-        else:
+        assert lines[:2] == [str(os.getpid()), _HOST]
+        # Every platform with a proven start time writes it as an integer third line; one without writes two lines.
+        if (token := process_start_token(os.getpid())) is not None:
+            assert lines == [str(os.getpid()), _HOST, str(token)]
+        else:  # pragma: no cover  # every CI platform exposes a start time
             assert lines == [str(os.getpid()), _HOST]
 
 
@@ -59,23 +60,51 @@ def test_lock_writes_pid_and_hostname(lock_path: Path) -> None:
     "content",
     [
         pytest.param(_holder(_DEAD_PID), id="two_line"),
-        pytest.param(_holder(_DEAD_PID, creation_time=123456789), id="three_line"),
+        pytest.param(_holder(_DEAD_PID, start=123456789), id="three_line"),
     ],
 )
 def test_stale_lock_broken_when_process_dead(lock_path: Path, mocker: MockerFixture, content: str) -> None:
     lock_path.write_text(content, encoding="utf-8")
-    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=False)
+    mocker.patch("filelock._identity.process_alive", return_value=False)
     _assert_self_heals(lock_path)
 
 
 def test_stale_lock_not_broken_when_process_alive(lock_path: Path, mocker: MockerFixture) -> None:
     lock_path.write_text(_holder(os.getpid()), encoding="utf-8")
-    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=True)
+    mocker.patch("filelock._identity.process_alive", return_value=True)
     _assert_times_out(lock_path)
 
 
 def test_stale_lock_not_broken_different_hostname(lock_path: Path) -> None:
     lock_path.write_text(_holder(_DEAD_PID, host="other-host.example.com"), encoding="utf-8")
+    _assert_times_out(lock_path)
+
+
+_REQUIRES_START_TOKEN: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    process_start_token(os.getpid()) is None, reason="platform exposes no proven process start time"
+)
+
+
+@_REQUIRES_START_TOKEN
+def test_recycled_pid_marker_self_heals(lock_path: Path) -> None:
+    # A live PID (our own) whose recorded start token differs is a recycled PID: the process that wrote the marker is
+    # gone even though the number is now in use. No mock: the real start token is read and found not to match.
+    token = process_start_token(os.getpid())
+    assert token is not None
+    lock_path.write_text(_holder(os.getpid(), start=token + 1), encoding="utf-8")
+    _assert_self_heals(lock_path)
+
+
+@_REQUIRES_START_TOKEN
+def test_live_process_with_matching_start_token_retained(lock_path: Path) -> None:
+    # Our own PID and our own start token: the recorded owner is this live process, so the marker must stand.
+    lock_path.write_text(_holder(os.getpid(), start=process_start_token(os.getpid())), encoding="utf-8")
+    _assert_times_out(lock_path)
+
+
+def test_live_process_without_start_token_falls_back_to_pid(lock_path: Path) -> None:
+    # A two-line marker carries no start token, so liveness rests on the PID alone; a live PID is left held.
+    lock_path.write_text(_holder(os.getpid()), encoding="utf-8")
     _assert_times_out(lock_path)
 
 
@@ -86,7 +115,7 @@ def test_stale_lock_not_broken_different_hostname(lock_path: Path) -> None:
 )
 def test_stale_lock_not_broken_on_kill_error(lock_path: Path, mocker: MockerFixture, errno: int) -> None:
     lock_path.write_text(_holder(99999), encoding="utf-8")
-    mocker.patch("filelock._soft.os.kill", side_effect=OSError(errno, "kill failed"))
+    mocker.patch("filelock._identity.os.kill", side_effect=OSError(errno, "kill failed"))
     _assert_times_out(lock_path)
 
 
@@ -97,13 +126,13 @@ def test_stale_lock_not_broken_on_kill_error(lock_path: Path, mocker: MockerFixt
         pytest.param(b"", id="empty"),
         pytest.param(b"x" * (_MAX_LOCK_FILE_SIZE + 1), id="oversized"),
         pytest.param(b"not-a-pid\nhostname\n", id="two_line_bad_pid"),
-        pytest.param(f"{_DEAD_PID}\nhostname\nnot-a-time\n".encode(), id="three_line_bad_creation_time"),
+        pytest.param(f"{_DEAD_PID}\nhostname\nnot-a-token\n".encode(), id="three_line_bad_start_token"),
     ],
 )
 def test_unparseable_lock_evicted_when_old(lock_path: Path, content: bytes) -> None:
     lock_path.write_bytes(content)
     os.utime(lock_path, (0, 0))
-    # An unreadable lock (bad line count, non-integer pid/creation time, empty, or oversized) must self-heal
+    # An unreadable lock (bad line count, non-integer pid/start token, empty, or oversized) must self-heal
     # instead of staying stuck; a matching line count alone does not make a file well-formed.
     _assert_self_heals(lock_path)
 
@@ -147,7 +176,7 @@ def test_out_of_range_pid_not_evicted_when_fresh(lock_path: Path) -> None:
 
 def test_stale_lock_rename_race(lock_path: Path, mocker: MockerFixture) -> None:
     lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
-    mocker.patch.object(SoftFileLock, "_is_process_alive", return_value=False)
+    mocker.patch("filelock._identity.process_alive", return_value=False)
     mocker.patch.object(Path, "rename", side_effect=FileNotFoundError("already gone"))
     _assert_times_out(lock_path)
 
@@ -237,7 +266,7 @@ def test_windows_stale_lock_uses_captured_process_error(
         ctypes.windll.kernel32.SetLastError(ambient_error)
 
     # ctypes function pointers do not expose a Python signature for autospec.
-    mocker.patch("filelock._soft._KERNEL32.OpenProcess", side_effect=fail_open_process)
+    mocker.patch("filelock._identity._KERNEL32.OpenProcess", side_effect=fail_open_process)
     lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
     if acquires:
         _assert_self_heals(lock_path)
@@ -249,8 +278,8 @@ def test_windows_stale_lock_uses_captured_process_error(
 def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path) -> None:
     process_marker = lock_path.with_suffix(".process")
     with SoftFileLock(process_marker):
-        creation_time = int(process_marker.read_text(encoding="utf-8").splitlines()[2])
-    lock_path.write_text(_holder(os.getpid(), creation_time=creation_time + 1), encoding="utf-8")
+        start = int(process_marker.read_text(encoding="utf-8").splitlines()[2])
+    lock_path.write_text(_holder(os.getpid(), start=start + 1), encoding="utf-8")
     _assert_self_heals(lock_path)
 
 
@@ -265,7 +294,7 @@ def test_windows_live_process_marker_retained(lock_path: Path) -> None:
 
 
 @_WINDOWS_ONLY
-def test_windows_live_process_marker_without_creation_time_retained(lock_path: Path) -> None:
+def test_windows_live_process_marker_without_start_token_retained(lock_path: Path) -> None:
     lock_path.write_text(_holder(os.getpid()), encoding="utf-8")
     _assert_times_out(lock_path)
 

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -23,6 +23,7 @@ from filelock import (
     StrictSoftFileLock,
     Timeout,
 )
+from filelock._identity import process_start_token
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -42,6 +43,7 @@ def test_strict_soft_acquire_publishes_owner_claim(tmp_path: Path) -> None:
                 token=lock.claims[0].token,
                 pid=os.getpid(),
                 hostname=socket.gethostname(),
+                start=process_start_token(os.getpid()),
             ),
         )
     assert (lock_path.read_bytes(), lock.claims, lock.is_locked) == (_SENTINEL, (), False)
@@ -93,8 +95,8 @@ def test_legacy_client_never_reclaims_permanent_sentinel(tmp_path: Path, mocker:
     lock_path = tmp_path / "resource.lock"
     lock_path.write_bytes(_SENTINEL)
     os.utime(lock_path, (0, 0))
-    mocker.patch("filelock._soft.socket.gethostname", return_value="filelock-strict-v1\x00")
-    mocker.patch("filelock._soft.os.kill", side_effect=ProcessLookupError)
+    mocker.patch("filelock._identity.socket.gethostname", return_value="filelock-strict-v1\x00")
+    mocker.patch("filelock._identity.os.kill", side_effect=ProcessLookupError)
 
     with pytest.raises(Timeout):
         SoftFileLock(lock_path, timeout=0).acquire()
@@ -247,7 +249,7 @@ def test_strict_soft_orphan_claim_blocks_without_reclamation(tmp_path: Path, sta
     claims = Path(f"{lock_path}.filelock") / "claims"
     claims.mkdir(parents=True)
     (claims / claim_name).write_text(
-        f"filelock-strict-v1\n{token}\n{os.getpid()}\n{socket.gethostname().encode().hex()}\n",
+        f"filelock-strict-v1\n{token}\n{os.getpid()}\n{socket.gethostname().encode().hex()}\n4242\n",
         encoding="ascii",
         newline="",
     )
@@ -256,7 +258,9 @@ def test_strict_soft_orphan_claim_blocks_without_reclamation(tmp_path: Path, sta
     with pytest.raises(Timeout):
         lock.acquire()
     assert lock.claims == (
-        StrictSoftFileClaim(name=claim_name, state=state, token=token, pid=os.getpid(), hostname=socket.gethostname()),
+        StrictSoftFileClaim(
+            name=claim_name, state=state, token=token, pid=os.getpid(), hostname=socket.gethostname(), start=4242
+        ),
     )
 
 

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -536,7 +536,7 @@ def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path,
         scans += 1
         if scans == 3:
             Path(path, competitor_name).write_text(
-                f"filelock-strict-v1\n{competitor_token}\n{os.getpid()}\n{socket.gethostname().encode().hex()}\n",
+                f"filelock-strict-v1\n{competitor_token}\n{os.getpid()}\n{socket.gethostname().encode().hex()}\n4242\n",
                 encoding="ascii",
                 newline="",
             )
@@ -714,8 +714,11 @@ def test_strict_soft_claim_directory_read_error_fails_closed(tmp_path: Path, moc
 @pytest.mark.parametrize(
     "content",
     [
-        pytest.param(b"filelock-strict-v1\n" + b"0" * 32 + b"\n0\n00\n", id="zero-pid"),
-        pytest.param(b"filelock-strict-v1\n" + b"1" * 32 + b"\n1\n00\n", id="wrong-token"),
+        pytest.param(b"filelock-strict-v1\n" + b"0" * 32 + b"\n0\n00\n4242\n", id="zero-pid"),
+        pytest.param(b"filelock-strict-v1\n" + b"1" * 32 + b"\n1\n00\n4242\n", id="wrong-token"),
+        pytest.param(b"filelock-strict-v1\n" + b"0" * 32 + b"\n1\n686f7374\nnot-int\n", id="non-integer-start"),
+        pytest.param(b"filelock-strict-v1\n" + b"0" * 32 + b"\n1\n686f7374\n-5\n", id="negative-start"),
+        pytest.param(b"filelock-strict-v1\n" + b"0" * 32 + b"\n1\n686f7374\n007\n", id="noncanonical-start"),
     ],
 )
 def test_strict_soft_structurally_invalid_record_fails_closed(tmp_path: Path, content: bytes) -> None:
@@ -734,7 +737,7 @@ def test_strict_soft_accepts_maximum_pid(tmp_path: Path) -> None:
     claims = Path(f"{lock_path}.filelock") / "claims"
     claims.mkdir(parents=True)
     (claims / f"held-v1-{token}.claim").write_text(
-        f"filelock-strict-v1\n{token}\n4294967295\n686f7374\n",
+        f"filelock-strict-v1\n{token}\n4294967295\n686f7374\n4242\n",
         encoding="ascii",
         newline="",
     )
@@ -759,7 +762,7 @@ def test_strict_soft_rejects_noncanonical_owner_record(tmp_path: Path, pid: str,
     claims = Path(f"{lock_path}.filelock") / "claims"
     claims.mkdir(parents=True)
     (claims / f"held-v1-{token}.claim").write_text(
-        f"filelock-strict-v1\n{token}\n{pid}\n{hostname_hex}\n",
+        f"filelock-strict-v1\n{token}\n{pid}\n{hostname_hex}\n4242\n",
         encoding="ascii",
         newline="",
     )

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Final
 import pytest
 
 from filelock import SoftFileLock, UnixFileLock
+from filelock._identity import process_start_token
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -94,7 +95,11 @@ def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
 
     with UnixFileLock(lock_path):
-        assert lock_path.read_text(encoding="utf-8") == f"{os.getpid()}\n{socket.gethostname()}\n"
+        lines = lock_path.read_text(encoding="utf-8").splitlines()
+    expected = [str(os.getpid()), socket.gethostname()]
+    if (token := process_start_token(os.getpid())) is not None:
+        expected.append(str(token))
+    assert lines == expected
 
 
 @_UNIX_ONLY


### PR DESCRIPTION
A Unix `SoftFileLock` marker records a PID and hostname but nothing that survives PID reuse. When the recorded holder dies and the kernel hands its PID to an unrelated process, `_try_break_stale_lock` sees a live PID and refuses to reclaim, so acquisition wedges until an operator removes the file. Windows already carried a process creation time to tell a recycled PID from the original; Unix had no equivalent. Addresses #639.

Every platform now records the holder's process start time as an integer third line, and one fail-closed rule decides liveness for `SoftFileLock`, `SoftFileLease` and the strict claim: reclaim a marker only when the recorded owner is provably gone. A PID that no longer exists is gone; a live PID whose start token differs is a recycled PID, so the original is gone; a live PID whose token still matches, a token that cannot be read, and a marker from another host all read as held. This is the rule PostgreSQL, Qt `QLockFile`, Mercurial and Firefox all converge on: break a stale lock only on proof of death, never on doubt.

The start token is a per-platform integer compared only for equality. Linux reads `starttime` (field 22) from `/proc/<pid>/stat`, the same `(pid, starttime)` identity psutil uses, folded with the boot id from `/proc/sys/kernel/random/boot_id` so the token stays reboot-safe like the absolute clocks the other platforms expose; macOS reads `kp_proc.p_starttime` through `sysctl(KERN_PROC_PID)`; Windows reuses the `GetProcessTimes` creation `FILETIME`. Qt `QLockFile` records the same boot id for the same reason. Keeping the third line an integer preserves the 3.29 marker format, so a 3.29 reader parses a new marker as well-formed and stays conservative rather than evicting a live holder. The Windows process probe keeps its `use_last_error` binding and `ERROR_INVALID_PARAMETER` handling from #630, now shared by every backend from one module.

`StrictSoftFileLock` never reclaims a claim on its own, so its claim record carries the start token for identity only, exposed on `StrictSoftFileClaim.start` for tooling. Lease compromise reporting and the fencing guidance are unchanged: a start token names an owner, it does not fence a resource. The fail-closed rule preserves the earlier hardening in #534, #551, #556 and #645, which the regression suite re-checks across Linux, macOS and Windows.
