### PR TITLE
🔧 build(pre-commit): swap prettier for mdformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,13 @@ repos:
       - id: ruff-format
       - id: ruff-check
         args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix"]
-  - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.9.5" # Use the sha / tag you want to point at
+  - repo: https://github.com/hukkin/mdformat
+    rev: "1.0.0"
     hooks:
-      - id: prettier
-        args: ["--print-width=120", "--prose-wrap=always"]
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+        args: ["--wrap=120"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.26.1
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ This page lists the steps needed to set up a development environment and contrib
 
 1. Fork and clone this repo.
 
-2. [Install tox](https://tox.wiki/en/latest/installation.html#via-pipx).
+1. [Install tox](https://tox.wiki/en/latest/installation.html#via-pipx).
 
-3. Run tests:
+1. Run tests:
 
    ```shell
    tox run
@@ -18,7 +18,7 @@ This page lists the steps needed to set up a development environment and contrib
    tox run -f py311
    ```
 
-4. Running other tox commands (eg. linting):
+1. Running other tox commands (eg. linting):
 
    ```shell
    tox -e fix


### PR DESCRIPTION
Every pre-commit hook in this repo provisions through uv/pip except one: prettier pulls in a Node toolchain solely to format three markdown files. That extra runtime is the odd one out, and installing it fails outright in constrained or sandboxed shells where npm cannot complete, which blocks the whole local hook run rather than just the markdown step.

This swaps prettier for `mdformat`, a pure-Python formatter that installs down the same path as ruff, codespell, and the rest. The `mdformat-gfm` plugin keeps GitHub-flavored markdown intact and `--wrap=120` preserves the 120-column prose width prettier enforced, so `README.md`, `CONTRIBUTING.md`, and `.github/SECURITY.md` stay wrapped the same way. mdformat renumbers ordered lists to a single marker, which is the only visible reformatting here.

The YAML and JSON files prettier also touched are left alone; they already pass the other hooks and no longer need a Node dependency in the loop.
