### PR TITLE
📝 docs: separate changelog releases with a blank line

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,7 @@
 - Refresh the documentation to the current code: a new trust-boundaries and ownership-scope section (same-UID boundary, advisory native locks, strict claims and lease fencing, a filesystem support matrix, migration off timed stale breaking), the lock-selection flowchart and comparison tables extended with ``StrictSoftFileLock`` and ``SoftFileLease``, and the cross-platform process start token replacing the Windows-only description throughout. :pr:`663`
 - The filesystem support matrix records mutual exclusion measured across two independent client caches in CI: NFS (v4 and v3) for the native, soft, and strict locks, and SMB for the native and soft locks. :pr:`665`
 - Build the changelog from towncrier news fragments, render pending fragments as an ``Unreleased`` docs section, and refuse to publish a tag the changelog does not document. :pr:`626`
+
 ********************
  3.29.7 (2026-07-07)
 ********************

--- a/docs/changelog/template.jinja2
+++ b/docs/changelog/template.jinja2
@@ -10,3 +10,4 @@
 {% endfor %}
 {% endfor %}
 {% endfor %}
+{{ "\n" }}


### PR DESCRIPTION
## What

- Add the missing blank line between the 3.30.0 and 3.29.7 sections in `docs/changelog.rst`.
- Emit a trailing newline from `docs/changelog/template.jinja2` so every future release is separated from the one below it.

## Why

Read the Docs runs `sphinx-build` with `-W`, so any docutils warning fails the build. Both the `stable` and `latest` builds of 3.30.0 failed on:

```
docs/changelog.rst:66: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
build finished with problems, 1 warning (with warnings treated as errors).
```

The towncrier template rendered each release without a trailing blank line, and towncrier's writer (`content + prev_body`, with `prev_body` left-stripped) joins the new section directly onto the previous one — so 3.30.0's last bullet abutted the 3.29.7 header.

`{{ "\n" }}` is used rather than a trailing blank line in the file because towncrier builds the template with `keep_trailing_newline` left at its default (False), which would strip a plain trailing newline.

Verified with the RTD command (`tox run -e docs`, i.e. `sphinx-build -W`): build succeeds, warning gone. A test `towncrier build` confirms new sections are now separated by a blank line.

> [!NOTE]
> This fixes `latest`. The `stable` build renders the `3.30.0` git tag, whose `changelog.rst` still has the defect baked in, so `stable` stays red until the next tag is cut (or 3.30.0 is re-tagged).