### PR TITLE
📝 docs(mermaid): follow the light and dark theme toggle

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -61,9 +61,115 @@
     }
 }
 
-/* Mermaid diagrams carry light fills with dark ink in both themes, so the rendered SVG keeps its own background
-   rather than inheriting furo's dark surface. Center each diagram and let a wide flowchart scroll on its own. */
+/* Center each diagram and let a wide flowchart scroll on its own. */
 .mermaid {
     text-align: center;
     overflow-x: auto;
 }
+
+/* The diagrams carry no colors of their own: sphinxcontrib-mermaid renders them in the browser and re-renders them on
+   every theme toggle, so a palette written into the diagram source would be baked at whichever theme happened to load
+   first and then stay light on a dark page. The source names a role (`class default recommended`), mermaid copies that
+   name onto the node, and the two palettes below fill it in. Keep a tint's meaning consistent across diagrams: blue is
+   the caller's own code, orange is the lock coordinating it, green is the data under the lock, purple the way out.
+
+   Mermaid scopes its own rules under the generated SVG's id, which outranks anything selectable from here, so these
+   declarations need !important to land. */
+body {
+    --diagram-green-bg: #e8f5e9;
+    --diagram-green-line: #2e7d32;
+    --diagram-green-ink: #1b5e20;
+    --diagram-orange-bg: #fff3e0;
+    --diagram-orange-line: #e65100;
+    --diagram-orange-ink: #bf360c;
+    --diagram-blue-bg: #e3f2fd;
+    --diagram-blue-line: #1565c0;
+    --diagram-blue-ink: #0d47a1;
+    --diagram-purple-bg: #ede7f6;
+    --diagram-purple-line: #4527a0;
+    --diagram-purple-ink: #311b92;
+}
+
+/* Dark tints hold their hue at roughly a tenth of the light fill's lightness, and lift the ink to the same hue's pale
+   end: every pair clears 7:1, which the light palette's orange does not quite manage. Mirror furo's own two-selector
+   split so an explicit toggle and an untouched "auto" both land. */
+@media not print {
+    body[data-theme="dark"] {
+        --diagram-green-bg: #1b3a24;
+        --diagram-green-line: #66bb6a;
+        --diagram-green-ink: #c8e6c9;
+        --diagram-orange-bg: #3d2a14;
+        --diagram-orange-line: #ffa726;
+        --diagram-orange-ink: #ffe0b2;
+        --diagram-blue-bg: #12304d;
+        --diagram-blue-line: #42a5f5;
+        --diagram-blue-ink: #bbdefb;
+        --diagram-purple-bg: #272040;
+        --diagram-purple-line: #9575cd;
+        --diagram-purple-ink: #d1c4e9;
+    }
+
+    @media (prefers-color-scheme: dark) {
+        body:not([data-theme="light"]) {
+            --diagram-green-bg: #1b3a24;
+            --diagram-green-line: #66bb6a;
+            --diagram-green-ink: #c8e6c9;
+            --diagram-orange-bg: #3d2a14;
+            --diagram-orange-line: #ffa726;
+            --diagram-orange-ink: #ffe0b2;
+            --diagram-blue-bg: #12304d;
+            --diagram-blue-line: #42a5f5;
+            --diagram-blue-ink: #bbdefb;
+            --diagram-purple-bg: #272040;
+            --diagram-purple-line: #9575cd;
+            --diagram-purple-ink: #d1c4e9;
+        }
+    }
+}
+
+.mermaid g.node.recommended > rect,
+.mermaid g.node.store > rect {
+    fill: var(--diagram-green-bg) !important;
+    stroke: var(--diagram-green-line) !important;
+}
+
+.mermaid g.node.recommended .nodeLabel,
+.mermaid g.node.store .nodeLabel {
+    color: var(--diagram-green-ink) !important;
+}
+
+.mermaid g.node.alternative > rect,
+.mermaid g.node.counter > rect {
+    fill: var(--diagram-orange-bg) !important;
+    stroke: var(--diagram-orange-line) !important;
+}
+
+.mermaid g.node.alternative .nodeLabel,
+.mermaid g.node.counter .nodeLabel {
+    color: var(--diagram-orange-ink) !important;
+}
+
+.mermaid g.node.special > rect,
+.mermaid g.node.thread > rect {
+    fill: var(--diagram-blue-bg) !important;
+    stroke: var(--diagram-blue-line) !important;
+}
+
+.mermaid g.node.special .nodeLabel,
+.mermaid g.node.thread .nodeLabel {
+    color: var(--diagram-blue-ink) !important;
+}
+
+.mermaid g.node.escape > rect {
+    fill: var(--diagram-purple-bg) !important;
+    stroke: var(--diagram-purple-line) !important;
+}
+
+.mermaid g.node.escape .nodeLabel {
+    color: var(--diagram-purple-ink) !important;
+}
+
+/* A sequence diagram's `box` renders as a bare `rect.rect` with no per-box hook, so the tints above cannot reach it and
+   the group colors stay in the diagram source. They are translucent for that reason: an alpha over the hue composites
+   against whichever background the theme paints, reading pale on white and deep on the dark page, and it shifts the
+   lightness too little to strand the title text mermaid draws on top in the theme's own ink. */

--- a/docs/changelog/674.doc.rst
+++ b/docs/changelog/674.doc.rst
@@ -1,0 +1,2 @@
+Color the mermaid diagrams from whichever theme is active. They previously carried a light palette baked into each
+diagram's source, which stayed light on a dark page.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -16,13 +16,12 @@ For example, imagine two processes writing to the same configuration file:
 
 .. mermaid::
 
-    %%{init: {'theme':'base','themeVariables':{'actorBkg':'#e3f2fd','actorBorder':'#1565c0','actorTextColor':'#0d47a1','actorLineColor':'#90a4ae','activationBkgColor':'#fff3e0','activationBorderColor':'#e65100','noteBkgColor':'#e8f5e9','noteBorderColor':'#2e7d32','noteTextColor':'#1b5e20','signalColor':'#37474f','signalTextColor':'#37474f','labelBoxBkgColor':'#ede7f6','labelBoxBorderColor':'#4527a0','labelTextColor':'#311b92','loopTextColor':'#311b92'}}}%%
     sequenceDiagram
-        box rgb(227, 242, 253) Processes
+        box rgba(21, 101, 192, 0.16) Processes
             participant A as Process A
             participant B as Process B
         end
-        box rgb(232, 245, 233) Shared state
+        box rgba(46, 125, 50, 0.16) Shared state
             participant File as Configuration File
         end
         activate A
@@ -46,16 +45,15 @@ File locks prevent this by ensuring only one process can access a resource at a 
 
 .. mermaid::
 
-    %%{init: {'theme':'base','themeVariables':{'actorBkg':'#e3f2fd','actorBorder':'#1565c0','actorTextColor':'#0d47a1','actorLineColor':'#90a4ae','activationBkgColor':'#fff3e0','activationBorderColor':'#e65100','noteBkgColor':'#e8f5e9','noteBorderColor':'#2e7d32','noteTextColor':'#1b5e20','signalColor':'#37474f','signalTextColor':'#37474f','labelBoxBkgColor':'#ede7f6','labelBoxBorderColor':'#4527a0','labelTextColor':'#311b92','loopTextColor':'#311b92'}}}%%
     sequenceDiagram
-        box rgb(227, 242, 253) Processes
+        box rgba(21, 101, 192, 0.16) Processes
             participant A as Process A
             participant B as Process B
         end
-        box rgb(255, 243, 224) Coordination
+        box rgba(230, 81, 0, 0.16) Coordination
             participant Lock as File Lock
         end
-        box rgb(232, 245, 233) Shared state
+        box rgba(46, 125, 50, 0.16) Shared state
             participant File as Configuration File
         end
         activate A
@@ -286,10 +284,11 @@ Lock selection flowchart:
         question3 -->|Yes| platform["Use UnixFileLock<br/>or WindowsFileLock"]
         question3 -->|No| default["Use FileLock<br/>(recommended)"]
 
-        classDef recommended fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#1b5e20
-        classDef alternative fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#bf360c
-        classDef special fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#0d47a1
-        classDef escape fill:#ede7f6,stroke:#4527a0,stroke-width:2px,color:#311b92
+        %% docs/_static/custom.css colors these classes, once per light and dark theme
+        classDef recommended stroke-width:2px
+        classDef alternative stroke-width:2px
+        classDef special stroke-width:2px
+        classDef escape stroke-width:2px
         class default recommended
         class soft,strict,lease,platform,srw alternative
         class rw,arw special
@@ -756,9 +755,10 @@ Async locks default to ``thread_local=False`` because the thread that calls ``ac
             T4["Thread B"] --- SC
         end
 
-        classDef thread fill:#e3f2fd,stroke:#1565c0,color:#0d47a1
-        classDef counter fill:#fff3e0,stroke:#e65100,color:#bf360c
-        classDef store fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+        %% docs/_static/custom.css colors these classes, once per light and dark theme
+        classDef thread stroke-width:2px
+        classDef counter stroke-width:2px
+        classDef store stroke-width:2px
         class T1,T2,T3,T4 thread
         class SC counter
         class L1,L2 store

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,11 @@ extensions = [
     "sphinxcontrib.towncrier.ext",  # render unreleased news fragments as a draft "Unreleased" section
     "sphinxext.opengraph",
 ]
+# raw output lets the browser render the diagrams, so they can follow furo's light/dark toggle. The extension picks the
+# theme below from the page background and re-renders on every toggle; neutral pairs grays with the semantic tints that
+# docs/_static/custom.css applies.
 mermaid_output_format = "raw"
+mermaid_light_theme = "neutral"
 
 # sphinxcontrib-towncrier: the .. towncrier-draft-entries:: directive in changelog.rst shows the unreleased fragments.
 towncrier_draft_autoversion_mode = "draft"

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -268,15 +268,14 @@ chatty log never shortens the wait, and a long wait never goes quiet. ``huggingf
 
 .. mermaid::
 
-    %%{init: {'theme':'base','themeVariables':{'actorBkg':'#e3f2fd','actorBorder':'#1565c0','actorTextColor':'#0d47a1','actorLineColor':'#90a4ae','activationBkgColor':'#fff3e0','activationBorderColor':'#e65100','noteBkgColor':'#e8f5e9','noteBorderColor':'#2e7d32','noteTextColor':'#1b5e20','signalColor':'#37474f','signalTextColor':'#37474f','labelBoxBkgColor':'#ede7f6','labelBoxBorderColor':'#4527a0','labelTextColor':'#311b92','loopTextColor':'#311b92'}}}%%
     sequenceDiagram
-        box rgb(227, 242, 253) This process
+        box rgba(21, 101, 192, 0.16) This process
             participant C as Caller
         end
-        box rgb(255, 243, 224) Coordination
+        box rgba(230, 81, 0, 0.16) Coordination
             participant L as File Lock
         end
-        box rgb(237, 231, 246) Peer
+        box rgba(69, 39, 160, 0.16) Peer
             participant H as Holder
         end
         activate H
@@ -1128,15 +1127,14 @@ become available.
 
 .. mermaid::
 
-    %%{init: {'theme':'base','themeVariables':{'actorBkg':'#e3f2fd','actorBorder':'#1565c0','actorTextColor':'#0d47a1','actorLineColor':'#90a4ae','activationBkgColor':'#fff3e0','activationBorderColor':'#e65100','noteBkgColor':'#e8f5e9','noteBorderColor':'#2e7d32','noteTextColor':'#1b5e20','signalColor':'#37474f','signalTextColor':'#37474f','labelBoxBkgColor':'#ede7f6','labelBoxBorderColor':'#4527a0','labelTextColor':'#311b92','loopTextColor':'#311b92'}}}%%
     sequenceDiagram
-        box rgb(227, 242, 253) Worker
+        box rgba(21, 101, 192, 0.16) Worker
             participant W as Worker Thread
         end
-        box rgb(255, 243, 224) Coordination
+        box rgba(230, 81, 0, 0.16) Coordination
             participant L as File Lock
         end
-        box rgb(237, 231, 246) Control
+        box rgba(69, 39, 160, 0.16) Control
             participant M as Main Thread
         end
         W->>+L: acquire(cancel_check=shutdown.is_set)

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -76,16 +76,15 @@ the lock and write inside it, two processes can both see it missing and both pro
 
 .. mermaid::
 
-    %%{init: {'theme':'base','themeVariables':{'actorBkg':'#e3f2fd','actorBorder':'#1565c0','actorTextColor':'#0d47a1','actorLineColor':'#90a4ae','activationBkgColor':'#fff3e0','activationBorderColor':'#e65100','noteBkgColor':'#e8f5e9','noteBorderColor':'#2e7d32','noteTextColor':'#1b5e20','signalColor':'#37474f','signalTextColor':'#37474f','labelBoxBkgColor':'#ede7f6','labelBoxBorderColor':'#4527a0','labelTextColor':'#311b92','loopTextColor':'#311b92'}}}%%
     sequenceDiagram
-        box rgb(227, 242, 253) virtualenv runs
+        box rgba(21, 101, 192, 0.16) virtualenv runs
             participant A as virtualenv A
             participant B as virtualenv B
         end
-        box rgb(255, 243, 224) Coordination
+        box rgba(230, 81, 0, 0.16) Coordination
             participant L as Lock
         end
-        box rgb(232, 245, 233) App data
+        box rgba(46, 125, 50, 0.16) App data
             participant C as Cache file
         end
         activate A


### PR DESCRIPTION
The docs render every mermaid diagram in the browser, and `sphinxcontrib-mermaid` re-renders them whenever furo's light/dark toggle flips. 🎨 None of that reached the page. Each diagram pinned its own light palette through a `%%{init}%%` themeVariables block, `box rgb(...)` colors, and `classDef fill:#...`, and a palette in the source outranks the theme the extension picks. On a dark page the diagrams kept dark ink on light fills.

The sources now carry no colors and name a role instead (`class default recommended`). Mermaid copies that name onto the rendered node, and one block in `docs/_static/custom.css` holds both palettes and fills the roles in, keyed off furo's own `body[data-theme=dark]` and `prefers-color-scheme` selectors. Two mermaid constraints set that shape, both checked against mermaid 11.12.1 rather than assumed. `classDef fill:var(--x)` is a parse error and `box var(--x)` falls back to transparent, so the palette cannot live in the source. Mermaid also scopes its own rules under the generated SVG's id, which outranks anything a stylesheet can select, so these declarations need `!important` to land.

The flowchart tints flip between two palettes this way. The dark one holds each hue and lifts the ink to the same hue's pale end, so all four dark pairs clear 7:1 against their fill, where the light palette's orange reaches 5.11. 🌗

A sequence diagram's `box` offers no per-box hook to select on, so those group tints stay in the source and carry an alpha instead. The hue composites against whichever background the theme paints, which reads pale on white and deep on the dark page from one authored value, and shifts the lightness too little to strand the title text mermaid draws on top in the theme's own ink: 16.6:1 light, 9.7:1 dark. The blue caller, orange lock, green data, and purple peer survive on both sides.

Builds on the stylesheet #673 added, and rebased onto `main` now that it merged, so this branch holds one commit.
