### PR TITLE
asyncio: scope the reentrant-deadlock registry to the owning task

### DIFF
--- a/docs/changelog/676.bugfix.rst
+++ b/docs/changelog/676.bugfix.rst
@@ -1,0 +1,2 @@
+``AsyncFileLock`` and ``AsyncSoftFileLock`` no longer raise a deadlock ``RuntimeError`` when a different asyncio task
+waits for a lock they hold; the check now scopes holders to the owning task, so only a same-task reacquire is refused.

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -10,7 +10,7 @@ import sys
 import time
 import warnings
 from abc import ABCMeta, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Hashable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import count, starmap
@@ -324,9 +324,7 @@ def _canonical(path: str | os.PathLike[str]) -> str:
 class _ThreadLocalRegistry(local):
     def __init__(self) -> None:
         super().__init__()
-        # Keyed by BaseFileLock._registry_key: a canonical path when thread-scoped, else a (scope, path) tuple
-        # for locks that scope holders to a finer execution unit such as an asyncio task.
-        self.held: dict[object, int] = {}
+        self.held: dict[Hashable, int] = {}
 
 
 _registry: Final[_ThreadLocalRegistry] = _ThreadLocalRegistry()
@@ -1189,21 +1187,6 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             descriptors.append((self._context.pending_lock_file_fd, self._context.pending_lock_file_fd_identity))
         return tuple(descriptors)
 
-    def _deadlock_scope(self) -> object:  # noqa: PLR6301  # overridable hook; base is intentionally stateless
-        """
-        Execution unit whose own hold would deadlock a new acquire.
-
-        ``None`` scopes holders to the thread, which the thread-local registry already separates. Async locks
-        override it with the running task, since one event loop thread runs many tasks and only a reacquire from
-        the *same* task can self-deadlock.
-        """
-        return None
-
-    def _registry_key(self, canonical: str) -> object:
-        """Registry key for this hold: the path alone when thread-scoped, else paired with the scope identity."""
-        scope = self._deadlock_scope()
-        return canonical if scope is None else (scope, canonical)
-
     def _raise_if_would_deadlock(self, canonical: str, *, timeout: float, blocking: bool) -> None:
         """
         Fail fast when a *different* live instance already holds this path in the current deadlock scope.
@@ -1219,6 +1202,20 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
                 f"Use is_singleton=True to enable reentrant locking across instances."
             )
             raise RuntimeError(msg)
+
+    def _registry_key(self, canonical: str) -> Hashable:
+        return canonical if (scope := self._deadlock_scope()) is None else (scope, canonical)
+
+    @staticmethod
+    def _deadlock_scope() -> Hashable | None:
+        """
+        Execution unit whose own hold would deadlock a new acquire.
+
+        ``None`` scopes holders to the thread, which the thread-local registry already separates. Async locks
+        override it with the running task, since one event loop thread runs many tasks and only a reacquire from
+        the *same* task can self-deadlock.
+        """
+        return None
 
     def _poll_until_acquired(
         self,
@@ -1506,7 +1503,7 @@ class FileLockContext:
     lock_counter: int = 0
 
     #: Canonical registry key captured when the first physical acquisition commits.
-    lock_file_key: object | None = None
+    lock_file_key: Hashable | None = None
 
     #: Claim pathnames this owner published, removed by name on release so no holder ever unlinks a peer's claim.
     owner_claim_paths: tuple[str, ...] = ()

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -324,8 +324,8 @@ def _canonical(path: str | os.PathLike[str]) -> str:
 class _ThreadLocalRegistry(local):
     def __init__(self) -> None:
         super().__init__()
-        # Keys are produced by BaseFileLock._registry_key: a canonical path for thread-scoped holders, or a
-        # (scope, path) tuple for classes that scope holders to a finer execution unit (e.g. an asyncio task).
+        # Keyed by BaseFileLock._registry_key: a canonical path when thread-scoped, else a (scope, path) tuple
+        # for locks that scope holders to a finer execution unit such as an asyncio task.
         self.held: dict[object, int] = {}
 
 
@@ -1191,16 +1191,16 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
 
     def _deadlock_scope(self) -> object:  # noqa: PLR6301  # overridable hook; base is intentionally stateless
         """
-        Execution-flow scope in which a held entry can deadlock a new acquire.
+        Execution unit whose own hold would deadlock a new acquire.
 
-        ``None`` means the thread-local registry alone distinguishes flows: two entries on different threads can
-        never be mistaken for one another. Async locks override this to return the current task, because every task
-        of an event loop shares one thread while only an acquire from the *same* task can genuinely self-deadlock.
+        ``None`` scopes holders to the thread, which the thread-local registry already separates. Async locks
+        override it with the running task, since one event loop thread runs many tasks and only a reacquire from
+        the *same* task can self-deadlock.
         """
         return None
 
     def _registry_key(self, canonical: str) -> object:
-        """Registry key for this holder flow: the path alone when thread-scoped, else scoped by the flow identity."""
+        """Registry key for this hold: the path alone when thread-scoped, else paired with the scope identity."""
         scope = self._deadlock_scope()
         return canonical if scope is None else (scope, canonical)
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -324,7 +324,9 @@ def _canonical(path: str | os.PathLike[str]) -> str:
 class _ThreadLocalRegistry(local):
     def __init__(self) -> None:
         super().__init__()
-        self.held: dict[str, int] = {}
+        # Keys are produced by BaseFileLock._registry_key: a canonical path for thread-scoped holders, or a
+        # (scope, path) tuple for classes that scope holders to a finer execution unit (e.g. an asyncio task).
+        self.held: dict[object, int] = {}
 
 
 _registry: Final[_ThreadLocalRegistry] = _ThreadLocalRegistry()
@@ -1187,15 +1189,30 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
             descriptors.append((self._context.pending_lock_file_fd, self._context.pending_lock_file_fd_identity))
         return tuple(descriptors)
 
+    def _deadlock_scope(self) -> object:  # noqa: PLR6301  # overridable hook; base is intentionally stateless
+        """
+        Execution-flow scope in which a held entry can deadlock a new acquire.
+
+        ``None`` means the thread-local registry alone distinguishes flows: two entries on different threads can
+        never be mistaken for one another. Async locks override this to return the current task, because every task
+        of an event loop shares one thread while only an acquire from the *same* task can genuinely self-deadlock.
+        """
+        return None
+
+    def _registry_key(self, canonical: str) -> object:
+        """Registry key for this holder flow: the path alone when thread-scoped, else scoped by the flow identity."""
+        scope = self._deadlock_scope()
+        return canonical if scope is None else (scope, canonical)
+
     def _raise_if_would_deadlock(self, canonical: str, *, timeout: float, blocking: bool) -> None:
         """
-        Fail fast when a *different* live instance already holds this path on the current thread/task.
+        Fail fast when a *different* live instance already holds this path in the current deadlock scope.
 
         Only the first, indefinitely-blocking acquire can self-deadlock this way: waiting in the OS primitive would
-        block on a lock this thread already owns. A finite timeout or ``blocking=False`` keeps the normal Timeout path.
+        block on a lock this flow already owns. A finite timeout or ``blocking=False`` keeps the normal Timeout path.
         """
         would_block = self._context.lock_counter == 1 and not self.is_locked and timeout < 0 and blocking
-        if would_block and _registry.held.get(canonical) not in {None, id(self)}:
+        if would_block and _registry.held.get(self._registry_key(canonical)) not in {None, id(self)}:
             self._context.lock_counter -= 1
             msg = (
                 f"Deadlock: lock '{self.lock_file}' is already held by a different {self._deadlock_holder_desc}. "
@@ -1369,15 +1386,17 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # noqa
     def _commit_acquire(self, canonical: str) -> None:
         """Record this instance as the holder once the first acquire succeeds, so peers can detect the deadlock."""
         if self._context.lock_counter == 1:
-            self._context.lock_file_key = canonical
-            _registry.held[canonical] = id(self)
+            key = self._registry_key(canonical)
+            # The holder scope is resolved once at commit so a later release from another flow drops the right entry.
+            self._context.lock_file_key = key
+            _registry.held[key] = id(self)
 
     def _drop_registry_entry(self) -> None:
         """Forget the key owned by this hold without resolving a mutable path again."""
-        canonical = self._context.lock_file_key
+        key = self._context.lock_file_key
         self._context.lock_file_key = None
-        if canonical is not None:
-            _registry.held.pop(canonical, None)
+        if key is not None:
+            _registry.held.pop(key, None)
 
     def _commit_release(self) -> None:
         """Record the lock as fully released: reset the recursion counter and drop the deadlock-registry entry."""
@@ -1487,7 +1506,7 @@ class FileLockContext:
     lock_counter: int = 0
 
     #: Canonical registry key captured when the first physical acquisition commits.
-    lock_file_key: str | None = None
+    lock_file_key: object | None = None
 
     #: Claim pathnames this owner published, removed by name on release so no holder ever unlinks a peer's claim.
     owner_claim_paths: tuple[str, ...] = ()

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -125,6 +125,17 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     _deadlock_holder_desc: str = "BaseAsyncFileLock instance in this task"
     _constructor_lifetime_warning_stacklevel: int = 4
 
+    def _deadlock_scope(self) -> object:  # noqa: PLR6301  # overridable hook; identity comes from the loop
+        # All tasks of an event loop share one thread, so the thread-local registry alone cannot distinguish a
+        # same-task reentrant acquire (a real deadlock: the polling task can never reach its own release) from a
+        # different task legitimately queuing behind the holder (no deadlock: each poll yields the event loop, so
+        # the holder keeps running and releases). Only the former may fail fast, so scope holders to the task.
+        try:
+            return asyncio.current_task()
+        except RuntimeError:
+            # No running event loop; fall back to thread granularity, matching the sync behavior.
+            return None
+
     def __init__(  # noqa: PLR0913
         self,
         lock_file: str | os.PathLike[str],

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -126,14 +126,13 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     _constructor_lifetime_warning_stacklevel: int = 4
 
     def _deadlock_scope(self) -> object:  # noqa: PLR6301  # overridable hook; identity comes from the loop
-        # All tasks of an event loop share one thread, so the thread-local registry alone cannot distinguish a
-        # same-task reentrant acquire (a real deadlock: the polling task can never reach its own release) from a
-        # different task legitimately queuing behind the holder (no deadlock: each poll yields the event loop, so
-        # the holder keeps running and releases). Only the former may fail fast, so scope holders to the task.
+        # One event loop thread runs every task, so a thread-scoped registry cannot tell a same-task reacquire
+        # (a real deadlock: the polling task never reaches its own release) from another task queuing behind the
+        # holder (no deadlock: each poll yields, so the holder runs on and releases). Only the first may fail
+        # fast, so scope holders to the task.
         try:
             return asyncio.current_task()
-        except RuntimeError:
-            # No running event loop; fall back to thread granularity, matching the sync behavior.
+        except RuntimeError:  # no running loop, so fall back to thread granularity like the sync path
             return None
 
     def __init__(  # noqa: PLR0913

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -49,7 +49,7 @@ from ._windows import WindowsFileLock
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Awaitable, Callable, Coroutine
+    from collections.abc import Awaitable, Callable, Coroutine, Hashable
     from concurrent import futures
     from types import TracebackType
 
@@ -125,15 +125,13 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     _deadlock_holder_desc: str = "BaseAsyncFileLock instance in this task"
     _constructor_lifetime_warning_stacklevel: int = 4
 
-    def _deadlock_scope(self) -> object:  # noqa: PLR6301  # overridable hook; identity comes from the loop
+    @staticmethod
+    def _deadlock_scope() -> Hashable | None:
         # One event loop thread runs every task, so a thread-scoped registry cannot tell a same-task reacquire
         # (a real deadlock: the polling task never reaches its own release) from another task queuing behind the
         # holder (no deadlock: each poll yields, so the holder runs on and releases). Only the first may fail
         # fast, so scope holders to the task.
-        try:
-            return asyncio.current_task()
-        except RuntimeError:  # no running loop, so fall back to thread granularity like the sync path
-            return None
+        return asyncio.current_task()
 
     def __init__(  # noqa: PLR0913
         self,

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -473,6 +473,49 @@ async def test_different_tasks_no_false_positive(tmp_path: Path, lock_type: type
     assert not isinstance(error, RuntimeError), "Should not raise RuntimeError in a different task"
 
 
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_cross_task_blocking_acquire_queues(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
+    # A blocking acquire from a different task must queue behind the holder, not raise. Polling yields the event
+    # loop on every iteration, so the holder keeps running and releases; only a same-task reentry can deadlock.
+    lock_path = tmp_path / "test.lock"
+    events: list[str] = []
+
+    async def holder() -> None:
+        async with lock_type(lock_path):
+            events.append("holder:acquired")
+            await asyncio.sleep(0.05)  # the waiter starts polling while the lock is held
+            events.append("holder:released")
+
+    async def waiter() -> None:
+        await asyncio.sleep(0)  # let the holder grab the lock first
+        async with lock_type(lock_path):
+            events.append("waiter:acquired")
+
+    async with asyncio.TaskGroup() as tg:  # raises if any acquire false-positives as a deadlock
+        tg.create_task(holder())
+        tg.create_task(waiter())
+
+    assert events.index("holder:acquired") < events.index("holder:released") < events.index("waiter:acquired")
+
+
+@pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
+@pytest.mark.asyncio
+async def test_release_from_different_task_clears_registry(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
+    # The holder scope is pinned at commit time, so releasing from a different task still drops the registry entry.
+    lock_path = tmp_path / "test.lock"
+    lock = lock_type(lock_path)
+    await lock.acquire()
+
+    async def release() -> None:
+        await lock.release()
+
+    await asyncio.create_task(release())
+
+    async with lock_type(lock_path):  # would raise Deadlock if the scoped entry had leaked
+        pass
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="unix-only symlink test")
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -478,25 +478,27 @@ async def test_different_tasks_no_false_positive(tmp_path: Path, lock_type: type
 async def test_cross_task_blocking_acquire_queues(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
     # A blocking acquire from a different task must queue behind the holder, not raise. Polling yields the event
     # loop on every iteration, so the holder keeps running and releases; only a same-task reentry can deadlock.
+    # The waiter starts on an event the holder sets once it holds: yielding with sleep(0) instead would let the
+    # waiter run its check before the holder registers, so an empty registry would pass even with the bug.
     lock_path = tmp_path / "test.lock"
     events: list[str] = []
+    holding = asyncio.Event()
 
     async def holder() -> None:
         async with lock_type(lock_path):
             events.append("holder:acquired")
-            await asyncio.sleep(0.05)  # the waiter starts polling while the lock is held
+            holding.set()
+            await asyncio.sleep(0.05)  # the waiter polls while the lock is held
             events.append("holder:released")
 
     async def waiter() -> None:
-        await asyncio.sleep(0)  # let the holder grab the lock first
+        await holding.wait()
         async with lock_type(lock_path):
             events.append("waiter:acquired")
 
-    async with asyncio.TaskGroup() as tg:  # raises if any acquire false-positives as a deadlock
-        tg.create_task(holder())
-        tg.create_task(waiter())
+    await asyncio.gather(holder(), waiter())  # propagates a false-positive Deadlock
 
-    assert events.index("holder:acquired") < events.index("holder:released") < events.index("waiter:acquired")
+    assert events == ["holder:acquired", "holder:released", "waiter:acquired"]
 
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])


### PR DESCRIPTION
An attempt to fix https://github.com/tox-dev/filelock/issues/675