### PR TITLE
reject non-finite lease duration in marker records

### DIFF
--- a/docs/changelog/670.bugfix.rst
+++ b/docs/changelog/670.bugfix.rst
@@ -1,0 +1,2 @@
+``SoftFileLease`` reads a marker whose lease duration is ``nan`` or ``inf`` as malformed rather than as a valid lease,
+so such a marker ages out through the grace window instead of raising ``LeaseSettingsMismatch`` on every contender.

--- a/src/filelock/_marker.py
+++ b/src/filelock/_marker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import os
 from contextlib import suppress
 from typing import Final, Literal, NamedTuple
@@ -138,7 +139,10 @@ def _build_record(fields: dict[str, str]) -> OwnerRecord | None:
     if not 1 <= pid <= _MAX_PID:
         return None
     token = fields.get("token")
-    if mode == "lease" and (token is None or duration is None or duration <= 0):
+    # float() also parses "nan"/"inf", which slip past a bare duration <= 0 guard (nan <= 0 and inf <= 0 are both
+    # False). A non-finite duration is never something a lease could legitimately publish, so treat such a marker as
+    # malformed and let the reader self-heal it rather than accept it as a valid claim.
+    if mode == "lease" and (token is None or duration is None or not (math.isfinite(duration) and duration > 0)):
         return None
     return OwnerRecord(pid=pid, hostname=hostname, mode=mode, token=token, lease_duration=duration, start=start)
 

--- a/src/filelock/_marker.py
+++ b/src/filelock/_marker.py
@@ -139,9 +139,9 @@ def _build_record(fields: dict[str, str]) -> OwnerRecord | None:
     if not 1 <= pid <= _MAX_PID:
         return None
     token = fields.get("token")
-    # float() also parses "nan"/"inf", which slip past a bare duration <= 0 guard (nan <= 0 and inf <= 0 are both
-    # False). A non-finite duration is never something a lease could legitimately publish, so treat such a marker as
-    # malformed and let the reader self-heal it rather than accept it as a valid claim.
+    # float() accepts "nan" and "inf", and neither is non-positive, so a duration <= 0 guard alone would read such a
+    # marker as a valid lease. A nan duration mismatches every configured duration and so wedges reclaim, where a
+    # malformed marker ages out through the grace window.
     if mode == "lease" and (token is None or duration is None or not (math.isfinite(duration) and duration > 0)):
         return None
     return OwnerRecord(pid=pid, hostname=hostname, mode=mode, token=token, lease_duration=duration, start=start)

--- a/tests/test_marker_records.py
+++ b/tests/test_marker_records.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
         pytest.param(
             "filelock/2\npid=1\nhost=h\nmode=lease\ntoken=t\nduration=soon\n", id="lease-duration-not-a-number"
         ),
+        pytest.param("filelock/2\npid=1\nhost=h\nmode=lease\ntoken=t\nduration=nan\n", id="lease-duration-nan"),
+        pytest.param("filelock/2\npid=1\nhost=h\nmode=lease\ntoken=t\nduration=inf\n", id="lease-duration-inf"),
         pytest.param("filelock/2\npid=1\nhost=h\nmode=strict\nstart=later\n", id="start-not-a-number"),
     ],
 )


### PR DESCRIPTION
_build_record parses a marker's lease duration with float(), which also accepts "nan" and "inf"; the following duration <= 0 guard lets both through, since neither compares as non-positive. A peer sharing the filesystem that plants a lease marker carrying duration=nan is then read as a valid claim rather than a malformed one, so every contender raises LeaseSettingsMismatch (nan compares unequal to any configured duration) and the stale marker is never reclaimed, wedging acquisition on that path. Rejecting a non-finite duration lets such a marker fall through to the malformed path and self-heal, the same way an out-of-range pid already does.