### PR TITLE
🐛 fix: tolerate NFSv3 stale handle in strict claim read

### DIFF
--- a/docs/changelog/669.bugfix.rst
+++ b/docs/changelog/669.bugfix.rst
@@ -1,0 +1,3 @@
+``StrictSoftFileLock`` and ``AsyncStrictSoftFileLock`` no longer abort acquisition when a peer's claim vanishes as an
+NFSv3 stale filehandle instead of a clean removal; the reader revalidates and skips it, so strict locks hold mutual
+exclusion across independent NFSv3 client caches.

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
-from errno import EACCES, EEXIST, ENOENT, ENOSYS, ENOTSUP, EPERM, EXDEV
+from errno import EACCES, EEXIST, ENOENT, ENOSYS, ENOTSUP, EPERM, ESTALE, EXDEV
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal, cast
 
@@ -299,9 +299,12 @@ def _read_claims(lock_file: str, directory: Path) -> tuple[StrictSoftFileClaim, 
 
 
 def _read_claim_record(lock_file: str, directory: Path, name: str) -> bytes | None:
-    # Windows holds a claim mid-unlink in a delete-pending state that fails an open with EACCES until the unlink
-    # completes, so a contended scan hits a claim that neither exists nor is readable yet. Retry briefly: a transient
-    # claim resolves to a clean removal, while a genuinely unreadable one (a locked-down record) still fails closed.
+    # A contended scan can list a claim that is not yet cleanly readable, in two ways that both resolve on a brief
+    # retry. Windows holds a claim mid-unlink in a delete-pending state that fails an open with EACCES until the unlink
+    # completes. On NFS, a peer that unlinks its own claim leaves this client's cached filehandle stale, so the next
+    # open returns ESTALE rather than a clean ENOENT until the lookup revalidates against the server. Retrying re-runs
+    # the path lookup, which turns the vanished claim into ENOENT (skip) or reads it if it still exists. A genuinely
+    # unreadable record (a locked-down file, an EIO fault) still fails closed.
     deadline = time.monotonic() + _CLAIM_READ_GRACE
     delaying = False
     while True:
@@ -311,14 +314,20 @@ def _read_claim_record(lock_file: str, directory: Path, name: str) -> bytes | No
         if pending is None:
             return record
         if time.monotonic() >= deadline:
+            if pending.errno == ESTALE:
+                # A stale handle that outlives revalidation is a claim the server no longer has (RFC 1813
+                # NFS3ERR_STALE): skip it like ENOENT. Skipping a peer's vanished claim can only overcount
+                # contention, never free a held lock.
+                return None
             reason = f"cannot read claim: {pending.strerror or str(pending) or type(pending).__name__}"
             raise SoftFileLockProtocolError(lock_file, name, reason) from pending
         delaying = True
 
 
-def _attempt_claim_read(lock_file: str, directory: Path, name: str) -> tuple[bytes | None, PermissionError | None]:
-    # Return the record, or (None, None) when the claim has already gone, or (None, error) for a delete-pending open
-    # the caller may retry. Any other OSError is a real fault and fails closed here rather than looping.
+def _attempt_claim_read(lock_file: str, directory: Path, name: str) -> tuple[bytes | None, OSError | None]:
+    # Return the record, or (None, None) when the claim has already gone, or (None, error) for an open the caller may
+    # retry: a Windows delete-pending EACCES that resolves to a clean removal, or an NFS ESTALE from a peer unlinking
+    # its own claim out from under this client's cached filehandle. Any other OSError is a real fault and fails closed.
     try:
         return _read_record(directory / name, _CLAIM_RECORD_LIMIT), None
     except FileNotFoundError:
@@ -326,6 +335,8 @@ def _attempt_claim_read(lock_file: str, directory: Path, name: str) -> tuple[byt
     except PermissionError as error:
         return None, error
     except OSError as error:
+        if error.errno == ESTALE:
+            return None, error
         reason = f"cannot read claim: {error.strerror or str(error) or type(error).__name__}"
         raise SoftFileLockProtocolError(lock_file, name, reason) from error
 

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -6,7 +6,7 @@ import socket
 import stat
 import sys
 import time
-from errno import EACCES, EEXIST, EIO, EXDEV
+from errno import EACCES, EEXIST, EIO, ESTALE, EXDEV
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -832,6 +832,64 @@ def test_strict_soft_claim_replaced_while_opening_fails_closed(
 
     with pytest.raises(SoftFileLockProtocolError, match=message):
         StrictSoftFileLock(lock_path).acquire()
+
+
+def _write_held_claim(claims: Path) -> Path:
+    claims.mkdir(parents=True)
+    claim = claims / f"held-v1-{'0' * 32}.claim"
+    claim.write_bytes(b"filelock-strict-v1\n" + b"0" * 32 + b"\n1\n686f7374\n\n")
+    return claim
+
+
+def _open_raising_for(claim: Path, error: OSError, mocker: MockerFixture) -> None:
+    real_open = os.open
+
+    def failing_open(path: _PathValue, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        if os.fsdecode(path) == str(claim):
+            raise error
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    mocker.patch("filelock._strict.os.open", side_effect=failing_open)
+
+
+def test_strict_soft_stale_claim_read_is_skipped(tmp_path: Path, mocker: MockerFixture) -> None:
+    # An NFS peer that unlinks its own claim leaves this client's cached filehandle stale, so the open returns ESTALE
+    # rather than ENOENT. A stale handle that outlives revalidation is a vanished claim, not an unreadable one.
+    lock_path = tmp_path / "resource.lock"
+    claim = _write_held_claim(Path(f"{lock_path}.filelock") / "claims")
+    mocker.patch("filelock._strict._CLAIM_READ_GRACE", 0.02)
+    _open_raising_for(claim, OSError(ESTALE, "Stale file handle"), mocker)
+
+    assert StrictSoftFileLock(lock_path).claims == ()
+
+
+def test_strict_soft_stale_claim_read_revalidates_to_gone(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    claim = _write_held_claim(Path(f"{lock_path}.filelock") / "claims")
+    real_open = os.open
+    stale_raised = False
+
+    def stale_then_vanish(path: _PathValue, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        nonlocal stale_raised
+        if not stale_raised and os.fsdecode(path) == str(claim):
+            stale_raised = True
+            claim.unlink()
+            raise OSError(ESTALE, "Stale file handle")
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    mocker.patch("filelock._strict.os.open", side_effect=stale_then_vanish)
+
+    assert StrictSoftFileLock(lock_path).claims == ()
+    assert stale_raised
+
+
+def test_strict_soft_io_error_claim_read_fails_closed(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    claim = _write_held_claim(Path(f"{lock_path}.filelock") / "claims")
+    _open_raising_for(claim, OSError(EIO, "I/O error"), mocker)
+
+    with pytest.raises(SoftFileLockProtocolError, match="cannot read claim"):
+        _ = StrictSoftFileLock(lock_path).claims
 
 
 def test_strict_soft_directory_inspection_error_fails_closed(tmp_path: Path, mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Symptom

The `🗄️ NFS mutual exclusion` CI job fails on **NFSv3** while `StrictSoftFileLock` reads a peer's `intent-*.claim`:

```
StrictSoftFileLock   FAIL  held=300/400 overlaps=0
  SoftFileLockProtocolError: Invalid strict soft-lock state at /mnt/nfs3b/...: claim 'intent-v1-….claim': cannot read claim: …
```

`overlaps=0` throughout — mutual exclusion is never violated; acquisition just **aborts**. The same test passes on NFSv4.2, SMB, and local filesystems.

## Root cause

The strict lock is a hard-link bakery/doorway: a contender publishes an `intent-*` claim, and once it promotes to `held-*` it unlinks its own `intent-*` (`_strict.py`, step 5). A concurrent contender scans the claim directory and reads every claim it lists.

On NFSv3 with `nosharecache`, each mount holds an independent attribute/dentry cache, and the client only drops a cached positive `LOOKUP` after it observes a change in the parent directory's mtime. So a scanner that already resolved the peer's `intent-*` name still holds a **cached filehandle** for it. When the peer unlinks that file, the scanner's `lstat`/`open` reuses the now-stale filehandle and the server returns **`NFS3ERR_STALE` → `ESTALE`**, not `ENOENT` (RFC 1813: a filehandle to an object that no longer exists yields `STALE`, distinct from name-based `NOENT`). `_attempt_claim_read` treated `FileNotFoundError` as "gone, skip" but routed **every other `OSError` straight to a fatal fail-closed error** — so this benign vanished-claim race aborted acquisition.

This was verified against RFC 1813, `nfs(5)`, the Linux VFS ESTALE-retry work ([LWN](https://lwn.net/Articles/515302/)), IBM APARs [IZ98698](https://www.ibm.com/support/pages/apar/IZ98698)/[IZ98699](https://www.ibm.com/support/pages/apar/IZ98699) (returning `ENOENT` instead of `ESTALE` for a deleted file is itself classified as a *defect*), and the canonical NFS-safe Python lock [`flufl.lock`](https://bugs.launchpad.net/bugs/977999), which has caught `(ENOENT, ESTALE)` identically for ~12 years.

## Fix

In the claim reader, treat `ESTALE` as a **retryable, revalidate-then-skip** condition rather than a fatal error:

- On `ESTALE`, retry the read within the existing grace window. The retry re-runs the path lookup, which forces NFS revalidation — the claim resolves to `ENOENT` (skip) or reads successfully if it still exists.
- A stale handle that outlives revalidation is a claim the server no longer has, so skip it like `ENOENT`.
- **Every other `OSError` (e.g. `EIO`) still fails closed** — blanket-skipping arbitrary errors would be the unsafe shortcut.

This preserves the never-two-holders guarantee: skipping a peer's vanished claim can only *overcount* contention (a spurious retry), never declare a held lock free. Applies to `StrictSoftFileLock` and `AsyncStrictSoftFileLock`.

## Tests

- `test_strict_soft_stale_claim_read_is_skipped` — a persistent `ESTALE` on read is skipped, not fatal.
- `test_strict_soft_stale_claim_read_revalidates_to_gone` — an `ESTALE` that revalidates to `ENOENT` is skipped without exhausting the grace window.
- `test_strict_soft_io_error_claim_read_fails_closed` — `EIO` still fails closed (the safety boundary).

Full strict + async strict suites pass locally.

## Note on the exact errno

The CI log truncates the reason at 160 chars (`verify_filesystem.py` caps it), so the literal `ESTALE` string wasn't captured — it is the strongly-evidenced inference from the caching mechanism + RFC 1813 + the symptom profile (non-`ENOENT`, `nosharecache`, cross-client unlink race). The fix is correct regardless: some stacks return `ENOENT` for this race, which is already handled; catching `ESTALE` too closes the gap.