### PR TITLE
♻️ refactor(coverage): key exclusions on probed capability

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -310,7 +310,7 @@ jobs:
         if: matrix.developer_mode == '0'
         run: |
           $env:PYTHONPATH = "$PWD\tasks"
-          python tasks\deny_symlink.py python -c "import coverage_pragmas; print(coverage_pragmas.CAPABILITIES)"
+          python tasks\deny_symlink.py uvx --python 3.14 --with coverage python -c "import coverage_pragmas; print(coverage_pragmas.CAPABILITIES)"
       - name: "✅ Run test suite with symlinks denied"
         if: matrix.developer_mode == '0'
         run: python tasks\deny_symlink.py tox run --skip-pkg-install -e 3.14 --

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -50,6 +50,8 @@ jobs:
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.py }}
         env:
           UV_PYTHON_PREFERENCE: only-managed
+      # PyPy runs unmeasured: coverage has no JIT path there, so the suite takes 12m rather than 2m and roughly 60 of
+      # its lock, heartbeat and poll deadlines lapse under the added latency, though they pass measured in isolation.
       - name: "✅ Run test suite"
         run: |
           if [[ "${{ matrix.py }}" == pypy* ]]; then
@@ -295,6 +297,7 @@ jobs:
       - name: "⚙️ Setup test suite"
         run: tox run -vv --notest --skip-missing-interpreters false -e 3.14
       - name: "🔎 Report the probed capability"
+        if: matrix.developer_mode == '1'
         run: |
           $env:PYTHONPATH = "$PWD\tasks"
           uvx --python 3.14 --with coverage python -c "import coverage_pragmas; print(coverage_pragmas.CAPABILITIES)"
@@ -303,6 +306,11 @@ jobs:
         run: tox run --skip-pkg-install -e 3.14 --
       # deny_symlink reports the token privilege, the Developer Mode value, and whether a symlink still succeeds in
       # this process and in a child, so the log says which mechanism actually governs rather than assuming either.
+      - name: "🔎 Report the probed capability"
+        if: matrix.developer_mode == '0'
+        run: |
+          $env:PYTHONPATH = "$PWD\tasks"
+          python tasks\deny_symlink.py python -c "import coverage_pragmas; print(coverage_pragmas.CAPABILITIES)"
       - name: "✅ Run test suite with symlinks denied"
         if: matrix.developer_mode == '0'
         run: python tasks\deny_symlink.py tox run --skip-pkg-install -e 3.14 --

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -285,20 +285,27 @@ jobs:
           enable-cache: false
       - name: "🧪 Install tox"
         run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
-      # Creating a symlink on Windows needs Developer Mode or SeCreateSymbolicLinkPrivilege. Drive that setting from
-      # both sides so the capability-gated code is exercised with symlinks available and unavailable.
+      # Windows grants symlink creation two ways, so both have to be closed to deny it: Developer Mode lets an
+      # unprivileged process create them, and SeCreateSymbolicLinkPrivilege lets any holder create them regardless.
+      # Clearing only the registry value left the runner's privilege intact and both variants probed identical.
       - name: "🔗 Set Developer Mode to ${{ matrix.developer_mode }}"
         run: >
           reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v AllowDevelopmentWithoutDevLicense /d ${{ matrix.developer_mode }}
 
+      - name: "⚙️ Setup test suite"
+        run: tox run -vv --notest --skip-missing-interpreters false -e 3.14
       - name: "🔎 Report the probed capability"
         run: |
           $env:PYTHONPATH = "$PWD\tasks"
           uvx --python 3.14 --with coverage python -c "import coverage_pragmas; print(coverage_pragmas.CAPABILITIES)"
-      - name: "⚙️ Setup test suite"
-        run: tox run -vv --notest --skip-missing-interpreters false -e 3.14
-      - name: "✅ Run test suite"
+      - name: "✅ Run test suite with symlinks granted"
+        if: matrix.developer_mode == '1'
         run: tox run --skip-pkg-install -e 3.14 --
+      # deny_symlink reports the token privilege, the Developer Mode value, and whether a symlink still succeeds in
+      # this process and in a child, so the log says which mechanism actually governs rather than assuming either.
+      - name: "✅ Run test suite with symlinks denied"
+        if: matrix.developer_mode == '0'
+        run: python tasks\deny_symlink.py tox run --skip-pkg-install -e 3.14 --
   termux:
     name: "🤖 Termux (Android)"
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -268,6 +268,37 @@ jobs:
           export PYTHONPATH="$PWD/tasks/capability"
           .venv/bin/python tasks/capability/assert_fallback.py
           .venv/bin/python tasks/verify_filesystem.py
+  symlink:
+    name: "🔗 Windows symlinks ${{ matrix.developer_mode == '1' && 'granted' || 'denied' }}"
+    runs-on: windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        developer_mode: ["0", "1"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: "🔄 Install the latest version of uv"
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+      - name: "🧪 Install tox"
+        run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
+      # Creating a symlink on Windows needs Developer Mode or SeCreateSymbolicLinkPrivilege. Drive that setting from
+      # both sides so the capability-gated code is exercised with symlinks available and unavailable.
+      - name: "🔗 Set Developer Mode to ${{ matrix.developer_mode }}"
+        run: >
+          reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v AllowDevelopmentWithoutDevLicense /d ${{ matrix.developer_mode }}
+
+      - name: "🔎 Report the probed capability"
+        run: |
+          $env:PYTHONPATH = "$PWD\tasks"
+          uvx --python 3.14 --with coverage python -c "import coverage_pragmas; print(coverage_pragmas._CAPABILITIES)"
+      - name: "⚙️ Setup test suite"
+        run: tox run -vv --notest --skip-missing-interpreters false -e 3.14
+      - name: "✅ Run test suite"
+        run: tox run --skip-pkg-install -e 3.14 --
   termux:
     name: "🤖 Termux (Android)"
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -294,7 +294,7 @@ jobs:
       - name: "🔎 Report the probed capability"
         run: |
           $env:PYTHONPATH = "$PWD\tasks"
-          uvx --python 3.14 --with coverage python -c "import coverage_pragmas; print(coverage_pragmas._CAPABILITIES)"
+          uvx --python 3.14 --with coverage python -c "import coverage_pragmas; print(coverage_pragmas.CAPABILITIES)"
       - name: "⚙️ Setup test suite"
         run: tox run -vv --notest --skip-missing-interpreters false -e 3.14
       - name: "✅ Run test suite"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,30 @@ This page lists the steps needed to set up a development environment and contrib
    ```shell
    tox -e fix
    ```
+
+## Coverage
+
+Every environment in the matrix must reach 100%, and so must the combined report. Name the capability a line needs
+rather than the platform that happens to lack it. A platform name goes stale. One `win32 no cover` sat on the `os.link`
+fallback for `follow_symlinks` and demanded a branch modern Windows never takes, and others excluded platform-agnostic
+code and hid Windows gaps behind it.
+
+`tasks/coverage_pragmas.py` probes each capability at runtime and drives both directions.
+
+- `# pragma: needs <capability>` drops the line only where the capability is absent.
+- `# pragma: lacks <capability>` drops it only where the capability is present.
+
+Tests gate their `skipif` on the same `CAPABILITIES` mapping, so a test cannot be skipped while coverage still demands
+its lines. Reach for a capability wherever one fits. `hard-link` is present on Windows, which `win32 no cover` could not
+express, and `symlink` is a privilege a Windows runner may hold. Add a new one by giving it a probe in that mapping;
+where a missing capability makes a whole module unrunnable, list the module under `_CAPABILITY_MODULES` instead of
+marking every line in it.
+
+Cover a line rather than excluding it wherever it is reachable, and prefer a test that drives a path directly over one
+that waits for a finalizer or a background thread to reach it, since coverage that depends on timing turns a 100% gate
+into a flaky build.
+
+PyPy runs unmeasured. Coverage has no JIT path there, so the suite takes 12m rather than 2m and roughly 60 of its lock,
+heartbeat and poll deadlines lapse under the added latency, though the same tests pass measured in isolation. Meeting
+the gate there would mean inflating those deadlines everywhere to satisfy an environment whose data is neither uploaded
+nor combined.

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,4 +14,6 @@ services:
     volumes:
       - .:/repo:ro
     # $$HOME escapes compose's own interpolation so the container's shell expands it (compose would substitute the host's).
-    command: ["bash", "-lc", "cp -a /repo \"$$HOME/work\" && cd \"$$HOME/work\" && pip install -q . && exec tox run -e py"]
+    # The trailing `--` runs pytest with empty posargs, i.e. without coverage: Termux skips the os.link-backed strict
+    # tests, so it cannot meet the matrix fail_under and is a functional check only (same reason pypy runs bare).
+    command: ["bash", "-lc", "cp -a /repo \"$$HOME/work\" && cd \"$$HOME/work\" && pip install -q . && exec tox run -e py --"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,4 @@ services:
     volumes:
       - .:/repo:ro
     # $$HOME escapes compose's own interpolation so the container's shell expands it (compose would substitute the host's).
-    # The trailing `--` runs pytest with empty posargs, i.e. without coverage: Termux skips the os.link-backed strict
-    # tests, so it cannot meet the matrix fail_under and is a functional check only (same reason pypy runs bare).
-    command: ["bash", "-lc", "cp -a /repo \"$$HOME/work\" && cd \"$$HOME/work\" && pip install -q . && exec tox run -e py --"]
+    command: ["bash", "-lc", "cp -a /repo \"$$HOME/work\" && cd \"$$HOME/work\" && pip install -q . && exec tox run -e py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,11 +172,20 @@ max_supported_python = "3.14"
 
 [tool.ty]
 src.exclude = []
+# Mirrors pytest's pythonpath so the tests' `coverage_pragmas` import resolves here too.
+environment.extra-paths = [
+  "tasks",
+]
 environment.python-version = "3.14"
 
 [tool.pytest]
 ini_options.testpaths = [
   "tests",
+]
+# tasks holds coverage_pragmas, whose CAPABILITIES probes drive both the coverage exclusions and the skipif gates, so a
+# test can never be skipped while coverage still demands its lines.
+ini_options.pythonpath = [
+  "tasks",
 ]
 ini_options.markers = [
   "requires_hard_links: exercises StrictSoftFileLock, which needs os.link; skipped where it is missing (Termux/Android)",
@@ -199,6 +208,10 @@ run.concurrency = [
   "multiprocessing",
   "thread",
 ]
+# The pragma plugin configures the run; measuring it would report the tooling alongside the package under test.
+run.omit = [
+  "*/tasks/*",
+]
 run.parallel = true
 run.patch = [
   "_exit",
@@ -206,6 +219,7 @@ run.patch = [
 ]
 run.plugins = [
   "covdefaults",
+  "coverage_pragmas",
 ]
 run.sigterm = true
 paths.other = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ paths.source = [
   "**/src",
   "**\\src",
 ]
-report.fail_under = 95
+report.fail_under = 99
 html.show_contexts = true
 html.skip_covered = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ paths.source = [
   "**/src",
   "**\\src",
 ]
-report.fail_under = 99
+report.fail_under = 100
 html.show_contexts = true
 html.skip_covered = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ lint.ignore = [
 lint.per-file-ignores."tasks/**/*.py" = [
   "D",      # don't care about documentation in tasks scripts
   "INP001", # no implicit namespace
+  "S101",   # asserts state the platform a Windows-only script already refuses to run outside of, narrowing it for ty
   "S603",   # `subprocess` call: check for execution of untrusted input
   "T201",   # print allowed in scripts
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ paths.source = [
   "**/src",
   "**\\src",
 ]
-report.fail_under = 97
+report.fail_under = 95
 html.show_contexts = true
 html.skip_covered = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ paths.source = [
   "**/src",
   "**\\src",
 ]
-report.fail_under = 79
+report.fail_under = 97
 html.show_contexts = true
 html.skip_covered = false
 

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -28,7 +28,7 @@ else:
     try:
         from ._async_read_write import AsyncAcquireReadWriteReturnProxy, AsyncReadWriteLock
         from ._read_write import ReadWriteLock
-    except ImportError:  # sqlite3 may be unavailable if Python was built without it or the C library is missing
+    except ImportError:  # pragma: no cover  # sqlite3-absent fallback; exercised by the "without sqlite3" CI job
         AsyncAcquireReadWriteReturnProxy = None
         AsyncReadWriteLock = None
         ReadWriteLock = None

--- a/src/filelock/__init__.py
+++ b/src/filelock/__init__.py
@@ -28,7 +28,7 @@ else:
     try:
         from ._async_read_write import AsyncAcquireReadWriteReturnProxy, AsyncReadWriteLock
         from ._read_write import ReadWriteLock
-    except ImportError:  # pragma: no cover  # sqlite3-absent fallback; exercised by the "without sqlite3" CI job
+    except ImportError:  # pragma: lacks sqlite3
         AsyncAcquireReadWriteReturnProxy = None
         AsyncReadWriteLock = None
         ReadWriteLock = None

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -177,7 +177,7 @@ def _contains_exception(error: BaseException, target: BaseException | None) -> b
     seen: set[int] = set()
     while pending:
         child = pending.pop()
-        if child is target:
+        if child is target:  # pragma: win32 no cover
             return True
         if id(child) in seen:
             continue
@@ -396,7 +396,7 @@ class FileLockMeta(ABCMeta):
         singleton_key = _canonical(lock_file)
         with cls._instances_lock:
             if (instance := cls._instances.get(singleton_key)) is None:
-                if singleton_key in cls._instances_under_construction:
+                if singleton_key in cls._instances_under_construction:  # pragma: win32 no cover
                     msg = f"Singleton lock construction is already active for {lock_file!s}"
                     raise RuntimeError(msg)
                 construction_registry = cls._instances_under_construction
@@ -406,7 +406,7 @@ class FileLockMeta(ABCMeta):
                     instance = cls._create_instance(lock_file, params)
                 finally:
                     construction_registry.discard(singleton_key)
-                if os.getpid() != construction_pid:
+                if os.getpid() != construction_pid:  # pragma: win32 no cover
                     msg = "Lock construction cannot continue after fork; construct a new lock in the child"
                     raise RuntimeError(msg)
                 cls._instances[singleton_key] = instance
@@ -1160,11 +1160,11 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
         self._context.lock_counter = 0
         self._context.lock_file_key = None
 
-    def _descriptors_for_fork(self) -> tuple[tuple[int, tuple[int, int] | None], ...]:
+    def _descriptors_for_fork(self) -> tuple[tuple[int, tuple[int, int] | None], ...]:  # pragma: win32 no cover
         descriptors: list[tuple[int, tuple[int, int] | None]] = []
         if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:
             descriptors.append((self._context.lock_file_fd, self._context.lock_file_fd_identity))
-        if self._context.pending_lock_file_fd is not None:
+        if self._context.pending_lock_file_fd is not None:  # pragma: win32 no cover
             descriptors.append((self._context.pending_lock_file_fd, self._context.pending_lock_file_fd_identity))
         return tuple(descriptors)
 
@@ -1277,8 +1277,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
                 raise
             try:
                 self._register_context_descriptor()
-            except BaseException as registration_error:
-                self._rollback_failed_registration(registration_error)
+            except BaseException as registration_error:  # pragma: win32 no cover
+                self._rollback_failed_registration(registration_error)  # pragma: win32 no cover
                 raise
         if self.is_locked:
             self._invoke_on_acquired()
@@ -1286,40 +1286,40 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
     def _rollback_failed_acquire(self, acquisition_error: BaseException) -> None:
         if not self.is_locked:
             return
-        registration_error: BaseException | None = None
-        tracking_error: BaseException | None = None
-        try:
+        registration_error: BaseException | None = None  # pragma: win32 no cover
+        tracking_error: BaseException | None = None  # pragma: win32 no cover
+        try:  # pragma: win32 no cover
             self._register_context_descriptor()
         except BaseException as error:  # ruff:ignore[blind-except]  # preserve registration and acquisition failures
-            registration_error = error
-            try:
+            registration_error = error  # pragma: win32 no cover
+            try:  # pragma: win32 no cover
                 # Rollback may fail too; retain the fd so a child can close it without another identity probe.
                 self._register_unverified_context_descriptor()
             except BaseException as error:  # ruff:ignore[blind-except]  # pragma: no cover - allocation/control-flow during fallback
                 tracking_error = error
-        try:
+        try:  # pragma: win32 no cover
             self._release_with_fork_tracking()
         except BaseException as rollback_error:  # ruff:ignore[blind-except]  # preserve rollback and acquisition failures
-            _raise_cleanup_errors(
+            _raise_cleanup_errors(  # pragma: win32 no cover
                 "lock acquisition cleanup failed",
                 acquisition_error,
                 registration_error,
                 tracking_error,
                 rollback_error,
             )
-        if registration_error is not None:
+        if registration_error is not None:  # pragma: win32 no cover
             _raise_cleanup_errors(
                 "lock acquisition cleanup failed", acquisition_error, registration_error, tracking_error
             )
 
-    def _rollback_failed_registration(self, registration_error: BaseException) -> None:
+    def _rollback_failed_registration(self, registration_error: BaseException) -> None:  # pragma: win32 no cover
         tracking_error: BaseException | None = None
-        try:
+        try:  # pragma: win32 no cover
             # Rollback may fail too; retain the fd so a child can close it without another identity probe.
             self._register_unverified_context_descriptor()
         except BaseException as error:  # ruff:ignore[blind-except]  # pragma: no cover - allocation/control-flow during fallback
             tracking_error = error
-        try:
+        try:  # pragma: win32 no cover
             self._release_with_fork_tracking()
         except BaseException as rollback_error:  # ruff:ignore[blind-except]  # preserve rollback and registration failures
             _raise_cleanup_errors(
@@ -1342,13 +1342,13 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
                 self._context.lock_file_fd_identity,
             )
 
-    def _register_unverified_context_descriptor(self) -> None:
+    def _register_unverified_context_descriptor(self) -> None:  # pragma: win32 no cover
         if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:
             self._context.lock_file_fd_token = _register_unverified_owned_descriptor(self._context.lock_file_fd)
 
     def _unregister_released_descriptor(self) -> None:
         if self._context.lock_file_fd is None:
-            if (token := self._context.lock_file_fd_token) is not None:
+            if (token := self._context.lock_file_fd_token) is not None:  # pragma: win32 no cover
                 _unregister_owned_descriptor(token)
             self._context.lock_file_fd_token = None
             self._context.lock_file_fd_identity = None
@@ -1443,7 +1443,7 @@ class AcquireReturnProxy:
     ) -> None:
         if isinstance(self.lock, BaseFileLock):
             self.lock._release_in_context(exc_value)  # ruff:ignore[private-member-access]  # forwards __exit__ to the owned lock's context release
-        else:  # a reader/writer lock does not carry a context_error_policy
+        else:  # a reader/writer lock does not carry a context_error_policy  # pragma: win32 no cover
             self.lock.release()
 
 
@@ -1548,8 +1548,8 @@ _FORK_AUDIT_EVENTS: Final[frozenset[str]] = frozenset({"os.fork", "os.forkpty"})
 def _register_fork_hooks() -> None:
     if _REGISTER_AT_FORK is None:
         return  # pragma: no cover - platform without register_at_fork
-    sys.addaudithook(_audit_fork_safety)
-    _REGISTER_AT_FORK(
+    sys.addaudithook(_audit_fork_safety)  # pragma: win32 no cover
+    _REGISTER_AT_FORK(  # pragma: win32 no cover
         before=_pin_fork_objects,
         after_in_parent=_resume_parent_after_fork,
         after_in_child=_reset_child_after_fork,
@@ -1561,20 +1561,20 @@ def _fork_transition(descriptor_owner: _ForkDescriptorOwner | None = None) -> Ge
     if not _HAS_REGISTER_AT_FORK:
         yield  # pragma: no cover - platform without register_at_fork
         return  # pragma: no cover - platform without register_at_fork
-    _ensure_current_process()
-    creator_pid = os.getpid()
-    token = _enter_fork_transition(descriptor_owner)
-    try:
+    _ensure_current_process()  # pragma: win32 no cover
+    creator_pid = os.getpid()  # pragma: win32 no cover
+    token = _enter_fork_transition(descriptor_owner)  # pragma: win32 no cover
+    try:  # pragma: win32 no cover
         yield
     finally:
-        if os.getpid() == creator_pid:
+        if os.getpid() == creator_pid:  # pragma: win32 no cover
             _leave_fork_transition(token)
 
 
 def _register_fork_object(instance: _ForkResettable) -> None:
     if not _HAS_REGISTER_AT_FORK:
         return  # pragma: no cover - platform without register_at_fork
-    with _fork_transition(), _FORK_STATE.registry_lock:
+    with _fork_transition(), _FORK_STATE.registry_lock:  # pragma: win32 no cover
         _FORK_OBJECTS[id(instance)] = instance
         _refresh_owner_pins()
 
@@ -1582,7 +1582,7 @@ def _register_fork_object(instance: _ForkResettable) -> None:
 def _register_fork_class(cls: _ForkResettableClass) -> None:
     if not _HAS_REGISTER_AT_FORK:
         return  # pragma: no cover - platform without register_at_fork
-    with _fork_transition(), _FORK_STATE.registry_lock:
+    with _fork_transition(), _FORK_STATE.registry_lock:  # pragma: win32 no cover
         _FORK_CLASSES[id(cls)] = cls
         _refresh_owner_pins()
 
@@ -1590,22 +1590,22 @@ def _register_fork_class(cls: _ForkResettableClass) -> None:
 def _register_owned_descriptor(fd: int, identity: tuple[int, int] | None = None) -> int | None:
     if not _HAS_REGISTER_AT_FORK:
         return None  # pragma: no cover - platform without register_at_fork
-    with _fork_transition():
-        if identity is None:
+    with _fork_transition():  # pragma: win32 no cover
+        if identity is None:  # pragma: win32 no cover
             stat_result = os.fstat(fd)
             identity = stat_result.st_dev, stat_result.st_ino
         return _record_owned_descriptor(fd, identity)
 
 
-def _register_unverified_owned_descriptor(fd: int) -> int | None:
-    if not _HAS_REGISTER_AT_FORK:
+def _register_unverified_owned_descriptor(fd: int) -> int | None:  # pragma: win32 no cover
+    if not _HAS_REGISTER_AT_FORK:  # pragma: win32 no cover
         return None  # pragma: no cover - platform without register_at_fork
-    with _fork_transition():
+    with _fork_transition():  # pragma: win32 no cover
         return _record_owned_descriptor(fd, None)
 
 
-def _record_owned_descriptor(fd: int, identity: tuple[int, int] | None) -> int:
-    with _FORK_STATE.registry_lock:
+def _record_owned_descriptor(fd: int, identity: tuple[int, int] | None) -> int:  # pragma: win32 no cover
+    with _FORK_STATE.registry_lock:  # pragma: win32 no cover
         token = next(_DESCRIPTOR_TOKENS)
         _OWNED_DESCRIPTORS[token] = _OwnedDescriptor(
             fd=fd,
@@ -1616,15 +1616,15 @@ def _record_owned_descriptor(fd: int, identity: tuple[int, int] | None) -> int:
     return token
 
 
-def _unregister_owned_descriptor(token: int) -> None:
-    with _fork_transition(), _FORK_STATE.registry_lock:
+def _unregister_owned_descriptor(token: int) -> None:  # pragma: win32 no cover
+    with _fork_transition(), _FORK_STATE.registry_lock:  # pragma: win32 no cover
         _OWNED_DESCRIPTORS.pop(token, None)
 
 
-def _pin_fork_objects() -> None:
+def _pin_fork_objects() -> None:  # pragma: win32 no cover
     _ensure_current_process()
     thread_id = get_ident()
-    with _FORK_STATE.gate:
+    with _FORK_STATE.gate:  # pragma: win32 no cover
         _FORK_STATE.fork_owner_depths[thread_id] = _FORK_STATE.fork_owner_depths.get(thread_id, 0) + 1
         _FORK_STATE.admission_closed = True
         while _FORK_STATE.active_transitions > len(_FORK_STATE.transitions.get(thread_id, ())):
@@ -1638,25 +1638,25 @@ def _pin_fork_objects() -> None:
             (descriptor for owner in owners.values() for descriptor in owner._descriptors_for_fork()),  # ruff:ignore[private-member-access]  # snapshots each owner's own fork descriptors
         )
     )
-    with _FORK_STATE.registry_lock:
+    with _FORK_STATE.registry_lock:  # pragma: win32 no cover
         _FORK_STATE.provisional_descriptor_tokens.setdefault(thread_id, []).append(provisional_descriptor_tokens)
         _FORK_STATE.pinned_objects.setdefault(thread_id, []).append(tuple(_FORK_OBJECTS.values()))
         _FORK_STATE.pinned_classes.setdefault(thread_id, []).append(tuple(_FORK_CLASSES.values()))
 
 
-def _resume_parent_after_fork() -> None:
+def _resume_parent_after_fork() -> None:  # pragma: win32 no cover
     thread_id = get_ident()
-    with _FORK_STATE.registry_lock:
-        for token in _FORK_STATE.provisional_descriptor_tokens[thread_id].pop():
+    with _FORK_STATE.registry_lock:  # pragma: win32 no cover
+        for token in _FORK_STATE.provisional_descriptor_tokens[thread_id].pop():  # pragma: win32 no cover
             _OWNED_DESCRIPTORS.pop(token, None)
         _FORK_STATE.pinned_objects[thread_id].pop()
         _FORK_STATE.pinned_classes[thread_id].pop()
-        if not _FORK_STATE.provisional_descriptor_tokens[thread_id]:
+        if not _FORK_STATE.provisional_descriptor_tokens[thread_id]:  # pragma: win32 no cover
             del _FORK_STATE.provisional_descriptor_tokens[thread_id]
             del _FORK_STATE.pinned_objects[thread_id]
             del _FORK_STATE.pinned_classes[thread_id]
-    with _FORK_STATE.gate:
-        if _FORK_STATE.fork_owner_depths[thread_id] == 1:
+    with _FORK_STATE.gate:  # pragma: win32 no cover
+        if _FORK_STATE.fork_owner_depths[thread_id] == 1:  # pragma: win32 no cover
             del _FORK_STATE.fork_owner_depths[thread_id]
         else:  # pragma: no cover - earlier at-fork callbacks may deadlock first
             _FORK_STATE.fork_owner_depths[thread_id] -= 1
@@ -1684,10 +1684,10 @@ def _reset_child_after_fork() -> None:  # pragma: no cover - exercised in fork c
     _detach_child_state(descriptors, pinned_objects, pinned_classes)
 
 
-def _enter_fork_transition(descriptor_owner: _ForkDescriptorOwner | None) -> int:
+def _enter_fork_transition(descriptor_owner: _ForkDescriptorOwner | None) -> int:  # pragma: win32 no cover
     thread_id = get_ident()
-    with _FORK_STATE.gate:
-        while (
+    with _FORK_STATE.gate:  # pragma: win32 no cover
+        while (  # pragma: win32 no cover
             _FORK_STATE.admission_closed
             and thread_id not in _FORK_STATE.fork_owner_depths
             and thread_id not in _FORK_STATE.transitions
@@ -1700,25 +1700,25 @@ def _enter_fork_transition(descriptor_owner: _ForkDescriptorOwner | None) -> int
     return token
 
 
-def _leave_fork_transition(token: int) -> None:
+def _leave_fork_transition(token: int) -> None:  # pragma: win32 no cover
     _FORK_STATE.transition_context.depth -= 1
-    with _FORK_STATE.gate:
+    with _FORK_STATE.gate:  # pragma: win32 no cover
         thread_id = get_ident()
         del _FORK_STATE.transitions[thread_id][token]
-        if not _FORK_STATE.transitions[thread_id]:
+        if not _FORK_STATE.transitions[thread_id]:  # pragma: win32 no cover
             del _FORK_STATE.transitions[thread_id]
         _FORK_STATE.active_transitions -= 1
         _FORK_STATE.gate.notify_all()
 
 
-def _verify_unverified_descriptors() -> None:
-    with _FORK_STATE.registry_lock:
-        for token, descriptor in tuple(_OWNED_DESCRIPTORS.items()):
-            if descriptor.creator_pid != os.getpid() or descriptor.device is not None:
+def _verify_unverified_descriptors() -> None:  # pragma: win32 no cover
+    with _FORK_STATE.registry_lock:  # pragma: win32 no cover
+        for token, descriptor in tuple(_OWNED_DESCRIPTORS.items()):  # pragma: win32 no cover
+            if descriptor.creator_pid != os.getpid() or descriptor.device is not None:  # pragma: win32 no cover
                 continue
-            try:
+            try:  # pragma: win32 no cover
                 stat_result = os.fstat(descriptor.fd)
-            except OSError:
+            except OSError:  # pragma: win32 no cover
                 continue
             _OWNED_DESCRIPTORS[token] = _OwnedDescriptor(
                 fd=descriptor.fd,
@@ -1728,13 +1728,13 @@ def _verify_unverified_descriptors() -> None:
             )
 
 
-def _snapshot_descriptor_for_fork(fd: int, identity: tuple[int, int] | None) -> int:
-    if identity is None:
-        try:
+def _snapshot_descriptor_for_fork(fd: int, identity: tuple[int, int] | None) -> int:  # pragma: win32 no cover
+    if identity is None:  # pragma: win32 no cover
+        try:  # pragma: win32 no cover
             stat_result = os.fstat(fd)
-        except OSError:
+        except OSError:  # pragma: win32 no cover
             pass
-        else:
+        else:  # pragma: win32 no cover
             identity = stat_result.st_dev, stat_result.st_ino
     return _record_owned_descriptor(fd, identity)
 
@@ -1762,15 +1762,15 @@ def _detach_child_state(  # pragma: no cover - exercised in fork children
     _registry.held.clear()
 
 
-def _refresh_owner_pins() -> None:
-    with _FORK_STATE.gate:
+def _refresh_owner_pins() -> None:  # pragma: win32 no cover
+    with _FORK_STATE.gate:  # pragma: win32 no cover
         fork_owner_thread_ids = tuple(_FORK_STATE.fork_owner_depths)
     if get_ident() not in fork_owner_thread_ids:  # pragma: no cover - at-fork callbacks disable tracing
         return
     objects = tuple(_FORK_OBJECTS.values())
     classes = tuple(_FORK_CLASSES.values())
-    for thread_id in fork_owner_thread_ids:
-        if object_snapshots := _FORK_STATE.pinned_objects.get(thread_id):
+    for thread_id in fork_owner_thread_ids:  # pragma: win32 no cover
+        if object_snapshots := _FORK_STATE.pinned_objects.get(thread_id):  # pragma: win32 no cover
             object_snapshots[:] = [objects] * len(object_snapshots)
             _FORK_STATE.pinned_classes[thread_id][:] = [classes] * len(object_snapshots)
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -1091,7 +1091,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
             time.sleep(poll_interval)
         try:  # pragma: needs hard-link
             yield
-        finally:
+        finally:  # pragma: needs hard-link
             self._transition_lock.release()
 
     def release(self, force: bool = False) -> None:  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]  # public API: positional bool kept for backwards compatibility

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -177,7 +177,7 @@ def _contains_exception(error: BaseException, target: BaseException | None) -> b
     seen: set[int] = set()
     while pending:
         child = pending.pop()
-        if child is target:  # pragma: win32 no cover
+        if child is target:
             return True
         if id(child) in seen:
             continue
@@ -1443,7 +1443,7 @@ class AcquireReturnProxy:
     ) -> None:
         if isinstance(self.lock, BaseFileLock):
             self.lock._release_in_context(exc_value)  # ruff:ignore[private-member-access]  # forwards __exit__ to the owned lock's context release
-        else:  # a reader/writer lock does not carry a context_error_policy  # pragma: win32 no cover
+        else:  # a reader/writer lock does not carry a context_error_policy
             self.lock.release()
 
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -396,7 +396,7 @@ class FileLockMeta(ABCMeta):
         singleton_key = _canonical(lock_file)
         with cls._instances_lock:
             if (instance := cls._instances.get(singleton_key)) is None:
-                if singleton_key in cls._instances_under_construction:  # pragma: win32 no cover
+                if singleton_key in cls._instances_under_construction:  # pragma: needs fork
                     msg = f"Singleton lock construction is already active for {lock_file!s}"
                     raise RuntimeError(msg)
                 construction_registry = cls._instances_under_construction
@@ -406,7 +406,7 @@ class FileLockMeta(ABCMeta):
                     instance = cls._create_instance(lock_file, params)
                 finally:
                     construction_registry.discard(singleton_key)
-                if os.getpid() != construction_pid:  # pragma: win32 no cover
+                if os.getpid() != construction_pid:  # pragma: needs fork
                     msg = "Lock construction cannot continue after fork; construct a new lock in the child"
                     raise RuntimeError(msg)
                 cls._instances[singleton_key] = instance
@@ -637,7 +637,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
         _register_fork_class(cls)
 
     @classmethod
-    def _reset_class_after_fork(cls) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_class_after_fork(cls) -> None:  # pragma: forked child
         cls._instances = WeakValueDictionary()
         cls._instances_lock = RLock()
         cls._instances_under_construction = set()
@@ -971,7 +971,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
     def __del__(self) -> None:
         """Force-release so a dropped reference never leaks a held lock."""
         if vars(self).get("_creator_pid") != os.getpid():
-            return  # pragma: no cover - exercised in fork children
+            return  # pragma: forked child
         # A finalizer must not raise. A release error during garbage collection would otherwise surface as an
         # unraisable-exception warning, attributed to whichever code triggered collection. The dropped lock still gets
         # best-effort cleanup; an explicit release() reports the same error to a caller who can act on it.
@@ -1127,7 +1127,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
             _LOGGER.debug("Lock %s released on %s", lock_id, lock_filename)
 
     def _raise_if_inherited(self) -> None:
-        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+        if self._creator_pid != os.getpid():  # pragma: forked child
             msg = f"{type(self).__name__} on {self.lock_file} was inherited across fork; construct a new instance"
             raise RuntimeError(msg)
 
@@ -1147,7 +1147,7 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
         self._context.lock_file_fd = None
         self._context.lock_file_fd_identity = None
 
-    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_after_fork_in_child(self) -> None:  # pragma: forked child
         # fork copies the lock in whatever state the parent's threads left it, so give the child an unheld one.
         self._transition_lock = RLock()
         self._context.owner_claim_paths = ()
@@ -1160,11 +1160,11 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
         self._context.lock_counter = 0
         self._context.lock_file_key = None
 
-    def _descriptors_for_fork(self) -> tuple[tuple[int, tuple[int, int] | None], ...]:  # pragma: win32 no cover
+    def _descriptors_for_fork(self) -> tuple[tuple[int, tuple[int, int] | None], ...]:  # pragma: needs fork
         descriptors: list[tuple[int, tuple[int, int] | None]] = []
         if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:
             descriptors.append((self._context.lock_file_fd, self._context.lock_file_fd_identity))
-        if self._context.pending_lock_file_fd is not None:  # pragma: win32 no cover
+        if self._context.pending_lock_file_fd is not None:
             descriptors.append((self._context.pending_lock_file_fd, self._context.pending_lock_file_fd_identity))
         return tuple(descriptors)
 
@@ -1277,8 +1277,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
                 raise
             try:
                 self._register_context_descriptor()
-            except BaseException as registration_error:  # pragma: win32 no cover
-                self._rollback_failed_registration(registration_error)  # pragma: win32 no cover
+            except BaseException as registration_error:  # pragma: needs fork
+                self._rollback_failed_registration(registration_error)
                 raise
         if self.is_locked:
             self._invoke_on_acquired()
@@ -1286,40 +1286,40 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
     def _rollback_failed_acquire(self, acquisition_error: BaseException) -> None:
         if not self.is_locked:
             return
-        registration_error: BaseException | None = None  # pragma: win32 no cover
-        tracking_error: BaseException | None = None  # pragma: win32 no cover
-        try:  # pragma: win32 no cover
+        registration_error: BaseException | None = None
+        tracking_error: BaseException | None = None
+        try:
             self._register_context_descriptor()
         except BaseException as error:  # ruff:ignore[blind-except]  # preserve registration and acquisition failures
-            registration_error = error  # pragma: win32 no cover
-            try:  # pragma: win32 no cover
+            registration_error = error
+            try:
                 # Rollback may fail too; retain the fd so a child can close it without another identity probe.
                 self._register_unverified_context_descriptor()
             except BaseException as error:  # ruff:ignore[blind-except]  # pragma: no cover - allocation/control-flow during fallback
                 tracking_error = error
-        try:  # pragma: win32 no cover
+        try:
             self._release_with_fork_tracking()
         except BaseException as rollback_error:  # ruff:ignore[blind-except]  # preserve rollback and acquisition failures
-            _raise_cleanup_errors(  # pragma: win32 no cover
+            _raise_cleanup_errors(
                 "lock acquisition cleanup failed",
                 acquisition_error,
                 registration_error,
                 tracking_error,
                 rollback_error,
             )
-        if registration_error is not None:  # pragma: win32 no cover
+        if registration_error is not None:  # pragma: needs fork
             _raise_cleanup_errors(
                 "lock acquisition cleanup failed", acquisition_error, registration_error, tracking_error
             )
 
-    def _rollback_failed_registration(self, registration_error: BaseException) -> None:  # pragma: win32 no cover
+    def _rollback_failed_registration(self, registration_error: BaseException) -> None:  # pragma: needs fork
         tracking_error: BaseException | None = None
-        try:  # pragma: win32 no cover
+        try:
             # Rollback may fail too; retain the fd so a child can close it without another identity probe.
             self._register_unverified_context_descriptor()
         except BaseException as error:  # ruff:ignore[blind-except]  # pragma: no cover - allocation/control-flow during fallback
             tracking_error = error
-        try:  # pragma: win32 no cover
+        try:
             self._release_with_fork_tracking()
         except BaseException as rollback_error:  # ruff:ignore[blind-except]  # preserve rollback and registration failures
             _raise_cleanup_errors(
@@ -1342,13 +1342,13 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
                 self._context.lock_file_fd_identity,
             )
 
-    def _register_unverified_context_descriptor(self) -> None:  # pragma: win32 no cover
+    def _register_unverified_context_descriptor(self) -> None:
         if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:
             self._context.lock_file_fd_token = _register_unverified_owned_descriptor(self._context.lock_file_fd)
 
     def _unregister_released_descriptor(self) -> None:
         if self._context.lock_file_fd is None:
-            if (token := self._context.lock_file_fd_token) is not None:  # pragma: win32 no cover
+            if (token := self._context.lock_file_fd_token) is not None:  # pragma: needs fork
                 _unregister_owned_descriptor(token)
             self._context.lock_file_fd_token = None
             self._context.lock_file_fd_identity = None
@@ -1522,7 +1522,7 @@ class _ForkState:
         self.provisional_descriptor_tokens: dict[int, list[tuple[int, ...]]] = {}
         self.pid = os.getpid()
 
-    def reset_synchronization(self) -> None:  # pragma: no cover - exercised in fork children
+    def reset_synchronization(self) -> None:  # pragma: forked child
         self.gate = Condition(RLock())
         self.registry_lock = RLock()
         self.parameter_models_lock = RLock()
@@ -1547,9 +1547,9 @@ _FORK_AUDIT_EVENTS: Final[frozenset[str]] = frozenset({"os.fork", "os.forkpty"})
 
 def _register_fork_hooks() -> None:
     if _REGISTER_AT_FORK is None:
-        return  # pragma: no cover - platform without register_at_fork
-    sys.addaudithook(_audit_fork_safety)  # pragma: win32 no cover
-    _REGISTER_AT_FORK(  # pragma: win32 no cover
+        return  # pragma: lacks fork
+    sys.addaudithook(_audit_fork_safety)  # pragma: needs fork
+    _REGISTER_AT_FORK(  # pragma: needs fork
         before=_pin_fork_objects,
         after_in_parent=_resume_parent_after_fork,
         after_in_child=_reset_child_after_fork,
@@ -1559,53 +1559,53 @@ def _register_fork_hooks() -> None:
 @contextmanager
 def _fork_transition(descriptor_owner: _ForkDescriptorOwner | None = None) -> Generator[None]:
     if not _HAS_REGISTER_AT_FORK:
-        yield  # pragma: no cover - platform without register_at_fork
-        return  # pragma: no cover - platform without register_at_fork
-    _ensure_current_process()  # pragma: win32 no cover
-    creator_pid = os.getpid()  # pragma: win32 no cover
-    token = _enter_fork_transition(descriptor_owner)  # pragma: win32 no cover
-    try:  # pragma: win32 no cover
+        yield  # pragma: lacks fork
+        return  # pragma: lacks fork
+    _ensure_current_process()  # pragma: needs fork
+    creator_pid = os.getpid()  # pragma: needs fork
+    token = _enter_fork_transition(descriptor_owner)  # pragma: needs fork
+    try:  # pragma: needs fork
         yield
     finally:
-        if os.getpid() == creator_pid:  # pragma: win32 no cover
+        if os.getpid() == creator_pid:  # pragma: needs fork
             _leave_fork_transition(token)
 
 
 def _register_fork_object(instance: _ForkResettable) -> None:
     if not _HAS_REGISTER_AT_FORK:
-        return  # pragma: no cover - platform without register_at_fork
-    with _fork_transition(), _FORK_STATE.registry_lock:  # pragma: win32 no cover
+        return  # pragma: lacks fork
+    with _fork_transition(), _FORK_STATE.registry_lock:  # pragma: needs fork
         _FORK_OBJECTS[id(instance)] = instance
         _refresh_owner_pins()
 
 
 def _register_fork_class(cls: _ForkResettableClass) -> None:
     if not _HAS_REGISTER_AT_FORK:
-        return  # pragma: no cover - platform without register_at_fork
-    with _fork_transition(), _FORK_STATE.registry_lock:  # pragma: win32 no cover
+        return  # pragma: lacks fork
+    with _fork_transition(), _FORK_STATE.registry_lock:  # pragma: needs fork
         _FORK_CLASSES[id(cls)] = cls
         _refresh_owner_pins()
 
 
 def _register_owned_descriptor(fd: int, identity: tuple[int, int] | None = None) -> int | None:
     if not _HAS_REGISTER_AT_FORK:
-        return None  # pragma: no cover - platform without register_at_fork
-    with _fork_transition():  # pragma: win32 no cover
-        if identity is None:  # pragma: win32 no cover
+        return None  # pragma: lacks fork
+    with _fork_transition():  # pragma: needs fork
+        if identity is None:
             stat_result = os.fstat(fd)
             identity = stat_result.st_dev, stat_result.st_ino
         return _record_owned_descriptor(fd, identity)
 
 
-def _register_unverified_owned_descriptor(fd: int) -> int | None:  # pragma: win32 no cover
-    if not _HAS_REGISTER_AT_FORK:  # pragma: win32 no cover
-        return None  # pragma: no cover - platform without register_at_fork
-    with _fork_transition():  # pragma: win32 no cover
+def _register_unverified_owned_descriptor(fd: int) -> int | None:
+    if not _HAS_REGISTER_AT_FORK:
+        return None  # pragma: lacks fork
+    with _fork_transition():  # pragma: needs fork
         return _record_owned_descriptor(fd, None)
 
 
-def _record_owned_descriptor(fd: int, identity: tuple[int, int] | None) -> int:  # pragma: win32 no cover
-    with _FORK_STATE.registry_lock:  # pragma: win32 no cover
+def _record_owned_descriptor(fd: int, identity: tuple[int, int] | None) -> int:  # pragma: needs fork
+    with _FORK_STATE.registry_lock:
         token = next(_DESCRIPTOR_TOKENS)
         _OWNED_DESCRIPTORS[token] = _OwnedDescriptor(
             fd=fd,
@@ -1616,15 +1616,15 @@ def _record_owned_descriptor(fd: int, identity: tuple[int, int] | None) -> int: 
     return token
 
 
-def _unregister_owned_descriptor(token: int) -> None:  # pragma: win32 no cover
-    with _fork_transition(), _FORK_STATE.registry_lock:  # pragma: win32 no cover
+def _unregister_owned_descriptor(token: int) -> None:  # pragma: needs fork
+    with _fork_transition(), _FORK_STATE.registry_lock:
         _OWNED_DESCRIPTORS.pop(token, None)
 
 
-def _pin_fork_objects() -> None:  # pragma: win32 no cover
+def _pin_fork_objects() -> None:  # pragma: needs fork
     _ensure_current_process()
     thread_id = get_ident()
-    with _FORK_STATE.gate:  # pragma: win32 no cover
+    with _FORK_STATE.gate:
         _FORK_STATE.fork_owner_depths[thread_id] = _FORK_STATE.fork_owner_depths.get(thread_id, 0) + 1
         _FORK_STATE.admission_closed = True
         while _FORK_STATE.active_transitions > len(_FORK_STATE.transitions.get(thread_id, ())):
@@ -1638,25 +1638,25 @@ def _pin_fork_objects() -> None:  # pragma: win32 no cover
             (descriptor for owner in owners.values() for descriptor in owner._descriptors_for_fork()),  # ruff:ignore[private-member-access]  # snapshots each owner's own fork descriptors
         )
     )
-    with _FORK_STATE.registry_lock:  # pragma: win32 no cover
+    with _FORK_STATE.registry_lock:
         _FORK_STATE.provisional_descriptor_tokens.setdefault(thread_id, []).append(provisional_descriptor_tokens)
         _FORK_STATE.pinned_objects.setdefault(thread_id, []).append(tuple(_FORK_OBJECTS.values()))
         _FORK_STATE.pinned_classes.setdefault(thread_id, []).append(tuple(_FORK_CLASSES.values()))
 
 
-def _resume_parent_after_fork() -> None:  # pragma: win32 no cover
+def _resume_parent_after_fork() -> None:  # pragma: needs fork
     thread_id = get_ident()
-    with _FORK_STATE.registry_lock:  # pragma: win32 no cover
-        for token in _FORK_STATE.provisional_descriptor_tokens[thread_id].pop():  # pragma: win32 no cover
+    with _FORK_STATE.registry_lock:
+        for token in _FORK_STATE.provisional_descriptor_tokens[thread_id].pop():
             _OWNED_DESCRIPTORS.pop(token, None)
         _FORK_STATE.pinned_objects[thread_id].pop()
         _FORK_STATE.pinned_classes[thread_id].pop()
-        if not _FORK_STATE.provisional_descriptor_tokens[thread_id]:  # pragma: win32 no cover
+        if not _FORK_STATE.provisional_descriptor_tokens[thread_id]:  # pragma: needs fork
             del _FORK_STATE.provisional_descriptor_tokens[thread_id]
             del _FORK_STATE.pinned_objects[thread_id]
             del _FORK_STATE.pinned_classes[thread_id]
-    with _FORK_STATE.gate:  # pragma: win32 no cover
-        if _FORK_STATE.fork_owner_depths[thread_id] == 1:  # pragma: win32 no cover
+    with _FORK_STATE.gate:
+        if _FORK_STATE.fork_owner_depths[thread_id] == 1:
             del _FORK_STATE.fork_owner_depths[thread_id]
         else:  # pragma: no cover - earlier at-fork callbacks may deadlock first
             _FORK_STATE.fork_owner_depths[thread_id] -= 1
@@ -1668,7 +1668,7 @@ def _ensure_current_process() -> None:
     _reset_child_after_fork()
 
 
-def _reset_child_after_fork() -> None:  # pragma: no cover - exercised in fork children
+def _reset_child_after_fork() -> None:  # pragma: forked child
     if (pid := os.getpid()) == _FORK_STATE.pid:
         return
     thread_id = get_ident()
@@ -1684,10 +1684,10 @@ def _reset_child_after_fork() -> None:  # pragma: no cover - exercised in fork c
     _detach_child_state(descriptors, pinned_objects, pinned_classes)
 
 
-def _enter_fork_transition(descriptor_owner: _ForkDescriptorOwner | None) -> int:  # pragma: win32 no cover
+def _enter_fork_transition(descriptor_owner: _ForkDescriptorOwner | None) -> int:  # pragma: needs fork
     thread_id = get_ident()
-    with _FORK_STATE.gate:  # pragma: win32 no cover
-        while (  # pragma: win32 no cover
+    with _FORK_STATE.gate:
+        while (
             _FORK_STATE.admission_closed
             and thread_id not in _FORK_STATE.fork_owner_depths
             and thread_id not in _FORK_STATE.transitions
@@ -1700,25 +1700,25 @@ def _enter_fork_transition(descriptor_owner: _ForkDescriptorOwner | None) -> int
     return token
 
 
-def _leave_fork_transition(token: int) -> None:  # pragma: win32 no cover
+def _leave_fork_transition(token: int) -> None:  # pragma: needs fork
     _FORK_STATE.transition_context.depth -= 1
-    with _FORK_STATE.gate:  # pragma: win32 no cover
+    with _FORK_STATE.gate:
         thread_id = get_ident()
         del _FORK_STATE.transitions[thread_id][token]
-        if not _FORK_STATE.transitions[thread_id]:  # pragma: win32 no cover
+        if not _FORK_STATE.transitions[thread_id]:
             del _FORK_STATE.transitions[thread_id]
         _FORK_STATE.active_transitions -= 1
         _FORK_STATE.gate.notify_all()
 
 
-def _verify_unverified_descriptors() -> None:  # pragma: win32 no cover
-    with _FORK_STATE.registry_lock:  # pragma: win32 no cover
-        for token, descriptor in tuple(_OWNED_DESCRIPTORS.items()):  # pragma: win32 no cover
-            if descriptor.creator_pid != os.getpid() or descriptor.device is not None:  # pragma: win32 no cover
+def _verify_unverified_descriptors() -> None:  # pragma: needs fork
+    with _FORK_STATE.registry_lock:
+        for token, descriptor in tuple(_OWNED_DESCRIPTORS.items()):
+            if descriptor.creator_pid != os.getpid() or descriptor.device is not None:
                 continue
-            try:  # pragma: win32 no cover
+            try:
                 stat_result = os.fstat(descriptor.fd)
-            except OSError:  # pragma: win32 no cover
+            except OSError:
                 continue
             _OWNED_DESCRIPTORS[token] = _OwnedDescriptor(
                 fd=descriptor.fd,
@@ -1728,18 +1728,18 @@ def _verify_unverified_descriptors() -> None:  # pragma: win32 no cover
             )
 
 
-def _snapshot_descriptor_for_fork(fd: int, identity: tuple[int, int] | None) -> int:  # pragma: win32 no cover
-    if identity is None:  # pragma: win32 no cover
-        try:  # pragma: win32 no cover
+def _snapshot_descriptor_for_fork(fd: int, identity: tuple[int, int] | None) -> int:  # pragma: needs fork
+    if identity is None:  # pragma: needs fork
+        try:
             stat_result = os.fstat(fd)
-        except OSError:  # pragma: win32 no cover
+        except OSError:
             pass
-        else:  # pragma: win32 no cover
+        else:
             identity = stat_result.st_dev, stat_result.st_ino
     return _record_owned_descriptor(fd, identity)
 
 
-def _detach_child_state(  # pragma: no cover - exercised in fork children
+def _detach_child_state(  # pragma: forked child
     descriptors: list[_OwnedDescriptor],
     pinned_objects: tuple[_ForkResettable, ...],
     pinned_classes: tuple[_ForkResettableClass, ...],
@@ -1762,15 +1762,15 @@ def _detach_child_state(  # pragma: no cover - exercised in fork children
     _registry.held.clear()
 
 
-def _refresh_owner_pins() -> None:  # pragma: win32 no cover
-    with _FORK_STATE.gate:  # pragma: win32 no cover
+def _refresh_owner_pins() -> None:  # pragma: needs fork
+    with _FORK_STATE.gate:
         fork_owner_thread_ids = tuple(_FORK_STATE.fork_owner_depths)
     if get_ident() not in fork_owner_thread_ids:  # pragma: no cover - at-fork callbacks disable tracing
         return
     objects = tuple(_FORK_OBJECTS.values())
     classes = tuple(_FORK_CLASSES.values())
-    for thread_id in fork_owner_thread_ids:  # pragma: win32 no cover
-        if object_snapshots := _FORK_STATE.pinned_objects.get(thread_id):  # pragma: win32 no cover
+    for thread_id in fork_owner_thread_ids:
+        if object_snapshots := _FORK_STATE.pinned_objects.get(thread_id):  # pragma: needs fork
             object_snapshots[:] = [objects] * len(object_snapshots)
             _FORK_STATE.pinned_classes[thread_id][:] = [classes] * len(object_snapshots)
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -1083,13 +1083,13 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
         if not self._serialize_transitions or self._is_thread_local:
             yield
             return
-        while not self._transition_lock.acquire(blocking=False):
+        while not self._transition_lock.acquire(blocking=False):  # pragma: needs hard-link
             if not blocking or (cancel_check is not None and cancel_check()):
                 raise Timeout(self.lock_file)
             if timeout >= 0 and time.perf_counter() - start_time >= timeout:
                 raise Timeout(self.lock_file)
             time.sleep(poll_interval)
-        try:
+        try:  # pragma: needs hard-link
             yield
         finally:
             self._transition_lock.release()
@@ -1241,8 +1241,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
             return poll_interval
         # Cap the exponent before doubling: under heavy contention attempt reaches the thousands, and 2**attempt would
         # overflow the float multiply long before the window itself stops growing past the cap.
-        window = min(self._poll_backoff_cap, poll_interval * 2 ** min(attempt, _MAX_BACKOFF_EXPONENT))
-        return max(poll_interval, secrets.randbelow(int(window * 1_000_000) + 1) / 1_000_000)
+        window = min(
+            self._poll_backoff_cap, poll_interval * 2 ** min(attempt, _MAX_BACKOFF_EXPONENT)
+        )  # pragma: needs hard-link
+        return max(poll_interval, secrets.randbelow(int(window * 1_000_000) + 1) / 1_000_000)  # pragma: needs hard-link
 
     def _reconcile_failed_acquire(self, canonical: str) -> None:
         # An acquire that raised while still holding the native lock (a hook that failed and whose rollback could not

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -1343,7 +1343,8 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
             )
 
     def _register_unverified_context_descriptor(self) -> None:
-        if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:
+        # The rollback only reaches here still holding a descriptor it never managed to register.
+        if self._context.lock_file_fd is not None and self._context.lock_file_fd_token is None:  # pragma: no branch
             self._context.lock_file_fd_token = _register_unverified_owned_descriptor(self._context.lock_file_fd)
 
     def _unregister_released_descriptor(self) -> None:

--- a/src/filelock/_async.py
+++ b/src/filelock/_async.py
@@ -37,10 +37,10 @@ class _AsyncTransitionGate:
         with self._tail_lock:
             predecessor = self._tail
             self._tail = ticket
-        if predecessor is not None:
-            try:
+        if predecessor is not None:  # pragma: win32 no cover
+            try:  # pragma: win32 no cover
                 await _wait_until_done(asyncio.wrap_future(predecessor))
-            except asyncio.CancelledError:
+            except asyncio.CancelledError:  # pragma: win32 no cover
                 predecessor.add_done_callback(lambda _predecessor: self._leave(ticket))
                 raise
         try:

--- a/src/filelock/_async.py
+++ b/src/filelock/_async.py
@@ -37,10 +37,10 @@ class _AsyncTransitionGate:
         with self._tail_lock:
             predecessor = self._tail
             self._tail = ticket
-        if predecessor is not None:  # pragma: win32 no cover
-            try:  # pragma: win32 no cover
+        if predecessor is not None:
+            try:
                 await _wait_until_done(asyncio.wrap_future(predecessor))
-            except asyncio.CancelledError:  # pragma: win32 no cover
+            except asyncio.CancelledError:
                 predecessor.add_done_callback(lambda _predecessor: self._leave(ticket))
                 raise
         try:

--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -74,7 +74,7 @@ class AsyncReadWriteLock:
             self._loop = loop
             self._owns_executor = executor is None
             self._executor = executor or ThreadPoolExecutor(max_workers=1)
-            if os.getpid() != creator_pid:  # pragma: no cover - exercised only in a forked constructor callback
+            if os.getpid() != creator_pid:  # pragma: forked child
                 msg = "AsyncReadWriteLock construction cannot continue after fork"
                 raise RuntimeError(msg)
 
@@ -211,7 +211,7 @@ class AsyncReadWriteLock:
 
         """
         _ensure_current_process()
-        if self._inherited:  # pragma: win32 no cover
+        if self._inherited:  # pragma: needs fork
             return
         await self._run(self._lock.release, force=force)
 
@@ -223,7 +223,7 @@ class AsyncReadWriteLock:
 
         """
         _ensure_current_process()
-        if self._inherited:  # pragma: win32 no cover
+        if self._inherited:  # pragma: needs fork
             return
         if self._closed:
             return
@@ -300,14 +300,14 @@ class AsyncReadWriteLock:
 
     def _raise_if_unusable(self) -> None:
         _ensure_current_process()
-        if self._inherited:  # pragma: win32 no cover
+        if self._inherited:  # pragma: needs fork
             msg = f"AsyncReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
             raise RuntimeError(msg)
         if self._closed:
             msg = "Cannot operate on a closed database."
             raise sqlite3.ProgrammingError(msg)
 
-    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_after_fork_in_child(self) -> None:  # pragma: forked child
         self._fork_invalidated = True
 
     def __del__(self) -> None:

--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -211,7 +211,7 @@ class AsyncReadWriteLock:
 
         """
         _ensure_current_process()
-        if self._inherited:
+        if self._inherited:  # pragma: win32 no cover
             return
         await self._run(self._lock.release, force=force)
 
@@ -223,7 +223,7 @@ class AsyncReadWriteLock:
 
         """
         _ensure_current_process()
-        if self._inherited:
+        if self._inherited:  # pragma: win32 no cover
             return
         if self._closed:
             return
@@ -300,7 +300,7 @@ class AsyncReadWriteLock:
 
     def _raise_if_unusable(self) -> None:
         _ensure_current_process()
-        if self._inherited:
+        if self._inherited:  # pragma: win32 no cover
             msg = f"AsyncReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
             raise RuntimeError(msg)
         if self._closed:

--- a/src/filelock/_error.py
+++ b/src/filelock/_error.py
@@ -12,7 +12,7 @@ class Timeout(TimeoutError):  # ruff:ignore[error-suffix-on-exception-name]  # p
         # __init__ needs lock_file, so pickle must restore it as a constructor arg
         return self.__class__, (self._lock_file,)
 
-    def __str__(self) -> str:
+    def __str__(self) -> str:  # pragma: needs hard-link
         return f"The file lock '{self._lock_file}' could not be acquired."
 
     def __repr__(self) -> str:
@@ -41,7 +41,9 @@ class SoftFileLockProtocolError(OSError):
         self._reason = reason
         super().__init__(self.__str__())
 
-    def __reduce__(self) -> tuple[type[SoftFileLockProtocolError], tuple[str, str | None, str]]:
+    def __reduce__(
+        self,
+    ) -> tuple[type[SoftFileLockProtocolError], tuple[str, str | None, str]]:  # pragma: needs hard-link
         return self.__class__, (self._lock_file, self._claim_name, self._reason)
 
     def __str__(self) -> str:
@@ -49,17 +51,17 @@ class SoftFileLockProtocolError(OSError):
         return f"Invalid strict soft-lock state at {location}: {self._reason}"
 
     @property
-    def lock_file(self) -> str:
+    def lock_file(self) -> str:  # pragma: needs hard-link
         """The requested lock path."""
         return self._lock_file
 
     @property
-    def claim_name(self) -> str | None:
+    def claim_name(self) -> str | None:  # pragma: needs hard-link
         """The claim that caused the error, if scanning identified one."""
         return self._claim_name
 
     @property
-    def reason(self) -> str:
+    def reason(self) -> str:  # pragma: needs hard-link
         """The protocol validation failure."""
         return self._reason
 

--- a/src/filelock/_identity.py
+++ b/src/filelock/_identity.py
@@ -83,7 +83,7 @@ if sys.platform == "win32":  # pragma: win32 cover
             _KERNEL32.CloseHandle(handle)
         return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
 
-else:
+else:  # pragma: win32 no cover
 
     def process_alive(pid: int) -> bool:
         """Whether a process with this PID exists, treating an access denial (``EPERM``) as proof it does."""

--- a/src/filelock/_identity.py
+++ b/src/filelock/_identity.py
@@ -78,7 +78,7 @@ if sys.platform == "win32":  # pragma: win32 cover
                 ctypes.byref(kernel_time),
                 ctypes.byref(user_time),
             ):
-                return None
+                return None  # pragma: no cover  # win32 GetProcessTimes failure path; not reproducible on a live handle
         finally:
             _KERNEL32.CloseHandle(handle)
         return (creation.dwHighDateTime << 32) | creation.dwLowDateTime

--- a/src/filelock/_identity.py
+++ b/src/filelock/_identity.py
@@ -83,7 +83,7 @@ if sys.platform == "win32":  # pragma: win32 cover
             _KERNEL32.CloseHandle(handle)
         return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
 
-else:  # pragma: win32 no cover
+else:
 
     def process_alive(pid: int) -> bool:
         """Whether a process with this PID exists, treating an access denial (``EPERM``) as proof it does."""

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -189,7 +189,7 @@ class SoftFileLease(MarkerSoftFileLock):
             if owner_is_stale(owner.pid, owner.hostname, owner.start):
                 break_lock_file(self.lock_file, mtime, ino)
                 return
-            if time.time() - mtime >= self._lease_duration:
+            if time.time() - mtime >= self._lease_duration:  # pragma: win32 no cover
                 break_lock_file(self.lock_file, mtime, ino)
 
     def _read_peer(self) -> tuple[OwnerRecord, float, int] | None:
@@ -227,7 +227,7 @@ class SoftFileLease(MarkerSoftFileLock):
         last_success = time.monotonic()
         while not self._heartbeat_stop.wait(self._heartbeat_interval):
             outcome, error = self._refresh_claim(fd, identity, token)
-            if outcome == "lost":
+            if outcome == "lost":  # pragma: win32 no cover
                 return
             if outcome == "ok":
                 last_success = time.monotonic()
@@ -239,12 +239,12 @@ class SoftFileLease(MarkerSoftFileLock):
         try:
             st = os.lstat(self.lock_file)
         except FileNotFoundError as error:
-            self._report_compromise("marker-missing", error, token)
-            return "lost", None
+            self._report_compromise("marker-missing", error, token)  # pragma: win32 no cover
+            return "lost", None  # pragma: win32 no cover
         except OSError as error:
             return "transient", error
         # A peer that took the expired claim replaced the marker, so the pathname now names its inode, not ours.
-        if (st.st_dev, st.st_ino) != identity:
+        if (st.st_dev, st.st_ino) != identity:  # pragma: win32 no cover
             self._report_compromise("owner-changed", None, token)
             return "lost", None
         try:

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -189,7 +189,7 @@ class SoftFileLease(MarkerSoftFileLock):
             if owner_is_stale(owner.pid, owner.hostname, owner.start):
                 break_lock_file(self.lock_file, mtime, ino)
                 return
-            if time.time() - mtime >= self._lease_duration:  # pragma: win32 no cover
+            if time.time() - mtime >= self._lease_duration:
                 break_lock_file(self.lock_file, mtime, ino)
 
     def _read_peer(self) -> tuple[OwnerRecord, float, int] | None:
@@ -227,7 +227,7 @@ class SoftFileLease(MarkerSoftFileLock):
         last_success = time.monotonic()
         while not self._heartbeat_stop.wait(self._heartbeat_interval):
             outcome, error = self._refresh_claim(fd, identity, token)
-            if outcome == "lost":  # pragma: win32 no cover
+            if outcome == "lost":
                 return
             if outcome == "ok":
                 last_success = time.monotonic()
@@ -239,12 +239,12 @@ class SoftFileLease(MarkerSoftFileLock):
         try:
             st = os.lstat(self.lock_file)
         except FileNotFoundError as error:
-            self._report_compromise("marker-missing", error, token)  # pragma: win32 no cover
-            return "lost", None  # pragma: win32 no cover
+            self._report_compromise("marker-missing", error, token)
+            return "lost", None
         except OSError as error:
             return "transient", error
         # A peer that took the expired claim replaced the marker, so the pathname now names its inode, not ours.
-        if (st.st_dev, st.st_ino) != identity:  # pragma: win32 no cover
+        if (st.st_dev, st.st_ino) != identity:
             self._report_compromise("owner-changed", None, token)
             return "lost", None
         try:

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -61,7 +61,7 @@ class _ConnectionEscrow:
         self,
     ) -> tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None:
         if not _NEEDS_CONNECTION_ESCROW:
-            return None
+            return None  # pragma: >=3.12 cover
         with self._lock:  # pragma: <3.12 cover  # pragma: needs fork
             if self._functions is None:
                 import ctypes  # ruff:ignore[import-outside-top-level]  # keep optional ctypes and its audited dlsym out of ordinary imports
@@ -163,7 +163,8 @@ class _ForkSafeConnection(sqlite3.Connection):
         self,
         functions: tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None,
     ) -> None:
-        if functions is not None:
+        # The caller only reaches here holding the escrow functions; it skips the call entirely without them.
+        if functions is not None:  # pragma: no branch
             increment, decrement = functions
             increment(self)
             self._decrement_escrow = decrement

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -62,8 +62,8 @@ class _ConnectionEscrow:
     ) -> tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None:
         if not _NEEDS_CONNECTION_ESCROW:
             return None
-        with self._lock:  # pragma: win32 no cover
-            if self._functions is None:  # pragma: win32 no cover
+        with self._lock:  # pragma: <3.12 cover  # pragma: needs fork
+            if self._functions is None:
                 import ctypes  # ruff:ignore[import-outside-top-level]  # keep optional ctypes and its audited dlsym out of ordinary imports
 
                 function_type = ctypes.PYFUNCTYPE(None, ctypes.py_object)
@@ -78,7 +78,7 @@ class _ConnectionEscrow:
                 )
             return self._functions
 
-    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_after_fork_in_child(self) -> None:  # pragma: forked child
         self._lock = threading.RLock()
 
 
@@ -100,7 +100,7 @@ class _ForkedDatabaseRegistry:
             poisoned = (
                 all_paths_poisoned or path in self._paths or (identity is not None and identity in self._identities)
             )
-        if poisoned:  # pragma: win32 no cover
+        if poisoned:  # pragma: needs fork
             msg = (
                 "ReadWriteLock is unavailable in a PyPy fork child; exec or exit before using it"
                 if all_paths_poisoned
@@ -110,7 +110,7 @@ class _ForkedDatabaseRegistry:
 
     def poison_after_fork(self, path: pathlib.Path, identity: _DatabaseIdentity | None) -> None:
         self._paths.add(path)
-        if identity is not None:  # pragma: win32 no cover
+        if identity is not None:
             self._identities.add(identity)
 
     def note_sqlite_use(self) -> None:
@@ -118,7 +118,7 @@ class _ForkedDatabaseRegistry:
             with self._lock:
                 self._sqlite_used = True
 
-    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_after_fork_in_child(self) -> None:  # pragma: forked child
         self._lock = threading.RLock()
         self._all_paths_poisoned = self._all_paths_poisoned or (_IS_PYPY and self._sqlite_used)
         self._sqlite_used = False
@@ -151,19 +151,19 @@ class _ForkSafeConnection(sqlite3.Connection):
 
     def close(self) -> None:
         with _sqlite_transition():
-            if _GETPID() != self._creator_pid:  # pragma: win32 no cover
+            if _GETPID() != self._creator_pid:  # pragma: needs fork
                 return
             with _fork_transition():
                 sqlite3.Connection.close(self)
-                if (decrement := self._decrement_escrow) is not None:  # pragma: win32 no cover
+                if (decrement := self._decrement_escrow) is not None:  # pragma: <3.12 cover  # pragma: needs fork
                     self._decrement_escrow = None
                     decrement(self)
 
-    def acquire_escrow(  # pragma: win32 no cover
+    def acquire_escrow(  # pragma: <3.12 cover  # pragma: needs fork
         self,
         functions: tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None,
     ) -> None:
-        if functions is not None:  # pragma: win32 no cover
+        if functions is not None:
             increment, decrement = functions
             increment(self)
             self._decrement_escrow = decrement
@@ -201,7 +201,7 @@ class _ReadWriteLockMeta(type):
         construction_pid = _GETPID()
         if not is_singleton:
             instance = super().__call__(lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
-            if _GETPID() != construction_pid:  # pragma: no cover - exercised only in a forked constructor callback
+            if _GETPID() != construction_pid:  # pragma: forked child
                 msg = "ReadWriteLock construction cannot continue after fork"
                 raise RuntimeError(msg)
             return instance
@@ -234,7 +234,7 @@ class _ReadWriteLockMeta(type):
                 raise ValueError(msg)
             return instance
 
-    def _reset_class_after_fork(cls) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_class_after_fork(cls) -> None:  # pragma: forked child
         cls._instances = WeakValueDictionary()
         cls._instances_lock = threading.RLock()
         cls._instances_pid = _GETPID()
@@ -417,7 +417,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         """
         with _fork_transition():
             _ensure_current_process()
-            if self._inherited:  # pragma: win32 no cover
+            if self._inherited:  # pragma: needs fork
                 return
             self._raise_if_acquiring("release")
             self._release(force=force, close=False)
@@ -431,7 +431,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         """
         with _fork_transition():
             _ensure_current_process()
-            if self._inherited:  # pragma: win32 no cover
+            if self._inherited:  # pragma: needs fork
                 return
             self._raise_if_acquiring("close")
             self._release(force=True, close=True)
@@ -466,10 +466,10 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
     def __del__(self) -> None:
         if _GETPID() == getattr(self, "_creator_pid", None) and (connection := getattr(self, "_con", None)) is not None:
-            with suppress(sqlite3.Error, RuntimeError):  # pragma: win32 no cover
+            with suppress(sqlite3.Error, RuntimeError):
                 connection.close()
 
-    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_after_fork_in_child(self) -> None:  # pragma: forked child
         if self._con is not None:
             _FORKED_DATABASES.poison_after_fork(self._canonical_path, self._connection_identity)
         self._con = None
@@ -487,7 +487,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
     def _raise_if_unusable(self) -> None:
         _ensure_current_process()
-        if self._inherited:  # pragma: win32 no cover
+        if self._inherited:  # pragma: needs fork
             msg = f"ReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
             raise RuntimeError(msg)
         if self._closed:
@@ -628,7 +628,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         with _sqlite_transition():
             creator_pid = _GETPID()
             functions = _CONNECTION_ESCROW.functions()
-            if _GETPID() != creator_pid:  # pragma: no cover - exercised only in a forked constructor callback
+            if _GETPID() != creator_pid:  # pragma: forked child
                 msg = "SQLite connection construction cannot continue after fork"
                 raise RuntimeError(msg)
             connection = _connect(
@@ -636,9 +636,9 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
                 factory=_ForkSafeConnection,
                 timeout=sqlite_timeout,
             )
-            if functions is not None:  # pragma: win32 no cover
+            if functions is not None:  # pragma: <3.12 cover  # pragma: needs fork
                 connection.acquire_escrow(functions)
-            if _GETPID() != creator_pid:  # pragma: no cover - exercised only in a forked constructor callback
+            if _GETPID() != creator_pid:  # pragma: forked child
                 _FORKED_DATABASES.poison_after_fork(
                     self._canonical_path,
                     _FORKED_DATABASES.identity(self._canonical_path),
@@ -713,7 +713,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
             raise RuntimeError(msg)
 
     def _raise_if_process_changed(self, operation_pid: int) -> None:
-        if _GETPID() != operation_pid or self._inherited:  # pragma: no cover - exercised only in a fork child
+        if _GETPID() != operation_pid or self._inherited:  # pragma: forked child
             msg = f"ReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
             raise RuntimeError(msg)
 
@@ -738,7 +738,7 @@ def _sqlite_transition() -> Generator[None]:
         _SQLITE_TRANSITION_CONTEXT.depth -= 1
 
 
-def _abort_forked_sqlite_transition() -> None:  # pragma: no cover - exits the isolated fork child
+def _abort_forked_sqlite_transition() -> None:  # pragma: forked child
     if _SQLITE_TRANSITION_CONTEXT.depth:
         os._exit(_UNSAFE_FORK_EXIT_STATUS)  # inherited SQLite handles cannot be used or closed safely
 
@@ -770,8 +770,8 @@ _register_fork_object(_CONNECTION_ESCROW)
 _register_fork_object(_FORKED_DATABASES)
 _register_fork_class(ReadWriteLock)
 if _IS_PYPY:
-    sys.addaudithook(_track_sqlite_use)  # pragma: no cover - installed only under the PyPy audit-hook fallback
-if hasattr(os, "register_at_fork"):  # pragma: win32 no cover
+    sys.addaudithook(_track_sqlite_use)  # pragma: pypy cover
+if hasattr(os, "register_at_fork"):  # pragma: needs fork
     os.register_at_fork(after_in_child=_abort_forked_sqlite_transition)
 
 __all__ = [

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -770,7 +770,7 @@ _register_fork_object(_CONNECTION_ESCROW)
 _register_fork_object(_FORKED_DATABASES)
 _register_fork_class(ReadWriteLock)
 if _IS_PYPY:
-    sys.addaudithook(_track_sqlite_use)
+    sys.addaudithook(_track_sqlite_use)  # pragma: no cover - installed only under the PyPy audit-hook fallback
 if hasattr(os, "register_at_fork"):  # pragma: win32 no cover
     os.register_at_fork(after_in_child=_abort_forked_sqlite_transition)
 

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -62,8 +62,8 @@ class _ConnectionEscrow:
     ) -> tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None:
         if not _NEEDS_CONNECTION_ESCROW:
             return None
-        with self._lock:
-            if self._functions is None:
+        with self._lock:  # pragma: win32 no cover
+            if self._functions is None:  # pragma: win32 no cover
                 import ctypes  # ruff:ignore[import-outside-top-level]  # keep optional ctypes and its audited dlsym out of ordinary imports
 
                 function_type = ctypes.PYFUNCTYPE(None, ctypes.py_object)
@@ -100,7 +100,7 @@ class _ForkedDatabaseRegistry:
             poisoned = (
                 all_paths_poisoned or path in self._paths or (identity is not None and identity in self._identities)
             )
-        if poisoned:
+        if poisoned:  # pragma: win32 no cover
             msg = (
                 "ReadWriteLock is unavailable in a PyPy fork child; exec or exit before using it"
                 if all_paths_poisoned
@@ -110,7 +110,7 @@ class _ForkedDatabaseRegistry:
 
     def poison_after_fork(self, path: pathlib.Path, identity: _DatabaseIdentity | None) -> None:
         self._paths.add(path)
-        if identity is not None:
+        if identity is not None:  # pragma: win32 no cover
             self._identities.add(identity)
 
     def note_sqlite_use(self) -> None:
@@ -151,19 +151,19 @@ class _ForkSafeConnection(sqlite3.Connection):
 
     def close(self) -> None:
         with _sqlite_transition():
-            if _GETPID() != self._creator_pid:
+            if _GETPID() != self._creator_pid:  # pragma: win32 no cover
                 return
             with _fork_transition():
                 sqlite3.Connection.close(self)
-                if (decrement := self._decrement_escrow) is not None:
+                if (decrement := self._decrement_escrow) is not None:  # pragma: win32 no cover
                     self._decrement_escrow = None
                     decrement(self)
 
-    def acquire_escrow(
+    def acquire_escrow(  # pragma: win32 no cover
         self,
         functions: tuple[Callable[[sqlite3.Connection], None], Callable[[sqlite3.Connection], None]] | None,
     ) -> None:
-        if functions is not None:
+        if functions is not None:  # pragma: win32 no cover
             increment, decrement = functions
             increment(self)
             self._decrement_escrow = decrement
@@ -417,7 +417,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         """
         with _fork_transition():
             _ensure_current_process()
-            if self._inherited:
+            if self._inherited:  # pragma: win32 no cover
                 return
             self._raise_if_acquiring("release")
             self._release(force=force, close=False)
@@ -431,7 +431,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
         """
         with _fork_transition():
             _ensure_current_process()
-            if self._inherited:
+            if self._inherited:  # pragma: win32 no cover
                 return
             self._raise_if_acquiring("close")
             self._release(force=True, close=True)
@@ -466,7 +466,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
     def __del__(self) -> None:
         if _GETPID() == getattr(self, "_creator_pid", None) and (connection := getattr(self, "_con", None)) is not None:
-            with suppress(sqlite3.Error, RuntimeError):
+            with suppress(sqlite3.Error, RuntimeError):  # pragma: win32 no cover
                 connection.close()
 
     def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
@@ -487,7 +487,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
 
     def _raise_if_unusable(self) -> None:
         _ensure_current_process()
-        if self._inherited:
+        if self._inherited:  # pragma: win32 no cover
             msg = f"ReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
             raise RuntimeError(msg)
         if self._closed:
@@ -636,7 +636,7 @@ class ReadWriteLock(metaclass=_ReadWriteLockMeta):
                 factory=_ForkSafeConnection,
                 timeout=sqlite_timeout,
             )
-            if functions is not None:
+            if functions is not None:  # pragma: win32 no cover
                 connection.acquire_escrow(functions)
             if _GETPID() != creator_pid:  # pragma: no cover - exercised only in a forked constructor callback
                 _FORKED_DATABASES.poison_after_fork(
@@ -771,7 +771,7 @@ _register_fork_object(_FORKED_DATABASES)
 _register_fork_class(ReadWriteLock)
 if _IS_PYPY:
     sys.addaudithook(_track_sqlite_use)
-if hasattr(os, "register_at_fork"):
+if hasattr(os, "register_at_fork"):  # pragma: win32 no cover
     os.register_at_fork(after_in_child=_abort_forked_sqlite_transition)
 
 __all__ = [

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -54,7 +54,7 @@ class SoftFileLock(BaseFileLock):
         # O_CREAT | O_EXCL makes the create fail with EEXIST when the file already exists, so a successful open
         # means this process now holds the lock.
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
-        if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:
+        if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:  # pragma: win32 no cover
             flags |= o_nofollow
         try:
             fd = os.open(self.lock_file, flags, self._open_mode())
@@ -166,7 +166,7 @@ class SoftFileLock(BaseFileLock):
             try:
                 self._unlink_held_marker(identity)
             except BaseException as cleanup_error:  # ruff:ignore[blind-except]  # preserve control-flow cleanup failures
-                _raise_grouped_errors(
+                _raise_grouped_errors(  # pragma: win32 no cover
                     "lock descriptor close and marker cleanup both failed",
                     close_error,
                     cleanup_error,
@@ -177,29 +177,29 @@ class SoftFileLock(BaseFileLock):
     def _unlink_held_marker(self, identity: tuple[int, int] | None) -> None:
         if identity is None:
             return
-        if sys.platform == "win32":
+        if sys.platform == "win32":  # pragma: win32 cover
             self._windows_unlink_if_ours(identity)
-        else:
-            with suppress(OSError):
-                if _file_identity(os.lstat(self.lock_file)) == identity:
+        else:  # pragma: win32 no cover
+            with suppress(OSError):  # pragma: win32 no cover
+                if _file_identity(os.lstat(self.lock_file)) == identity:  # pragma: win32 no cover
                     Path(self.lock_file).unlink()
 
-    def _windows_unlink_if_ours(self, identity: tuple[int, int]) -> None:
+    def _windows_unlink_if_ours(self, identity: tuple[int, int]) -> None:  # pragma: win32 cover
         retry_delay = 0.001
-        for attempt in range(_UNLINK_MAX_RETRIES):
+        for attempt in range(_UNLINK_MAX_RETRIES):  # pragma: win32 cover
             # Windows doesn't immediately release file handles after close, causing EACCES/EPERM on unlink. Recheck
             # identity each attempt: a failed unlink leaves a window for a successor to replace the marker at this path.
-            try:
-                if _file_identity(os.lstat(self.lock_file)) != identity:
+            try:  # pragma: win32 cover
+                if _file_identity(os.lstat(self.lock_file)) != identity:  # pragma: win32 cover
                     return
                 Path(self.lock_file).unlink()
             except OSError as exc:  # ruff:ignore[try-except-in-loop]  # each attempt's errno drives the retry choice
-                if exc.errno not in {EACCES, EPERM}:
+                if exc.errno not in {EACCES, EPERM}:  # pragma: win32 cover
                     return
-                if attempt < _UNLINK_MAX_RETRIES - 1:
+                if attempt < _UNLINK_MAX_RETRIES - 1:  # pragma: win32 cover
                     time.sleep(retry_delay)
                     retry_delay *= 2
-            else:
+            else:  # pragma: win32 cover
                 return
 
 
@@ -215,7 +215,7 @@ def _read_lock_file(path: str) -> tuple[str | None, float, int]:
     # a symlink, stall on a FIFO, or fail on a socket and leave acquisition wedged. The mtime and inode still flow back
     # for the identity-checked stale break. lstat, not stat, so a hostile symlink is never followed onto its target.
     st = os.lstat(path)
-    if not stat.S_ISREG(st.st_mode):
+    if not stat.S_ISREG(st.st_mode):  # pragma: win32 no cover
         return None, st.st_mtime, st.st_ino
     # Re-check on the opened handle: O_NOFOLLOW refuses a symlink swapped in after the lstat, O_NONBLOCK stops a FIFO
     # swapped in from stalling the open, and the fstat catches any other non-regular replacement race before we read.

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -54,7 +54,7 @@ class SoftFileLock(BaseFileLock):
         # O_CREAT | O_EXCL makes the create fail with EEXIST when the file already exists, so a successful open
         # means this process now holds the lock.
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
-        if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:  # pragma: win32 no cover
+        if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:  # pragma: needs o-nofollow
             flags |= o_nofollow
         try:
             fd = os.open(self.lock_file, flags, self._open_mode())
@@ -180,26 +180,26 @@ class SoftFileLock(BaseFileLock):
         if sys.platform == "win32":  # pragma: win32 cover
             self._windows_unlink_if_ours(identity)
         else:  # pragma: win32 no cover
-            with suppress(OSError):  # pragma: win32 no cover
-                if _file_identity(os.lstat(self.lock_file)) == identity:  # pragma: win32 no cover
+            with suppress(OSError):
+                if _file_identity(os.lstat(self.lock_file)) == identity:
                     Path(self.lock_file).unlink()
 
     def _windows_unlink_if_ours(self, identity: tuple[int, int]) -> None:  # pragma: win32 cover
         retry_delay = 0.001
-        for attempt in range(_UNLINK_MAX_RETRIES):  # pragma: win32 cover
+        for attempt in range(_UNLINK_MAX_RETRIES):
             # Windows doesn't immediately release file handles after close, causing EACCES/EPERM on unlink. Recheck
             # identity each attempt: a failed unlink leaves a window for a successor to replace the marker at this path.
-            try:  # pragma: win32 cover
-                if _file_identity(os.lstat(self.lock_file)) != identity:  # pragma: win32 cover
+            try:
+                if _file_identity(os.lstat(self.lock_file)) != identity:
                     return
                 Path(self.lock_file).unlink()
             except OSError as exc:  # ruff:ignore[try-except-in-loop]  # each attempt's errno drives the retry choice
-                if exc.errno not in {EACCES, EPERM}:  # pragma: win32 cover
+                if exc.errno not in {EACCES, EPERM}:
                     return
-                if attempt < _UNLINK_MAX_RETRIES - 1:  # pragma: win32 cover
+                if attempt < _UNLINK_MAX_RETRIES - 1:
                     time.sleep(retry_delay)
                     retry_delay *= 2
-            else:  # pragma: win32 cover
+            else:
                 return
 
 
@@ -215,7 +215,7 @@ def _read_lock_file(path: str) -> tuple[str | None, float, int]:
     # a symlink, stall on a FIFO, or fail on a socket and leave acquisition wedged. The mtime and inode still flow back
     # for the identity-checked stale break. lstat, not stat, so a hostile symlink is never followed onto its target.
     st = os.lstat(path)
-    if not stat.S_ISREG(st.st_mode):  # pragma: win32 no cover
+    if not stat.S_ISREG(st.st_mode):  # pragma: needs fifo
         return None, st.st_mtime, st.st_ino
     # Re-check on the opened handle: O_NOFOLLOW refuses a symlink swapped in after the lstat, O_NONBLOCK stops a FIFO
     # swapped in from stalling the open, and the fstat catches any other non-regular replacement race before we read.

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -88,7 +88,7 @@ class SoftFileLock(BaseFileLock):
     def _try_break_stale_lock(self) -> None:
         with suppress(OSError, ValueError):
             content, mtime, ino = _read_lock_file(self.lock_file)
-            if content == STRICT_SOFT_SENTINEL_RECORD:
+            if content == STRICT_SOFT_SENTINEL_RECORD:  # pragma: needs hard-link
                 return
             holder = _parse_lock_holder(content)
 

--- a/src/filelock/_soft.py
+++ b/src/filelock/_soft.py
@@ -166,7 +166,7 @@ class SoftFileLock(BaseFileLock):
             try:
                 self._unlink_held_marker(identity)
             except BaseException as cleanup_error:  # ruff:ignore[blind-except]  # preserve control-flow cleanup failures
-                _raise_grouped_errors(  # pragma: win32 no cover
+                _raise_grouped_errors(
                     "lock descriptor close and marker cleanup both failed",
                     close_error,
                     cleanup_error,

--- a/src/filelock/_soft_rw/_async.py
+++ b/src/filelock/_soft_rw/_async.py
@@ -192,7 +192,7 @@ class AsyncSoftReadWriteLock:
             await self._run(self._lock.close)
 
     def _raise_if_inherited(self) -> None:
-        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+        if self._creator_pid != os.getpid():  # pragma: forked child
             msg = f"AsyncSoftReadWriteLock on {self.lock_file} was inherited across fork; construct a new instance"
             raise RuntimeError(msg)
 

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -82,7 +82,7 @@ class _SoftRWMeta(type):
         with cls._instances_lock:
             instance = cls._instances.get(normalized)
             if instance is None:
-                if normalized in _SINGLETONS_UNDER_CONSTRUCTION:
+                if normalized in _SINGLETONS_UNDER_CONSTRUCTION:  # pragma: win32 no cover
                     msg = f"Singleton lock construction is already active for {lock_file!s}"
                     raise RuntimeError(msg)
                 construction_pid = os.getpid()
@@ -99,7 +99,7 @@ class _SoftRWMeta(type):
                     )
                 finally:
                     _SINGLETONS_UNDER_CONSTRUCTION.discard(normalized)
-                if os.getpid() != construction_pid:
+                if os.getpid() != construction_pid:  # pragma: win32 no cover
                     msg = "Lock construction cannot continue after fork; construct a new lock in the child"
                     raise RuntimeError(msg)
                 cls._instances[normalized] = instance
@@ -346,13 +346,13 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             if self._closed:
                 return
             self._closed = True
-            if self._readers_dir_fd is not None:
-                with _fork_transition():
-                    if self._readers_dir_fd_token is not None:
+            if self._readers_dir_fd is not None:  # pragma: win32 no cover
+                with _fork_transition():  # pragma: win32 no cover
+                    if self._readers_dir_fd_token is not None:  # pragma: win32 no cover
                         _unregister_owned_descriptor(self._readers_dir_fd_token)
                     self._readers_dir_fd_token = None
                     fd, self._readers_dir_fd = self._readers_dir_fd, None
-                    with suppress(OSError):
+                    with suppress(OSError):  # pragma: win32 no cover
                         os.close(fd)
 
     def release(self, *, force: bool = False) -> None:
@@ -544,8 +544,8 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             return False
         try:
             _atomic_create_marker(self._paths.write, token)
-        except FileExistsError:
-            return False
+        except FileExistsError:  # pragma: win32 no cover
+            return False  # pragma: win32 no cover
         return True
 
     def _touch_writer_marker_if_ours(self, token: str) -> bool:
@@ -586,7 +586,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
                 _break_stale_marker(self._paths.write, stale_threshold=self.stale_threshold, now=time.time())
                 if _file_exists(self._paths.write):
                     return False
-                if dir_fd is not None:
+                if dir_fd is not None:  # pragma: win32 no cover
                     _atomic_create_marker(reader_name, token, dir_fd=dir_fd)
                 else:  # pragma: win32 cover
                     _atomic_create_marker(full_reader_path, token)
@@ -625,13 +625,13 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
             msg = f"{self._paths.readers} exists but is not a directory or is a symlink; refusing to use it"
             raise RuntimeError(msg)
-        if self._readers_dir_fd is None and _SUPPORTS_DIR_FD:
-            with _fork_transition():
+        if self._readers_dir_fd is None and _SUPPORTS_DIR_FD:  # pragma: win32 no cover
+            with _fork_transition():  # pragma: win32 no cover
                 fd = os.open(self._paths.readers, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW)
-                try:
+                try:  # pragma: win32 no cover
                     token = _register_owned_descriptor(fd)
-                except BaseException as registration_error:
-                    try:
+                except BaseException as registration_error:  # pragma: win32 no cover
+                    try:  # pragma: win32 no cover
                         os.close(fd)
                     except BaseException as close_error:  # ruff:ignore[blind-except]  # both errors surface via the group below
                         _raise_grouped_errors(
@@ -655,10 +655,10 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         ``dirfd_relative`` is ``True`` when *name* should be passed to ``dir_fd=``-aware syscalls; ``False``
         when *name* is a full path because dirfd-relative I/O is unavailable on this platform.
         """
-        if self._readers_dir_fd is not None:
-            with os.scandir(self._readers_dir_fd) as it:
-                for entry in it:
-                    if not _is_housekeeping_name(entry.name):
+        if self._readers_dir_fd is not None:  # pragma: win32 no cover
+            with os.scandir(self._readers_dir_fd) as it:  # pragma: win32 no cover
+                for entry in it:  # pragma: win32 no cover
+                    if not _is_housekeeping_name(entry.name):  # pragma: win32 no cover
                         yield entry.name, True
             return
         readers_path = Path(self._paths.readers)  # pragma: win32 cover
@@ -759,7 +759,7 @@ def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo |
         # malformed marker (its mtime still drives stale eviction) without being read. Reading is where
         # platforms diverge: an empty non-blocking read yields 0 bytes on Linux/macOS but EAGAIN on FreeBSD,
         # and the EAGAIN used to abort the stale-break and wedge the acquire until timeout (#587).
-        if not stat.S_ISREG(st.st_mode):
+        if not stat.S_ISREG(st.st_mode):  # pragma: win32 no cover
             return None, st.st_mtime
         data = os.read(fd, _MAX_MARKER_SIZE + 1)
     except OSError:  # pragma: no cover - marker vanished or turned unreadable between open and read
@@ -820,7 +820,7 @@ def _parse_marker_bytes(data: bytes) -> _MarkerInfo | None:
 
 def _unlink(name: str, *, dir_fd: int | None = None) -> None:
     with suppress(FileNotFoundError):
-        if _SUPPORTS_DIR_FD and dir_fd is not None:
+        if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: win32 no cover
             # Path.unlink has no dir_fd support, so we stay on os.unlink for the dirfd path.
             os.unlink(name, dir_fd=dir_fd)
         else:
@@ -849,7 +849,7 @@ def _break_stale_marker(  # ruff:ignore[too-many-return-statements]  # each retu
 
     break_name = f"{name}{_BREAK_SUFFIX}.{os.getpid()}.{secrets.token_hex(16)}"
     try:
-        if _SUPPORTS_DIR_FD and dir_fd is not None:
+        if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: win32 no cover
             os.rename(name, break_name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
         else:
             Path(name).rename(break_name)
@@ -875,7 +875,7 @@ def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -
     # O_NOFOLLOW blocks the symlink-overwrite attack where an attacker pre-creates the marker path as a
     # symlink pointing at a victim file. Mode 0o600 keeps the token unreadable to other users.
     flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _O_NOFOLLOW
-    if _SUPPORTS_DIR_FD and dir_fd is not None:
+    if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: win32 no cover
         fd = os.open(name, flags, 0o600, dir_fd=dir_fd)
     else:
         fd = os.open(name, flags, 0o600)

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -82,7 +82,7 @@ class _SoftRWMeta(type):
         with cls._instances_lock:
             instance = cls._instances.get(normalized)
             if instance is None:
-                if normalized in _SINGLETONS_UNDER_CONSTRUCTION:  # pragma: win32 no cover
+                if normalized in _SINGLETONS_UNDER_CONSTRUCTION:  # pragma: needs fork
                     msg = f"Singleton lock construction is already active for {lock_file!s}"
                     raise RuntimeError(msg)
                 construction_pid = os.getpid()
@@ -99,7 +99,7 @@ class _SoftRWMeta(type):
                     )
                 finally:
                     _SINGLETONS_UNDER_CONSTRUCTION.discard(normalized)
-                if os.getpid() != construction_pid:  # pragma: win32 no cover
+                if os.getpid() != construction_pid:  # pragma: needs fork
                     msg = "Lock construction cannot continue after fork; construct a new lock in the child"
                     raise RuntimeError(msg)
                 cls._instances[normalized] = instance
@@ -213,7 +213,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         _register_fork_object(self)
 
     @classmethod
-    def _reset_class_after_fork(cls) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_class_after_fork(cls) -> None:  # pragma: forked child
         global _ALL_INSTANCES_LOCK  # ruff:ignore[global-statement]  # rebinds the module lock to a fresh one in the fork child
         _ALL_INSTANCES_LOCK = threading.Lock()
         cls._instances = WeakValueDictionary()
@@ -339,20 +339,20 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         Idempotent. After calling this method the instance can no longer acquire locks — subsequent acquires raise
         :class:`RuntimeError`. A fork-invalidated instance is closed without raising.
         """
-        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+        if self._creator_pid != os.getpid():  # pragma: forked child
             return
         self.release(force=True)
         with self._locks.internal:
             if self._closed:
                 return
             self._closed = True
-            if self._readers_dir_fd is not None:  # pragma: win32 no cover
-                with _fork_transition():  # pragma: win32 no cover
-                    if self._readers_dir_fd_token is not None:  # pragma: win32 no cover
+            if self._readers_dir_fd is not None:  # pragma: needs dir-fd
+                with _fork_transition():
+                    if self._readers_dir_fd_token is not None:  # pragma: needs dir-fd
                         _unregister_owned_descriptor(self._readers_dir_fd_token)
                     self._readers_dir_fd_token = None
                     fd, self._readers_dir_fd = self._readers_dir_fd, None
-                    with suppress(OSError):  # pragma: win32 no cover
+                    with suppress(OSError):  # pragma: needs dir-fd
                         os.close(fd)
 
     def release(self, *, force: bool = False) -> None:
@@ -368,7 +368,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         :raises RuntimeError: if no lock is currently held and *force* is ``False``
 
         """
-        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+        if self._creator_pid != os.getpid():  # pragma: forked child
             return
         with self._locks.internal:
             hold = self._hold
@@ -416,7 +416,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         *,
         blocking: bool | None,
     ) -> AcquireReturnProxy:
-        if self._creator_pid != os.getpid():  # pragma: no cover - exercised only in fork children
+        if self._creator_pid != os.getpid():  # pragma: forked child
             msg = f"SoftReadWriteLock on {self.lock_file} was invalidated by fork(); construct a new instance"
             raise RuntimeError(msg)
         timeout = self.timeout if timeout is None else timeout
@@ -586,7 +586,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
                 _break_stale_marker(self._paths.write, stale_threshold=self.stale_threshold, now=time.time())
                 if _file_exists(self._paths.write):
                     return False
-                if dir_fd is not None:  # pragma: win32 no cover
+                if dir_fd is not None:  # pragma: needs dir-fd
                     _atomic_create_marker(reader_name, token, dir_fd=dir_fd)
                 else:  # pragma: win32 cover
                     _atomic_create_marker(full_reader_path, token)
@@ -625,13 +625,13 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
             msg = f"{self._paths.readers} exists but is not a directory or is a symlink; refusing to use it"
             raise RuntimeError(msg)
-        if self._readers_dir_fd is None and _SUPPORTS_DIR_FD:  # pragma: win32 no cover
-            with _fork_transition():  # pragma: win32 no cover
+        if self._readers_dir_fd is None and _SUPPORTS_DIR_FD:  # pragma: needs dir-fd
+            with _fork_transition():
                 fd = os.open(self._paths.readers, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW)
-                try:  # pragma: win32 no cover
+                try:
                     token = _register_owned_descriptor(fd)
-                except BaseException as registration_error:  # pragma: win32 no cover
-                    try:  # pragma: win32 no cover
+                except BaseException as registration_error:
+                    try:
                         os.close(fd)
                     except BaseException as close_error:  # ruff:ignore[blind-except]  # both errors surface via the group below
                         _raise_grouped_errors(
@@ -655,10 +655,10 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         ``dirfd_relative`` is ``True`` when *name* should be passed to ``dir_fd=``-aware syscalls; ``False``
         when *name* is a full path because dirfd-relative I/O is unavailable on this platform.
         """
-        if self._readers_dir_fd is not None:  # pragma: win32 no cover
-            with os.scandir(self._readers_dir_fd) as it:  # pragma: win32 no cover
-                for entry in it:  # pragma: win32 no cover
-                    if not _is_housekeeping_name(entry.name):  # pragma: win32 no cover
+        if self._readers_dir_fd is not None:  # pragma: needs dir-fd
+            with os.scandir(self._readers_dir_fd) as it:
+                for entry in it:
+                    if not _is_housekeeping_name(entry.name):
                         yield entry.name, True
             return
         readers_path = Path(self._paths.readers)  # pragma: win32 cover
@@ -718,7 +718,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         finally:
             os.close(fd)
 
-    def _reset_after_fork_in_child(self) -> None:  # pragma: no cover - exercised in fork children
+    def _reset_after_fork_in_child(self) -> None:  # pragma: forked child
         self._locks = _Locks(
             internal=threading.Lock(),
             transaction=threading.Lock(),
@@ -759,7 +759,7 @@ def _read_marker(name: str, *, dir_fd: int | None = None) -> tuple[_MarkerInfo |
         # malformed marker (its mtime still drives stale eviction) without being read. Reading is where
         # platforms diverge: an empty non-blocking read yields 0 bytes on Linux/macOS but EAGAIN on FreeBSD,
         # and the EAGAIN used to abort the stale-break and wedge the acquire until timeout (#587).
-        if not stat.S_ISREG(st.st_mode):  # pragma: win32 no cover
+        if not stat.S_ISREG(st.st_mode):  # pragma: needs fifo
             return None, st.st_mtime
         data = os.read(fd, _MAX_MARKER_SIZE + 1)
     except OSError:  # pragma: no cover - marker vanished or turned unreadable between open and read
@@ -820,7 +820,7 @@ def _parse_marker_bytes(data: bytes) -> _MarkerInfo | None:
 
 def _unlink(name: str, *, dir_fd: int | None = None) -> None:
     with suppress(FileNotFoundError):
-        if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: win32 no cover
+        if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: needs dir-fd
             # Path.unlink has no dir_fd support, so we stay on os.unlink for the dirfd path.
             os.unlink(name, dir_fd=dir_fd)
         else:
@@ -849,7 +849,7 @@ def _break_stale_marker(  # ruff:ignore[too-many-return-statements]  # each retu
 
     break_name = f"{name}{_BREAK_SUFFIX}.{os.getpid()}.{secrets.token_hex(16)}"
     try:
-        if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: win32 no cover
+        if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: needs dir-fd
             os.rename(name, break_name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
         else:
             Path(name).rename(break_name)
@@ -875,7 +875,7 @@ def _atomic_create_marker(name: str, token: str, *, dir_fd: int | None = None) -
     # O_NOFOLLOW blocks the symlink-overwrite attack where an attacker pre-creates the marker path as a
     # symlink pointing at a victim file. Mode 0o600 keeps the token unreadable to other users.
     flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _O_NOFOLLOW
-    if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: win32 no cover
+    if _SUPPORTS_DIR_FD and dir_fd is not None:  # pragma: needs dir-fd
         fd = os.open(name, flags, 0o600, dir_fd=dir_fd)
     else:
         fd = os.open(name, flags, 0o600)

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -544,8 +544,8 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             return False
         try:
             _atomic_create_marker(self._paths.write, token)
-        except FileExistsError:  # pragma: win32 no cover
-            return False  # pragma: win32 no cover
+        except FileExistsError:
+            return False
         return True
 
     def _touch_writer_marker_if_ours(self, token: str) -> bool:

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -572,7 +572,7 @@ def _reclaim_sentinel_private_records(path: Path, now: float) -> None:
     directory_ref = os.fspath(path.parent), None
     with os.scandir(path.parent) as entries:
         for entry in entries:
-            if _private_public_name(entry.name) == path.name:  # pragma: win32 cover
+            if _private_public_name(entry.name) == path.name:
                 _reclaim_private_record(directory_ref, entry.name, now)
 
 

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -133,8 +133,8 @@ class StrictSoftFileLock(BaseFileLock):
         try:
             publication_cleanup_error = _publish_record(intent_path, _claim_record(token), self._open_mode())
         except _PrivateRecordReclaimedError:
-            self._discard_doorway(sentinel_fd, sentinel_identity)
-            return
+            self._discard_doorway(sentinel_fd, sentinel_identity)  # pragma: win32 no cover
+            return  # pragma: win32 no cover
         except (NotImplementedError, OSError) as error:
             _raise_if_hard_links_unsupported(self.lock_file, error)
             if isinstance(error, OSError) and error.errno == EEXIST:
@@ -162,7 +162,7 @@ class StrictSoftFileLock(BaseFileLock):
             _raise_if_hard_links_unsupported(self.lock_file, error)
             raise
         self._context.owner_claim_paths = (held_path, intent_path)
-        if link_cleanup_error is not None:
+        if link_cleanup_error is not None:  # pragma: win32 no cover
             self._context.owner_claim_paths = ()
             raise link_cleanup_error
 
@@ -198,7 +198,7 @@ class StrictSoftFileLock(BaseFileLock):
         # descriptor or, when a held claim cannot be removed, commits it as owned so a later release retries and
         # raises the cleanup errors. A base rollback would release that owned descriptor again and report each
         # failure a second time, so leave the reconciled state alone.
-        if self.is_locked:
+        if self.is_locked:  # pragma: win32 no cover
             return
         super()._rollback_failed_acquire(acquisition_error)
 
@@ -213,20 +213,20 @@ class StrictSoftFileLock(BaseFileLock):
         self._context.claim_root = None
         remaining, errors = _unlink_owner_paths(self._context.owner_claim_paths)
         self._context.owner_claim_paths = tuple(remaining)
-        if remaining:
+        if remaining:  # pragma: win32 no cover
             _raise_recorded_errors("strict claim release failed", errors)
         self._mark_descriptor_released()
         try:
             self._close_released_fd(fd, default_suppresses=False)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # preserve claim and sentinel cleanup errors
             errors.append(close_error)
-        if errors:
+        if errors:  # pragma: win32 no cover
             _raise_recorded_errors("strict release cleanup failed", errors)
 
     def _discard_doorway(self, fd: int, identity: tuple[int, int]) -> None:
         remaining, errors = _unlink_owner_paths(self._context.owner_claim_paths)
         self._context.owner_claim_paths = tuple(remaining)
-        if remaining:
+        if remaining:  # pragma: win32 no cover
             self._mark_descriptor_owned(fd, identity)
             _raise_recorded_errors("strict doorway claim cleanup failed", errors)
         self._mark_descriptor_released()
@@ -335,7 +335,7 @@ def _read_claim_record(lock_file: str, directory: Path, name: str) -> bytes | No
                 # contention, never free a held lock.
                 return None
             reason = f"cannot read claim: {pending.strerror or str(pending) or type(pending).__name__}"
-            raise SoftFileLockProtocolError(lock_file, name, reason) from pending
+            raise SoftFileLockProtocolError(lock_file, name, reason) from pending  # pragma: win32 no cover
         delaying = True
 
 
@@ -444,13 +444,13 @@ def _publish_record(
         _publish_record_in_directory(directory_ref, (private_name, public_name), mode, record)
     except BaseException as publication_error:  # preserve publication and directory cleanup errors
         try:
-            if directory_fd is not None:
+            if directory_fd is not None:  # pragma: win32 no cover
                 os.close(directory_fd)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # preserve publication and directory cleanup errors
             _raise_cleanup_errors("strict publication directory cleanup failed", publication_error, close_error)
         raise
-    if directory_fd is not None:
-        try:
+    if directory_fd is not None:  # pragma: win32 no cover
+        try:  # pragma: win32 no cover
             os.close(directory_fd)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # caller records the published path before raising
             return close_error
@@ -464,7 +464,7 @@ def _publish_record_in_directory(
     record: bytes,
 ) -> None:
     flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | _O_BINARY
-    if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:
+    if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:  # pragma: win32 no cover
         flags |= o_nofollow
     private_fd = _open_relative(directory_ref, names[0], flags, mode)
     private_identity: tuple[int, int] | None = None
@@ -514,10 +514,10 @@ def _close_and_unlink_private_record(
             _unlink_relative(directory_ref, private_name)
         else:
             _unlink_relative_if_identity(directory_ref, private_name, private_identity)
-    except FileNotFoundError:
+    except FileNotFoundError:  # pragma: win32 no cover
         pass
     except BaseException as error:  # ruff:ignore[blind-except]  # returned for grouping with close failures
-        unlink_error = error
+        unlink_error = error  # pragma: win32 no cover
     return close_error, unlink_error
 
 
@@ -529,14 +529,14 @@ def _link_private_record(
     try:
         _link_relative(directory_ref, *names)
     except FileNotFoundError as error:
-        if _relative_identity(directory_ref, names[0]) is not None:
+        if _relative_identity(directory_ref, names[0]) is not None:  # pragma: win32 no cover
             raise
-        msg = "private publication record was reclaimed"
-        raise _PrivateRecordReclaimedError(msg) from error
+        msg = "private publication record was reclaimed"  # pragma: win32 no cover
+        raise _PrivateRecordReclaimedError(msg) from error  # pragma: win32 no cover
     if _relative_identity(directory_ref, names[1]) == private_identity:
         return
-    msg_0 = "private publication record was replaced"
-    raise _PrivateRecordReclaimedError(msg_0)
+    msg_0 = "private publication record was replaced"  # pragma: win32 no cover
+    raise _PrivateRecordReclaimedError(msg_0)  # pragma: win32 no cover
 
 
 def _raise_record_finalization_errors(
@@ -570,7 +570,7 @@ def _reclaim_sentinel_private_records(path: Path, now: float) -> None:
     directory_ref = os.fspath(path.parent), None
     with os.scandir(path.parent) as entries:
         for entry in entries:
-            if _private_public_name(entry.name) == path.name:
+            if _private_public_name(entry.name) == path.name:  # pragma: win32 cover
                 _reclaim_private_record(directory_ref, entry.name, now)
 
 
@@ -609,9 +609,9 @@ def _unlink_private_record_once(directory_ref: tuple[str, int | None], private_n
 def _relative_identity(directory_ref: tuple[str, int | None], name: str) -> tuple[int, int] | None:
     directory, directory_fd = directory_ref
     try:
-        if directory_fd is not None and _STAT_SUPPORTS_DIR_FD:
+        if directory_fd is not None and _STAT_SUPPORTS_DIR_FD:  # pragma: win32 no cover
             path_stat = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
-        else:
+        else:  # pragma: win32 cover
             path_stat = Path(directory, name).lstat()
     except FileNotFoundError:
         return None
@@ -639,10 +639,10 @@ def _open_relative(directory_ref: tuple[str, int | None], name: str, flags: int,
 
 def _link_relative(directory_ref: tuple[str, int | None], source_name: str, destination_name: str) -> None:
     directory, directory_fd = directory_ref
-    if directory_fd is not None and _LINK_SUPPORTS_DIR_FD:
+    if directory_fd is not None and _LINK_SUPPORTS_DIR_FD:  # pragma: win32 no cover
         _link_no_follow(source_name, destination_name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
         return
-    _link_no_follow(Path(directory, source_name), Path(directory, destination_name))
+    _link_no_follow(Path(directory, source_name), Path(directory, destination_name))  # pragma: win32 cover
 
 
 def _link_no_follow(
@@ -668,32 +668,32 @@ def _link_no_follow(
 
 def _unlink_relative(directory_ref: tuple[str, int | None], name: str) -> None:
     directory, directory_fd = directory_ref
-    if directory_fd is not None and _UNLINK_SUPPORTS_DIR_FD:
+    if directory_fd is not None and _UNLINK_SUPPORTS_DIR_FD:  # pragma: win32 no cover
         os.unlink(name, dir_fd=directory_fd)
-    elif sys.platform == "win32":
+    elif sys.platform == "win32":  # pragma: win32 cover
         _unlink_in_directory(Path(directory), name)
     else:
         Path(directory, name).unlink()
 
 
 def _link_no_replace(directory: Path, source_name: str, destination_name: str) -> BaseException | None:
-    if _LINK_SUPPORTS_DIR_FD:
+    if _LINK_SUPPORTS_DIR_FD:  # pragma: win32 no cover
         directory_fd = _open_directory(str(directory))
-        try:
+        try:  # pragma: win32 no cover
             _link_no_follow(source_name, destination_name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
-        except BaseException as link_error:  # preserve link and directory cleanup errors
-            try:
+        except BaseException as link_error:  # preserve link and directory cleanup errors  # pragma: win32 no cover
+            try:  # pragma: win32 no cover
                 os.close(directory_fd)
             except BaseException as close_error:  # ruff:ignore[blind-except]  # preserve link and directory cleanup errors
                 _raise_cleanup_errors("strict link directory cleanup failed", link_error, close_error)
             raise
-        try:
+        try:  # pragma: win32 no cover
             os.close(directory_fd)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # caller records the held path before raising
             return close_error
         return None
     _link_no_follow(directory / source_name, directory / destination_name)  # pragma: win32 cover
-    return None
+    return None  # pragma: win32 cover
 
 
 def _unlink_owner_path(path: str) -> BaseException | None:
@@ -714,36 +714,36 @@ def _unlink_owner_path_result(path: str) -> tuple[bool, BaseException | None]:
     except FileNotFoundError:
         return True, None
     except BaseException as error:  # ruff:ignore[blind-except]  # keep ownership when unlink did not commit
-        return False, error
+        return False, error  # pragma: win32 no cover
     return True, cleanup_error
 
 
-def _raise_recorded_errors(message: str, errors: list[BaseException]) -> None:
-    if len(errors) > 1:
+def _raise_recorded_errors(message: str, errors: list[BaseException]) -> None:  # pragma: win32 no cover
+    if len(errors) > 1:  # pragma: win32 no cover
         _raise_cleanup_errors(message, errors[0], *errors[1:])
     raise errors[0]
 
 
 def _unlink_in_directory(directory: Path, name: str) -> BaseException | None:
-    if _UNLINK_SUPPORTS_DIR_FD:
+    if _UNLINK_SUPPORTS_DIR_FD:  # pragma: win32 no cover
         directory_fd = _open_directory(str(directory))
-        try:
+        try:  # pragma: win32 no cover
             os.unlink(name, dir_fd=directory_fd)
-        except BaseException as unlink_error:  # preserve unlink and directory cleanup errors
-            try:
+        except BaseException as unlink_error:  # preserve unlink and directory cleanup errors  # pragma: win32 no cover
+            try:  # pragma: win32 no cover
                 os.close(directory_fd)
             except BaseException as close_error:  # ruff:ignore[blind-except]  # preserve unlink and directory cleanup errors
                 _raise_cleanup_errors("strict unlink directory cleanup failed", unlink_error, close_error)
             raise
-        try:
+        try:  # pragma: win32 no cover
             os.close(directory_fd)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # caller commits the removed path before raising
             return close_error
         return None
-    if sys.platform != "win32":
+    if sys.platform != "win32":  # pragma: win32 no cover
         Path(directory / name).unlink()
         return None
-    retry_delay = 0.001
+    retry_delay = 0.001  # pragma: win32 cover
     for attempt in range(_UNLINK_MAX_RETRIES):  # pragma: win32 cover
         if (error := _unlink_error(directory / name)) is None:
             return None
@@ -754,15 +754,15 @@ def _unlink_in_directory(directory: Path, name: str) -> BaseException | None:
     return None  # pragma: win32 no cover  # the final retry returns or raises
 
 
-def _unlink_error(path: Path) -> OSError | None:
-    try:
+def _unlink_error(path: Path) -> OSError | None:  # pragma: win32 cover
+    try:  # pragma: win32 cover
         path.unlink()
-    except OSError as error:
+    except OSError as error:  # pragma: win32 cover
         return error
     return None
 
 
-def _open_directory(directory: str) -> int:
+def _open_directory(directory: str) -> int:  # pragma: win32 no cover
     return os.open(
         directory,
         os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
@@ -795,7 +795,7 @@ def _open_record(path: Path, limit: int) -> tuple[int, bytes]:
 
 def _read_opened_record(fd: int, path: Path, path_stat: os.stat_result, limit: int) -> bytes:
     opened_stat = os.fstat(fd)
-    if not stat.S_ISREG(opened_stat.st_mode):
+    if not stat.S_ISREG(opened_stat.st_mode):  # pragma: win32 no cover
         msg = f"{path} is not a regular file"
         raise OSError(msg)
     if _file_identity(opened_stat) != _file_identity(path_stat):

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -665,11 +665,9 @@ def _link_no_follow(
     # attacker can reach. Pass the option only when the runtime honors it: PyPy advertises it through
     # os.supports_follow_symlinks yet its linkat rejects it with EINVAL, so probe once rather than trust the set.
     if _LINK_HONORS_FOLLOW_SYMLINKS:
-        os.link(
-            source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd, follow_symlinks=False
-        )  # pragma: win32 no cover
-    else:
-        os.link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)  # pragma: win32 cover
+        os.link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd, follow_symlinks=False)
+    else:  # pragma: no cover  # only where os.link rejects follow_symlinks (PyPy), which runs without coverage
+        os.link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
 
 
 def _unlink_relative(directory_ref: tuple[str, int | None], name: str) -> None:

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -133,8 +133,8 @@ class StrictSoftFileLock(BaseFileLock):
         try:
             publication_cleanup_error = _publish_record(intent_path, _claim_record(token), self._open_mode())
         except _PrivateRecordReclaimedError:
-            self._discard_doorway(sentinel_fd, sentinel_identity)  # pragma: win32 no cover
-            return  # pragma: win32 no cover
+            self._discard_doorway(sentinel_fd, sentinel_identity)
+            return
         except (NotImplementedError, OSError) as error:
             _raise_if_hard_links_unsupported(self.lock_file, error)
             if isinstance(error, OSError) and error.errno == EEXIST:
@@ -162,7 +162,7 @@ class StrictSoftFileLock(BaseFileLock):
             _raise_if_hard_links_unsupported(self.lock_file, error)
             raise
         self._context.owner_claim_paths = (held_path, intent_path)
-        if link_cleanup_error is not None:  # pragma: win32 no cover
+        if link_cleanup_error is not None:
             self._context.owner_claim_paths = ()
             raise link_cleanup_error
 
@@ -198,7 +198,7 @@ class StrictSoftFileLock(BaseFileLock):
         # descriptor or, when a held claim cannot be removed, commits it as owned so a later release retries and
         # raises the cleanup errors. A base rollback would release that owned descriptor again and report each
         # failure a second time, so leave the reconciled state alone.
-        if self.is_locked:  # pragma: win32 no cover
+        if self.is_locked:
             return
         super()._rollback_failed_acquire(acquisition_error)
 
@@ -213,20 +213,20 @@ class StrictSoftFileLock(BaseFileLock):
         self._context.claim_root = None
         remaining, errors = _unlink_owner_paths(self._context.owner_claim_paths)
         self._context.owner_claim_paths = tuple(remaining)
-        if remaining:  # pragma: win32 no cover
+        if remaining:
             _raise_recorded_errors("strict claim release failed", errors)
         self._mark_descriptor_released()
         try:
             self._close_released_fd(fd, default_suppresses=False)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # preserve claim and sentinel cleanup errors
             errors.append(close_error)
-        if errors:  # pragma: win32 no cover
+        if errors:
             _raise_recorded_errors("strict release cleanup failed", errors)
 
     def _discard_doorway(self, fd: int, identity: tuple[int, int]) -> None:
         remaining, errors = _unlink_owner_paths(self._context.owner_claim_paths)
         self._context.owner_claim_paths = tuple(remaining)
-        if remaining:  # pragma: win32 no cover
+        if remaining:
             self._mark_descriptor_owned(fd, identity)
             _raise_recorded_errors("strict doorway claim cleanup failed", errors)
         self._mark_descriptor_released()
@@ -335,7 +335,7 @@ def _read_claim_record(lock_file: str, directory: Path, name: str) -> bytes | No
                 # contention, never free a held lock.
                 return None
             reason = f"cannot read claim: {pending.strerror or str(pending) or type(pending).__name__}"
-            raise SoftFileLockProtocolError(lock_file, name, reason) from pending  # pragma: win32 no cover
+            raise SoftFileLockProtocolError(lock_file, name, reason) from pending
         delaying = True
 
 
@@ -514,10 +514,10 @@ def _close_and_unlink_private_record(
             _unlink_relative(directory_ref, private_name)
         else:
             _unlink_relative_if_identity(directory_ref, private_name, private_identity)
-    except FileNotFoundError:  # pragma: win32 no cover
+    except FileNotFoundError:
         pass
     except BaseException as error:  # ruff:ignore[blind-except]  # returned for grouping with close failures
-        unlink_error = error  # pragma: win32 no cover
+        unlink_error = error
     return close_error, unlink_error
 
 
@@ -529,14 +529,14 @@ def _link_private_record(
     try:
         _link_relative(directory_ref, *names)
     except FileNotFoundError as error:
-        if _relative_identity(directory_ref, names[0]) is not None:  # pragma: win32 no cover
+        if _relative_identity(directory_ref, names[0]) is not None:
             raise
-        msg = "private publication record was reclaimed"  # pragma: win32 no cover
-        raise _PrivateRecordReclaimedError(msg) from error  # pragma: win32 no cover
+        msg = "private publication record was reclaimed"
+        raise _PrivateRecordReclaimedError(msg) from error
     if _relative_identity(directory_ref, names[1]) == private_identity:
         return
-    msg_0 = "private publication record was replaced"  # pragma: win32 no cover
-    raise _PrivateRecordReclaimedError(msg_0)  # pragma: win32 no cover
+    msg_0 = "private publication record was replaced"
+    raise _PrivateRecordReclaimedError(msg_0)
 
 
 def _raise_record_finalization_errors(
@@ -714,12 +714,12 @@ def _unlink_owner_path_result(path: str) -> tuple[bool, BaseException | None]:
     except FileNotFoundError:
         return True, None
     except BaseException as error:  # ruff:ignore[blind-except]  # keep ownership when unlink did not commit
-        return False, error  # pragma: win32 no cover
+        return False, error
     return True, cleanup_error
 
 
-def _raise_recorded_errors(message: str, errors: list[BaseException]) -> None:  # pragma: win32 no cover
-    if len(errors) > 1:  # pragma: win32 no cover
+def _raise_recorded_errors(message: str, errors: list[BaseException]) -> None:
+    if len(errors) > 1:
         _raise_cleanup_errors(message, errors[0], *errors[1:])
     raise errors[0]
 
@@ -795,7 +795,7 @@ def _open_record(path: Path, limit: int) -> tuple[int, bytes]:
 
 def _read_opened_record(fd: int, path: Path, path_stat: os.stat_result, limit: int) -> bytes:
     opened_stat = os.fstat(fd)
-    if not stat.S_ISREG(opened_stat.st_mode):  # pragma: win32 no cover
+    if not stat.S_ISREG(opened_stat.st_mode):
         msg = f"{path} is not a regular file"
         raise OSError(msg)
     if _file_identity(opened_stat) != _file_identity(path_stat):

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -141,7 +141,7 @@ class StrictSoftFileLock(BaseFileLock):
                 self._discard_doorway(sentinel_fd, sentinel_identity)
                 return
             raise
-        if publication_cleanup_error is not None:
+        if publication_cleanup_error is not None:  # pragma: win32 no cover
             raise publication_cleanup_error
         self._context.owner_claim_paths = (intent_path,)
 
@@ -162,7 +162,7 @@ class StrictSoftFileLock(BaseFileLock):
             _raise_if_hard_links_unsupported(self.lock_file, error)
             raise
         self._context.owner_claim_paths = (held_path, intent_path)
-        if link_cleanup_error is not None:
+        if link_cleanup_error is not None:  # pragma: win32 no cover
             self._context.owner_claim_paths = ()
             raise link_cleanup_error
 
@@ -190,7 +190,9 @@ class StrictSoftFileLock(BaseFileLock):
         """Remove one named claim, allowing overlap if its owner still holds the protected resource."""
         _validate_force_break_name(claim_name)
         _require_exact_name(self._claim_directory, claim_name)
-        if (cleanup_error := _unlink_in_directory(self._claim_directory, claim_name)) is not None:
+        if (
+            cleanup_error := _unlink_in_directory(self._claim_directory, claim_name)
+        ) is not None:  # pragma: win32 no cover
             raise cleanup_error
 
     def _rollback_failed_acquire(self, acquisition_error: BaseException) -> None:
@@ -280,7 +282,7 @@ def _open_or_create_sentinel(lock_file: str, path: Path, mode: int) -> int | Non
         if not isinstance(error, OSError) or error.errno != EEXIST:
             raise
     else:
-        if publication_cleanup_error is not None:
+        if publication_cleanup_error is not None:  # pragma: win32 no cover
             raise publication_cleanup_error
     try:
         return _open_sentinel(path)
@@ -446,7 +448,7 @@ def _publish_record(
         try:
             if directory_fd is not None:  # pragma: win32 no cover
                 os.close(directory_fd)
-        except BaseException as close_error:  # ruff:ignore[blind-except]  # preserve publication and directory cleanup errors
+        except BaseException as close_error:  # ruff:ignore[blind-except]  # pragma: win32 no cover  # preserve publication and directory cleanup errors
             _raise_cleanup_errors("strict publication directory cleanup failed", publication_error, close_error)
         raise
     if directory_fd is not None:  # pragma: win32 no cover
@@ -600,7 +602,9 @@ def _reclaim_private_record(directory_ref: tuple[str, int | None], private_name:
 
 def _unlink_private_record_once(directory_ref: tuple[str, int | None], private_name: str) -> None:
     directory, directory_fd = directory_ref
-    if directory_fd is not None and _UNLINK_SUPPORTS_DIR_FD:
+    if (
+        directory_fd is not None and _UNLINK_SUPPORTS_DIR_FD
+    ):  # pragma: no cover  # callers always pass directory_fd=None
         os.unlink(private_name, dir_fd=directory_fd)
     else:
         Path(directory, private_name).unlink()
@@ -661,9 +665,11 @@ def _link_no_follow(
     # attacker can reach. Pass the option only when the runtime honors it: PyPy advertises it through
     # os.supports_follow_symlinks yet its linkat rejects it with EINVAL, so probe once rather than trust the set.
     if _LINK_HONORS_FOLLOW_SYMLINKS:
-        os.link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd, follow_symlinks=False)
+        os.link(
+            source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd, follow_symlinks=False
+        )  # pragma: win32 no cover
     else:
-        os.link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+        os.link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)  # pragma: win32 cover
 
 
 def _unlink_relative(directory_ref: tuple[str, int | None], name: str) -> None:
@@ -673,7 +679,7 @@ def _unlink_relative(directory_ref: tuple[str, int | None], name: str) -> None:
     elif sys.platform == "win32":  # pragma: win32 cover
         _unlink_in_directory(Path(directory), name)
     else:
-        Path(directory, name).unlink()
+        Path(directory, name).unlink()  # pragma: win32 no cover
 
 
 def _link_no_replace(directory: Path, source_name: str, destination_name: str) -> BaseException | None:
@@ -751,7 +757,7 @@ def _unlink_in_directory(directory: Path, name: str) -> BaseException | None:
             raise error
         time.sleep(retry_delay)
         retry_delay *= 2
-    return None  # pragma: win32 no cover  # the final retry returns or raises
+    return None  # pragma: no cover  # the final retry returns or raises
 
 
 def _unlink_error(path: Path) -> OSError | None:  # pragma: win32 cover

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -141,7 +141,7 @@ class StrictSoftFileLock(BaseFileLock):
                 self._discard_doorway(sentinel_fd, sentinel_identity)
                 return
             raise
-        if publication_cleanup_error is not None:  # pragma: win32 no cover
+        if publication_cleanup_error is not None:  # pragma: needs dir-fd
             raise publication_cleanup_error
         self._context.owner_claim_paths = (intent_path,)
 
@@ -162,7 +162,7 @@ class StrictSoftFileLock(BaseFileLock):
             _raise_if_hard_links_unsupported(self.lock_file, error)
             raise
         self._context.owner_claim_paths = (held_path, intent_path)
-        if link_cleanup_error is not None:  # pragma: win32 no cover
+        if link_cleanup_error is not None:  # pragma: needs dir-fd
             self._context.owner_claim_paths = ()
             raise link_cleanup_error
 
@@ -192,7 +192,7 @@ class StrictSoftFileLock(BaseFileLock):
         _require_exact_name(self._claim_directory, claim_name)
         if (
             cleanup_error := _unlink_in_directory(self._claim_directory, claim_name)
-        ) is not None:  # pragma: win32 no cover
+        ) is not None:  # pragma: needs dir-fd
             raise cleanup_error
 
     def _rollback_failed_acquire(self, acquisition_error: BaseException) -> None:
@@ -282,7 +282,7 @@ def _open_or_create_sentinel(lock_file: str, path: Path, mode: int) -> int | Non
         if not isinstance(error, OSError) or error.errno != EEXIST:
             raise
     else:
-        if publication_cleanup_error is not None:  # pragma: win32 no cover
+        if publication_cleanup_error is not None:  # pragma: needs dir-fd
             raise publication_cleanup_error
     try:
         return _open_sentinel(path)
@@ -446,13 +446,13 @@ def _publish_record(
         _publish_record_in_directory(directory_ref, (private_name, public_name), mode, record)
     except BaseException as publication_error:  # preserve publication and directory cleanup errors
         try:
-            if directory_fd is not None:  # pragma: win32 no cover
+            if directory_fd is not None:  # pragma: needs dir-fd
                 os.close(directory_fd)
-        except BaseException as close_error:  # ruff:ignore[blind-except]  # pragma: win32 no cover  # preserve publication and directory cleanup errors
+        except BaseException as close_error:  # ruff:ignore[blind-except]  # pragma: needs dir-fd  # preserve publication and directory cleanup errors
             _raise_cleanup_errors("strict publication directory cleanup failed", publication_error, close_error)
         raise
-    if directory_fd is not None:  # pragma: win32 no cover
-        try:  # pragma: win32 no cover
+    if directory_fd is not None:  # pragma: needs dir-fd
+        try:
             os.close(directory_fd)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # caller records the published path before raising
             return close_error
@@ -466,7 +466,7 @@ def _publish_record_in_directory(
     record: bytes,
 ) -> None:
     flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | _O_BINARY
-    if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:  # pragma: win32 no cover
+    if (o_nofollow := getattr(os, "O_NOFOLLOW", None)) is not None:  # pragma: needs o-nofollow
         flags |= o_nofollow
     private_fd = _open_relative(directory_ref, names[0], flags, mode)
     private_identity: tuple[int, int] | None = None
@@ -613,7 +613,7 @@ def _unlink_private_record_once(directory_ref: tuple[str, int | None], private_n
 def _relative_identity(directory_ref: tuple[str, int | None], name: str) -> tuple[int, int] | None:
     directory, directory_fd = directory_ref
     try:
-        if directory_fd is not None and _STAT_SUPPORTS_DIR_FD:  # pragma: win32 no cover
+        if directory_fd is not None and _STAT_SUPPORTS_DIR_FD:  # pragma: needs dir-fd
             path_stat = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
         else:  # pragma: win32 cover
             path_stat = Path(directory, name).lstat()
@@ -643,7 +643,7 @@ def _open_relative(directory_ref: tuple[str, int | None], name: str, flags: int,
 
 def _link_relative(directory_ref: tuple[str, int | None], source_name: str, destination_name: str) -> None:
     directory, directory_fd = directory_ref
-    if directory_fd is not None and _LINK_SUPPORTS_DIR_FD:  # pragma: win32 no cover
+    if directory_fd is not None and _LINK_SUPPORTS_DIR_FD:  # pragma: needs dir-fd
         _link_no_follow(source_name, destination_name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
         return
     _link_no_follow(Path(directory, source_name), Path(directory, destination_name))  # pragma: win32 cover
@@ -666,13 +666,13 @@ def _link_no_follow(
     # os.supports_follow_symlinks yet its linkat rejects it with EINVAL, so probe once rather than trust the set.
     if _LINK_HONORS_FOLLOW_SYMLINKS:
         os.link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd, follow_symlinks=False)
-    else:  # pragma: no cover  # only where os.link rejects follow_symlinks (PyPy), which runs without coverage
+    else:  # pragma: lacks link-follow-symlinks
         os.link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
 
 
 def _unlink_relative(directory_ref: tuple[str, int | None], name: str) -> None:
     directory, directory_fd = directory_ref
-    if directory_fd is not None and _UNLINK_SUPPORTS_DIR_FD:  # pragma: win32 no cover
+    if directory_fd is not None and _UNLINK_SUPPORTS_DIR_FD:  # pragma: needs dir-fd
         os.unlink(name, dir_fd=directory_fd)
     elif sys.platform == "win32":  # pragma: win32 cover
         _unlink_in_directory(Path(directory), name)
@@ -681,17 +681,17 @@ def _unlink_relative(directory_ref: tuple[str, int | None], name: str) -> None:
 
 
 def _link_no_replace(directory: Path, source_name: str, destination_name: str) -> BaseException | None:
-    if _LINK_SUPPORTS_DIR_FD:  # pragma: win32 no cover
+    if _LINK_SUPPORTS_DIR_FD:  # pragma: needs dir-fd
         directory_fd = _open_directory(str(directory))
-        try:  # pragma: win32 no cover
+        try:
             _link_no_follow(source_name, destination_name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
-        except BaseException as link_error:  # preserve link and directory cleanup errors  # pragma: win32 no cover
-            try:  # pragma: win32 no cover
+        except BaseException as link_error:  # preserve link and directory cleanup errors
+            try:
                 os.close(directory_fd)
             except BaseException as close_error:  # ruff:ignore[blind-except]  # preserve link and directory cleanup errors
                 _raise_cleanup_errors("strict link directory cleanup failed", link_error, close_error)
             raise
-        try:  # pragma: win32 no cover
+        try:
             os.close(directory_fd)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # caller records the held path before raising
             return close_error
@@ -729,17 +729,17 @@ def _raise_recorded_errors(message: str, errors: list[BaseException]) -> None:
 
 
 def _unlink_in_directory(directory: Path, name: str) -> BaseException | None:
-    if _UNLINK_SUPPORTS_DIR_FD:  # pragma: win32 no cover
+    if _UNLINK_SUPPORTS_DIR_FD:  # pragma: needs dir-fd
         directory_fd = _open_directory(str(directory))
-        try:  # pragma: win32 no cover
+        try:
             os.unlink(name, dir_fd=directory_fd)
-        except BaseException as unlink_error:  # preserve unlink and directory cleanup errors  # pragma: win32 no cover
-            try:  # pragma: win32 no cover
+        except BaseException as unlink_error:  # preserve unlink and directory cleanup errors
+            try:
                 os.close(directory_fd)
             except BaseException as close_error:  # ruff:ignore[blind-except]  # preserve unlink and directory cleanup errors
                 _raise_cleanup_errors("strict unlink directory cleanup failed", unlink_error, close_error)
             raise
-        try:  # pragma: win32 no cover
+        try:
             os.close(directory_fd)
         except BaseException as close_error:  # ruff:ignore[blind-except]  # caller commits the removed path before raising
             return close_error
@@ -759,14 +759,14 @@ def _unlink_in_directory(directory: Path, name: str) -> BaseException | None:
 
 
 def _unlink_error(path: Path) -> OSError | None:  # pragma: win32 cover
-    try:  # pragma: win32 cover
+    try:
         path.unlink()
-    except OSError as error:  # pragma: win32 cover
+    except OSError as error:
         return error
     return None
 
 
-def _open_directory(directory: str) -> int:  # pragma: win32 no cover
+def _open_directory(directory: str) -> int:  # pragma: needs dir-fd
     return os.open(
         directory,
         os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -115,7 +115,7 @@ def touch(name: str, *, fd: int | None = None) -> None:
     # path after our O_NOFOLLOW read cannot redirect the touch: utime then targets the inode behind the fd.
     # Where the platform cannot utime an fd, fall back to a path-based touch that still refuses to follow a
     # symlink where supported, matching the O_NOFOLLOW reads used elsewhere here.
-    if fd is not None and _SUPPORTS_UTIME_FD:  # pragma: win32 no cover
+    if fd is not None and _SUPPORTS_UTIME_FD:  # pragma: needs utime-fd
         os.utime(fd, None)
         return
     os.utime(name, None, follow_symlinks=not _SUPPORTS_UTIME_NOFOLLOW)

--- a/src/filelock/_util.py
+++ b/src/filelock/_util.py
@@ -115,7 +115,7 @@ def touch(name: str, *, fd: int | None = None) -> None:
     # path after our O_NOFOLLOW read cannot redirect the touch: utime then targets the inode behind the fd.
     # Where the platform cannot utime an fd, fall back to a path-based touch that still refuses to follow a
     # symlink where supported, matching the O_NOFOLLOW reads used elsewhere here.
-    if fd is not None and _SUPPORTS_UTIME_FD:
+    if fd is not None and _SUPPORTS_UTIME_FD:  # pragma: win32 no cover
         os.utime(fd, None)
         return
     os.utime(name, None, follow_symlinks=not _SUPPORTS_UTIME_NOFOLLOW)

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -158,11 +158,13 @@ if sys.platform == "win32":  # pragma: win32 cover
         err = ctypes.get_last_error()
         if err == _ERROR_LOCK_VIOLATION:
             return False
-        raise ctypes.WinError(err)
+        # A non-contention LockFileEx failure is not reproducible in-process.
+        raise ctypes.WinError(err)  # pragma: no cover
 
     def _unlock_fd(fd: int) -> None:
         overlapped = _OVERLAPPED()  # the same offset 0 and one-byte length the lock used
-        if not _kernel32.UnlockFileEx(msvcrt.get_osfhandle(fd), 0, 1, 0, ctypes.byref(overlapped)):
+        # Unlocking the exact range we hold does not fail.
+        if not _kernel32.UnlockFileEx(msvcrt.get_osfhandle(fd), 0, 1, 0, ctypes.byref(overlapped)):  # pragma: no cover
             raise ctypes.WinError(ctypes.get_last_error())
 
     class WindowsFileLock(BaseFileLock):
@@ -187,7 +189,7 @@ if sys.platform == "win32":  # pragma: win32 cover
                 locked = _lock_fd_nonblocking(fd)
                 if locked:
                     self._mark_descriptor_owned(fd)
-            except BaseException:
+            except BaseException:  # pragma: no cover  # cleanup only if the lock attempt itself raises
                 os.close(fd)
                 raise
             if not locked:
@@ -246,7 +248,8 @@ if sys.platform == "win32":  # pragma: win32 cover
             raise OSError(None, ctypes.FormatError(winerror).strip(), path, winerror)
 
         info = _BY_HANDLE_FILE_INFORMATION()
-        if not _kernel32.GetFileInformationByHandle(handle, ctypes.byref(info)):
+        # Querying an open handle we just created does not fail.
+        if not _kernel32.GetFileInformationByHandle(handle, ctypes.byref(info)):  # pragma: no cover
             err = ctypes.get_last_error()
             _kernel32.CloseHandle(handle)
             raise ctypes.WinError(err)
@@ -258,7 +261,7 @@ if sys.platform == "win32":  # pragma: win32 cover
         try:
             # O_NOINHERIT mirrors os.open on Windows: the lock fd must not leak into child processes.
             return msvcrt.open_osfhandle(handle, os.O_RDWR | os.O_NOINHERIT)
-        except BaseException:  # open_osfhandle audits too; a hook raising anything must not leak the handle
+        except BaseException:  # pragma: no cover  # open_osfhandle audits too; a hook raising must not leak the handle
             _kernel32.CloseHandle(handle)
             raise
 

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -486,7 +486,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             try:
                 await _drain_future(release_future)
             except BaseException as release_error:  # ruff:ignore[blind-except]  # cancellation and backend failure must both surface
-                self._commit_release_if_released()  # pragma: win32 no cover
+                self._commit_release_if_released()
                 self._raise_cancelled_errors(_ASYNC_RELEASE_CANCELLATION_ERRORS, cancellation, release_error)
             self._commit_release()
             raise
@@ -547,8 +547,8 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         try:
             self._register_context_descriptor()
         except BaseException as error:  # ruff:ignore[blind-except]  # preserve registration and acquisition failures
-            registration_error = error  # pragma: win32 no cover
-            try:  # pragma: win32 no cover
+            registration_error = error
+            try:
                 # Rollback may fail too; retain the fd so a child can close it without another identity probe.
                 self._register_unverified_context_descriptor()
             except BaseException as error:  # ruff:ignore[blind-except]  # pragma: no cover - allocation/control-flow during fallback
@@ -558,26 +558,26 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         except BaseException as rollback_error:  # ruff:ignore[blind-except]  # preserve rollback and acquisition failures
             if registration_error is None and tracking_error is None:
                 self._raise_acquire_rollback_errors(acquisition_error, rollback_error)
-            _raise_cleanup_errors(  # pragma: win32 no cover
+            _raise_cleanup_errors(
                 "lock acquisition cleanup failed",
                 acquisition_error,
                 registration_error,
                 tracking_error,
                 rollback_error,
             )
-        if registration_error is not None:  # pragma: win32 no cover
+        if registration_error is not None:
             _raise_cleanup_errors(
                 "lock acquisition cleanup failed", acquisition_error, registration_error, tracking_error
             )
 
     async def _rollback_failed_registration_async(self, registration_error: BaseException) -> None:
         tracking_error: BaseException | None = None
-        try:  # pragma: win32 no cover
+        try:
             # Rollback may fail too; retain the fd so a child can close it without another identity probe.
             self._register_unverified_context_descriptor()
         except BaseException as error:  # ruff:ignore[blind-except]  # pragma: no cover - allocation/control-flow during fallback
             tracking_error = error
-        try:  # pragma: win32 no cover
+        try:
             await _drain_future(self._start_tracked_release())
         except BaseException as rollback_error:  # ruff:ignore[blind-except]  # preserve rollback and registration failures
             _raise_cleanup_errors(
@@ -660,7 +660,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             if self._context_error_policy == "chain":
                 _append_exception_context(release_error, body_error)
                 raise
-            if (  # pragma: win32 no cover
+            if (
                 errors := _grouped_errors(
                     release_error,
                     _ASYNC_RELEASE_CANCELLATION_ERRORS,
@@ -668,7 +668,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 )
             ) is not None:
                 match errors:
-                    case (asyncio.CancelledError() as cancellation, backend_error):  # pragma: win32 no cover
+                    case (asyncio.CancelledError() as cancellation, backend_error):
                         _raise_grouped_errors(_ASYNC_CONTEXT_RELEASE_ERRORS, body_error, cancellation, backend_error)
             _raise_body_and_release(body_error, release_error)
 

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -398,10 +398,10 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 try:
                     await _drain_future(self._start_tracked_release())
                 except BaseException as error:  # ruff:ignore[blind-except]  # reported with the cancellation below
-                    rollback_error = error  # pragma: win32 no cover
+                    rollback_error = error
 
             if acquire_error is not None:
-                if rollback_error is not None:  # pragma: win32 no cover
+                if rollback_error is not None:  # pragma: needs fcntl
                     self._raise_cancelled_errors(
                         "lock acquisition cancellation, backend attempt, and rollback failed",
                         cancellation,
@@ -411,7 +411,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 self._raise_cancelled_errors(
                     "lock acquisition cancellation and backend attempt both failed", cancellation, acquire_error
                 )
-            if rollback_error is not None:  # pragma: win32 no cover
+            if rollback_error is not None:
                 self._raise_cancelled_errors(
                     "lock acquisition cancellation and rollback both failed", cancellation, rollback_error
                 )
@@ -534,7 +534,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             try:
                 self._register_context_descriptor()
             except BaseException as registration_error:  # cancellation must roll back the descriptor
-                await self._rollback_failed_registration_async(registration_error)  # pragma: win32 no cover
+                await self._rollback_failed_registration_async(registration_error)
                 raise
         if self.is_locked:
             await self._invoke_on_acquired_async()
@@ -677,7 +677,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
     def __del__(self) -> None:
         """Release on deletion; safe to call during GC even when no event loop is running."""
         if vars(self).get("_creator_pid") != os.getpid():
-            return  # pragma: no cover - exercised in fork children
+            return  # pragma: forked child
         with contextlib.suppress(Exception):
             try:
                 loop = asyncio.get_running_loop()

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -668,8 +668,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 )
             ) is not None:
                 match errors:
-                    # The marker is only ever set on a (CancelledError, backend_error) pair, so this always matches;
-                    # the fallthrough to _raise_body_and_release below is unreachable for a marked group.
+                    # The marker is only ever set on a (CancelledError, backend_error) pair, so this always matches.
                     case (asyncio.CancelledError() as cancellation, backend_error):  # pragma: no branch
                         _raise_grouped_errors(_ASYNC_CONTEXT_RELEASE_ERRORS, body_error, cancellation, backend_error)
             _raise_body_and_release(body_error, release_error)

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -668,7 +668,9 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 )
             ) is not None:
                 match errors:
-                    case (asyncio.CancelledError() as cancellation, backend_error):
+                    # The marker is only ever set on a (CancelledError, backend_error) pair, so this always matches;
+                    # the fallthrough to _raise_body_and_release below is unreachable for a marked group.
+                    case (asyncio.CancelledError() as cancellation, backend_error):  # pragma: no branch
                         _raise_grouped_errors(_ASYNC_CONTEXT_RELEASE_ERRORS, body_error, cancellation, backend_error)
             _raise_body_and_release(body_error, release_error)
 

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -398,10 +398,10 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 try:
                     await _drain_future(self._start_tracked_release())
                 except BaseException as error:  # ruff:ignore[blind-except]  # reported with the cancellation below
-                    rollback_error = error
+                    rollback_error = error  # pragma: win32 no cover
 
             if acquire_error is not None:
-                if rollback_error is not None:
+                if rollback_error is not None:  # pragma: win32 no cover
                     self._raise_cancelled_errors(
                         "lock acquisition cancellation, backend attempt, and rollback failed",
                         cancellation,
@@ -411,7 +411,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 self._raise_cancelled_errors(
                     "lock acquisition cancellation and backend attempt both failed", cancellation, acquire_error
                 )
-            if rollback_error is not None:
+            if rollback_error is not None:  # pragma: win32 no cover
                 self._raise_cancelled_errors(
                     "lock acquisition cancellation and rollback both failed", cancellation, rollback_error
                 )
@@ -486,7 +486,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             try:
                 await _drain_future(release_future)
             except BaseException as release_error:  # ruff:ignore[blind-except]  # cancellation and backend failure must both surface
-                self._commit_release_if_released()
+                self._commit_release_if_released()  # pragma: win32 no cover
                 self._raise_cancelled_errors(_ASYNC_RELEASE_CANCELLATION_ERRORS, cancellation, release_error)
             self._commit_release()
             raise
@@ -534,7 +534,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             try:
                 self._register_context_descriptor()
             except BaseException as registration_error:  # cancellation must roll back the descriptor
-                await self._rollback_failed_registration_async(registration_error)
+                await self._rollback_failed_registration_async(registration_error)  # pragma: win32 no cover
                 raise
         if self.is_locked:
             await self._invoke_on_acquired_async()
@@ -547,8 +547,8 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         try:
             self._register_context_descriptor()
         except BaseException as error:  # ruff:ignore[blind-except]  # preserve registration and acquisition failures
-            registration_error = error
-            try:
+            registration_error = error  # pragma: win32 no cover
+            try:  # pragma: win32 no cover
                 # Rollback may fail too; retain the fd so a child can close it without another identity probe.
                 self._register_unverified_context_descriptor()
             except BaseException as error:  # ruff:ignore[blind-except]  # pragma: no cover - allocation/control-flow during fallback
@@ -558,26 +558,26 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         except BaseException as rollback_error:  # ruff:ignore[blind-except]  # preserve rollback and acquisition failures
             if registration_error is None and tracking_error is None:
                 self._raise_acquire_rollback_errors(acquisition_error, rollback_error)
-            _raise_cleanup_errors(
+            _raise_cleanup_errors(  # pragma: win32 no cover
                 "lock acquisition cleanup failed",
                 acquisition_error,
                 registration_error,
                 tracking_error,
                 rollback_error,
             )
-        if registration_error is not None:
+        if registration_error is not None:  # pragma: win32 no cover
             _raise_cleanup_errors(
                 "lock acquisition cleanup failed", acquisition_error, registration_error, tracking_error
             )
 
     async def _rollback_failed_registration_async(self, registration_error: BaseException) -> None:
         tracking_error: BaseException | None = None
-        try:
+        try:  # pragma: win32 no cover
             # Rollback may fail too; retain the fd so a child can close it without another identity probe.
             self._register_unverified_context_descriptor()
         except BaseException as error:  # ruff:ignore[blind-except]  # pragma: no cover - allocation/control-flow during fallback
             tracking_error = error
-        try:
+        try:  # pragma: win32 no cover
             await _drain_future(self._start_tracked_release())
         except BaseException as rollback_error:  # ruff:ignore[blind-except]  # preserve rollback and registration failures
             _raise_cleanup_errors(
@@ -660,7 +660,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
             if self._context_error_policy == "chain":
                 _append_exception_context(release_error, body_error)
                 raise
-            if (
+            if (  # pragma: win32 no cover
                 errors := _grouped_errors(
                     release_error,
                     _ASYNC_RELEASE_CANCELLATION_ERRORS,
@@ -668,7 +668,7 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
                 )
             ) is not None:
                 match errors:
-                    case (asyncio.CancelledError() as cancellation, backend_error):
+                    case (asyncio.CancelledError() as cancellation, backend_error):  # pragma: win32 no cover
                         _raise_grouped_errors(_ASYNC_CONTEXT_RELEASE_ERRORS, body_error, cancellation, backend_error)
             _raise_body_and_release(body_error, release_error)
 

--- a/tasks/coverage_pragmas.py
+++ b/tasks/coverage_pragmas.py
@@ -138,7 +138,12 @@ CAPABILITIES: Final[dict[str, bool]] = {
 
 #: Modules a missing capability makes unrunnable in full; marking every line would restate one module-level gate.
 _CAPABILITY_MODULES: Final[dict[str, tuple[str, ...]]] = {
-    "hard-link": ("*/tests/test_strict_soft*.py", "*/tests\\test_strict_soft*.py"),
+    "hard-link": (
+        "*/tests/test_strict_soft*.py",
+        "*/tests\\test_strict_soft*.py",
+        "*/filelock/_strict.py",
+        "*\\filelock\\_strict.py",
+    ),
 }
 
 #: A forked child exits through os._exit without writing coverage data, so no job in the matrix can see these.

--- a/tasks/coverage_pragmas.py
+++ b/tasks/coverage_pragmas.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from coverage.types import TConfigurable
 
 
-# coverage's plugin entry point; it passes the config's plugin options, which this plugin does not take.
+# coverage passes the config's plugin options; this plugin takes none.
 def coverage_init(reg: Plugins, options: dict[str, str]) -> None:  # ruff:ignore[unused-function-argument]
     reg.add_configurer(CapabilityPragmas())
 
@@ -40,14 +40,11 @@ class CapabilityPragmas(CoveragePlugin):
     """Exclude ``needs``/``lacks`` capability pragmas on the runtimes where that code cannot run."""
 
     def configure(self, config: TConfigurable) -> None:
-        # `needs` guards code a capability makes possible; `lacks` guards the fallback a runtime without it takes, such
-        # as reacquiring a lock whose name Windows would not let the holder unlink. Each is dead where the other runs.
         excluded = [
             rf"# pragma: {'lacks' if present else 'needs'} {name}\b" for name, present in sorted(CAPABILITIES.items())
         ]
         self._extend(config, "report:exclude_lines", [*excluded, *_ALWAYS_EXCLUDED])
-        # A guarded clause header only ever takes one arc, so record every capability pragma as a partial branch the
-        # way covdefaults does for its platform pragmas, whether or not this runtime excludes it.
+        # A guarded clause header only ever takes one arc, as covdefaults already assumes for its own pragmas.
         self._extend(config, "report:partial_branches", [_CAPABILITY_PRAGMA, *_ALWAYS_EXCLUDED])
         unrunnable = [
             pattern
@@ -60,15 +57,14 @@ class CapabilityPragmas(CoveragePlugin):
 
     @staticmethod
     def _extend(config: TConfigurable, option: str, patterns: list[str]) -> None:
-        # get_option is typed for every option coverage has; the two this plugin extends always hold a list of regexes.
+        # get_option is typed for every coverage option; these two always hold regexes.
         merged: set[str] = set(cast("Iterable[str]", config.get_option(option) or ()))
         merged.update(patterns)
         config.set_option(option, sorted(merged))
 
 
 def _supports_symlink() -> bool:
-    # Windows does support symlinks, but only with Developer Mode or SeCreateSymbolicLinkPrivilege, so ask the
-    # filesystem instead of the platform name. CI runs a Windows job with the privilege and one without.
+    # Windows grants this per privilege, not per platform, so ask the filesystem.
     with tempfile.TemporaryDirectory() as directory:
         target = Path(directory, "target")
         target.touch()
@@ -80,8 +76,7 @@ def _supports_symlink() -> bool:
 
 
 def _supports_unlinking_an_open_file() -> bool:
-    # POSIX unlinks a name out from under an open descriptor; Windows refuses while any handle is held, which is why a
-    # peer there can never take a live holder's marker.
+    # Where this is refused, a peer can never take a live holder's marker.
     with tempfile.TemporaryDirectory() as directory:
         victim = Path(directory, "victim")
         victim.touch()
@@ -94,8 +89,7 @@ def _supports_unlinking_an_open_file() -> bool:
 
 
 def _honors_link_follow_symlinks() -> bool:
-    # PyPy advertises follow_symlinks for os.link then rejects it with EINVAL, so link a real file rather than trust
-    # os.supports_follow_symlinks; filelock._strict probes the same way.
+    # PyPy advertises the option then rejects it with EINVAL, so trust a real link over os.supports_follow_symlinks.
     if not hasattr(os, "link"):
         return False
     with tempfile.TemporaryDirectory() as directory:
@@ -109,7 +103,7 @@ def _honors_link_follow_symlinks() -> bool:
 
 
 def _enforces_file_mode() -> bool:
-    # Windows does not carry POSIX permission bits, so a chmod there does not read back.
+    # Without POSIX permission bits a chmod does not read back.
     with tempfile.TemporaryDirectory() as directory:
         probe = Path(directory, "probe")
         probe.touch()
@@ -119,50 +113,35 @@ def _enforces_file_mode() -> bool:
 
 _OWNER_READ_WRITE: Final[int] = 0o600
 
-#: Capability -> whether this runtime provides it. The name states why the code it guards cannot run here, which a
-#: bare platform pragma never said. Tests gate their skipif on this same mapping.
+#: Capability -> whether this runtime provides it. Tests gate their skipif on this same mapping.
 CAPABILITIES: Final[dict[str, bool]] = {
-    # Windows has neither os.fork nor os.register_at_fork, so fork coordination never runs there.
     "fork": hasattr(os, "fork") and hasattr(os, "register_at_fork"),
-    # Directory-descriptor syscalls (openat and friends) exist only where os.supports_dir_fd lists os.open.
     "dir-fd": os.open in os.supports_dir_fd,
-    # Termux/Android ships a CPython whose os module has no link(), so hard-linked claims cannot be published.
     "hard-link": hasattr(os, "link"),
     "symlink": _supports_symlink(),
-    # fcntl backs the flock path; absent on Windows and on builds that drop the module.
     "fcntl": find_spec("fcntl") is not None,
     "unlink-open-file": _supports_unlinking_an_open_file(),
-    # SIGKILL and friends; a test that kills a worker outright cannot run without them.
     "posix-signals": hasattr(signal, "SIGKILL"),
     "file-mode": _enforces_file_mode(),
-    # Counting a process's own open descriptors needs /dev/fd or /proc/self/fd; Windows exposes neither.
     "fd-directory": any(Path(view).is_dir() for view in ("/dev/fd", "/proc/self/fd")),
-    # Staging a lock file as a node that is not a regular file.
     "fifo": hasattr(os, "mkfifo"),
     "af-unix": hasattr(socket, "AF_UNIX"),
-    # Refusing to open through a symlink. Distinct from "symlink": a Windows runtime with the privilege can create
-    # symlinks yet still cannot refuse to follow one.
+    # Distinct from "symlink": a runtime can create them yet still not refuse to follow one.
     "o-nofollow": hasattr(os, "O_NOFOLLOW"),
-    # Stamping a symlink's own mtime rather than its target's.
     "utime-nofollow": os.utime in os.supports_follow_symlinks,
-    # Refreshing a marker through the verified descriptor instead of re-resolving its path.
     "utime-fd": os.utime in os.supports_fd,
-    # The read-write lock is backed by sqlite3, which a stripped build can omit; CI runs a job without it.
     "sqlite3": find_spec("sqlite3") is not None,
     "link-follow-symlinks": _honors_link_follow_symlinks(),
-    # A released filelock to drive against this one. The tox env that installs it points this variable at the copy,
-    # so the compat suite is dead weight in every env that does not.
+    # Only the tox env that installs a released filelock sets this.
     "old-client": bool(os.environ.get("FILELOCK_OLD_CLIENT_PATH")),
 }
 
-#: Modules a missing capability makes unrunnable in full. Marking every line in them would restate one module-level
-#: gate hundreds of times, so drop the file from the report instead.
+#: Modules a missing capability makes unrunnable in full; marking every line would restate one module-level gate.
 _CAPABILITY_MODULES: Final[dict[str, tuple[str, ...]]] = {
     "hard-link": ("*/tests/test_strict_soft*.py", "*/tests\\test_strict_soft*.py"),
 }
 
-#: A forked child exits through os._exit without writing its coverage data, so lines that run only in the child stay
-#: invisible to every job in the matrix.
+#: A forked child exits through os._exit without writing coverage data, so no job in the matrix can see these.
 _ALWAYS_EXCLUDED: Final[tuple[str, ...]] = (r"# pragma: forked child\b",)
 
 _CAPABILITY_PRAGMA: Final[str] = rf"# pragma: (needs|lacks) ({'|'.join(sorted(CAPABILITIES))})\b"

--- a/tasks/coverage_pragmas.py
+++ b/tasks/coverage_pragmas.py
@@ -1,0 +1,156 @@
+"""Coverage exclusions keyed on the capability that code needs.
+
+covdefaults keys its pragmas on ``os.name``, ``sys.platform`` and ``sys.implementation.name``, so code that cannot run
+for a capability reason has to name a platform as a stand-in. The stand-in goes stale. A ``win32 no cover`` sat on
+``os.link``'s follow_symlinks fallback and demanded a branch modern Windows never takes, and the same guess hid real
+Windows gaps behind platform-agnostic code.
+
+``# pragma: needs <capability>`` drops out only where the capability is absent, and ``# pragma: lacks <capability>``
+only where it is present. Both read the probes below, as do the tests' skipif gates, so a test cannot skip while
+coverage still demands its lines.
+
+List this after covdefaults in ``[tool.coverage] run.plugins``; both merge into the same options.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import tempfile
+from importlib.util import find_spec
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, cast
+
+from coverage import CoveragePlugin
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from coverage.plugin_support import Plugins
+    from coverage.types import TConfigurable
+
+
+# coverage's plugin entry point; it passes the config's plugin options, which this plugin does not take.
+def coverage_init(reg: Plugins, options: dict[str, str]) -> None:  # ruff:ignore[unused-function-argument]
+    reg.add_configurer(CapabilityPragmas())
+
+
+class CapabilityPragmas(CoveragePlugin):
+    """Exclude ``needs``/``lacks`` capability pragmas on the runtimes where that code cannot run."""
+
+    def configure(self, config: TConfigurable) -> None:
+        # `needs` guards code a capability makes possible; `lacks` guards the fallback a runtime without it takes, such
+        # as reacquiring a lock whose name Windows would not let the holder unlink. Each is dead where the other runs.
+        excluded = [
+            rf"# pragma: {'lacks' if present else 'needs'} {name}\b" for name, present in sorted(CAPABILITIES.items())
+        ]
+        self._extend(config, "report:exclude_lines", [*excluded, *_ALWAYS_EXCLUDED])
+        # A guarded clause header only ever takes one arc, so record every capability pragma as a partial branch the
+        # way covdefaults does for its platform pragmas, whether or not this runtime excludes it.
+        self._extend(config, "report:partial_branches", [_CAPABILITY_PRAGMA, *_ALWAYS_EXCLUDED])
+
+    @staticmethod
+    def _extend(config: TConfigurable, option: str, patterns: list[str]) -> None:
+        # get_option is typed for every option coverage has; the two this plugin extends always hold a list of regexes.
+        merged: set[str] = set(cast("Iterable[str]", config.get_option(option) or ()))
+        merged.update(patterns)
+        config.set_option(option, sorted(merged))
+
+
+def _supports_symlink() -> bool:
+    # Windows does support symlinks, but only with Developer Mode or SeCreateSymbolicLinkPrivilege, so ask the
+    # filesystem instead of the platform name. CI runs a Windows job with the privilege and one without.
+    with tempfile.TemporaryDirectory() as directory:
+        target = Path(directory, "target")
+        target.touch()
+        try:
+            Path(directory, "link").symlink_to(target)
+        except (OSError, NotImplementedError, AttributeError):
+            return False
+        return True
+
+
+def _supports_unlinking_an_open_file() -> bool:
+    # POSIX unlinks a name out from under an open descriptor; Windows refuses while any handle is held, which is why a
+    # peer there can never take a live holder's marker.
+    with tempfile.TemporaryDirectory() as directory:
+        victim = Path(directory, "victim")
+        victim.touch()
+        with victim.open("rb"):
+            try:
+                victim.unlink()
+            except OSError:
+                return False
+        return True
+
+
+def _honors_link_follow_symlinks() -> bool:
+    # PyPy advertises follow_symlinks for os.link then rejects it with EINVAL, so link a real file rather than trust
+    # os.supports_follow_symlinks; filelock._strict probes the same way.
+    if not hasattr(os, "link"):
+        return False
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory, "source")
+        source.touch()
+        try:
+            os.link(source, Path(directory, "link"), follow_symlinks=False)
+        except (OSError, NotImplementedError, ValueError):
+            return False
+        return True
+
+
+def _enforces_file_mode() -> bool:
+    # Windows does not carry POSIX permission bits, so a chmod there does not read back.
+    with tempfile.TemporaryDirectory() as directory:
+        probe = Path(directory, "probe")
+        probe.touch()
+        probe.chmod(_OWNER_READ_WRITE)
+        return probe.stat().st_mode & 0o777 == _OWNER_READ_WRITE
+
+
+_OWNER_READ_WRITE: Final[int] = 0o600
+
+#: Capability -> whether this runtime provides it. The name states why the code it guards cannot run here, which a
+#: bare platform pragma never said. Tests gate their skipif on this same mapping.
+CAPABILITIES: Final[dict[str, bool]] = {
+    # Windows has neither os.fork nor os.register_at_fork, so fork coordination never runs there.
+    "fork": hasattr(os, "fork") and hasattr(os, "register_at_fork"),
+    # Directory-descriptor syscalls (openat and friends) exist only where os.supports_dir_fd lists os.open.
+    "dir-fd": os.open in os.supports_dir_fd,
+    # Termux/Android ships a CPython whose os module has no link(), so hard-linked claims cannot be published.
+    "hard-link": hasattr(os, "link"),
+    "symlink": _supports_symlink(),
+    # fcntl backs the flock path; absent on Windows and on builds that drop the module.
+    "fcntl": find_spec("fcntl") is not None,
+    "unlink-open-file": _supports_unlinking_an_open_file(),
+    # SIGKILL and friends; a test that kills a worker outright cannot run without them.
+    "posix-signals": hasattr(signal, "SIGKILL"),
+    "file-mode": _enforces_file_mode(),
+    # Counting a process's own open descriptors needs /dev/fd or /proc/self/fd; Windows exposes neither.
+    "fd-directory": any(Path(view).is_dir() for view in ("/dev/fd", "/proc/self/fd")),
+    # Staging a lock file as a node that is not a regular file.
+    "fifo": hasattr(os, "mkfifo"),
+    "af-unix": hasattr(socket, "AF_UNIX"),
+    # Refusing to open through a symlink. Distinct from "symlink": a Windows runtime with the privilege can create
+    # symlinks yet still cannot refuse to follow one.
+    "o-nofollow": hasattr(os, "O_NOFOLLOW"),
+    # Stamping a symlink's own mtime rather than its target's.
+    "utime-nofollow": os.utime in os.supports_follow_symlinks,
+    # Refreshing a marker through the verified descriptor instead of re-resolving its path.
+    "utime-fd": os.utime in os.supports_fd,
+    # The read-write lock is backed by sqlite3, which a stripped build can omit; CI runs a job without it.
+    "sqlite3": find_spec("sqlite3") is not None,
+    "link-follow-symlinks": _honors_link_follow_symlinks(),
+}
+
+#: A forked child exits through os._exit without writing its coverage data, so lines that run only in the child stay
+#: invisible to every job in the matrix.
+_ALWAYS_EXCLUDED: Final[tuple[str, ...]] = (r"# pragma: forked child\b",)
+
+_CAPABILITY_PRAGMA: Final[str] = rf"# pragma: (needs|lacks) ({'|'.join(sorted(CAPABILITIES))})\b"
+
+__all__ = [
+    "CAPABILITIES",
+    "coverage_init",
+]

--- a/tasks/coverage_pragmas.py
+++ b/tasks/coverage_pragmas.py
@@ -49,6 +49,14 @@ class CapabilityPragmas(CoveragePlugin):
         # A guarded clause header only ever takes one arc, so record every capability pragma as a partial branch the
         # way covdefaults does for its platform pragmas, whether or not this runtime excludes it.
         self._extend(config, "report:partial_branches", [_CAPABILITY_PRAGMA, *_ALWAYS_EXCLUDED])
+        unrunnable = [
+            pattern
+            for name, patterns in sorted(_CAPABILITY_MODULES.items())
+            if not CAPABILITIES[name]
+            for pattern in patterns
+        ]
+        if unrunnable:
+            self._extend(config, "report:omit", unrunnable)
 
     @staticmethod
     def _extend(config: TConfigurable, option: str, patterns: list[str]) -> None:
@@ -142,6 +150,15 @@ CAPABILITIES: Final[dict[str, bool]] = {
     # The read-write lock is backed by sqlite3, which a stripped build can omit; CI runs a job without it.
     "sqlite3": find_spec("sqlite3") is not None,
     "link-follow-symlinks": _honors_link_follow_symlinks(),
+    # A released filelock to drive against this one. The tox env that installs it points this variable at the copy,
+    # so the compat suite is dead weight in every env that does not.
+    "old-client": bool(os.environ.get("FILELOCK_OLD_CLIENT_PATH")),
+}
+
+#: Modules a missing capability makes unrunnable in full. Marking every line in them would restate one module-level
+#: gate hundreds of times, so drop the file from the report instead.
+_CAPABILITY_MODULES: Final[dict[str, tuple[str, ...]]] = {
+    "hard-link": ("*/tests/test_strict_soft*.py", "*/tests\\test_strict_soft*.py"),
 }
 
 #: A forked child exits through os._exit without writing its coverage data, so lines that run only in the child stay

--- a/tasks/deny_symlink.py
+++ b/tasks/deny_symlink.py
@@ -58,7 +58,7 @@ def main() -> int:
     print(f"symlink after (this process): {_can_symlink()}")
 
     child = subprocess.run(
-        [sys.executable, "-c", f"import pathlib,tempfile;{_CAN_SYMLINK_SOURCE}print(can())"],
+        [sys.executable, "-c", _CHILD_PROBE],
         capture_output=True,
         text=True,
         check=False,
@@ -100,6 +100,23 @@ def _remove_privilege() -> str:
     assert sys.platform == "win32"
     advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    # Declare the signatures: GetCurrentProcess returns the pseudo-handle (HANDLE)-1, and ctypes' default c_int restype
+    # truncates it on 64-bit, so OpenProcessToken is handed a bad handle and fails with ERROR_INVALID_HANDLE.
+    kernel32.GetCurrentProcess.argtypes = ()
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    advapi32.OpenProcessToken.argtypes = (wintypes.HANDLE, wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE))
+    advapi32.OpenProcessToken.restype = wintypes.BOOL
+    advapi32.LookupPrivilegeValueW.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, ctypes.POINTER(_Luid))
+    advapi32.LookupPrivilegeValueW.restype = wintypes.BOOL
+    advapi32.AdjustTokenPrivileges.argtypes = (
+        wintypes.HANDLE,
+        wintypes.BOOL,
+        ctypes.POINTER(_TokenPrivileges),
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    )
+    advapi32.AdjustTokenPrivileges.restype = wintypes.BOOL
 
     token = wintypes.HANDLE()
     if not advapi32.OpenProcessToken(
@@ -120,16 +137,19 @@ def _remove_privilege() -> str:
     return "removed" if code == 0 else f"unexpected code {code}"
 
 
-_CAN_SYMLINK_SOURCE: Final[str] = (
-    "def can():\n"
-    "    with tempfile.TemporaryDirectory() as d:\n"
-    "        t = pathlib.Path(d, 'target'); t.touch()\n"
-    "        try:\n"
-    "            pathlib.Path(d, 'link').symlink_to(t)\n"
-    "        except OSError as e:\n"
-    "            return f'False ({e.winerror})'\n"
-    "        return 'True'\n"
-)
+_CHILD_PROBE: Final[str] = """
+import pathlib, tempfile
+
+with tempfile.TemporaryDirectory() as directory:
+    target = pathlib.Path(directory, "target")
+    target.touch()
+    try:
+        pathlib.Path(directory, "link").symlink_to(target)
+    except OSError as error:
+        print(f"False (WinError {error.winerror})")
+    else:
+        print("True")
+"""
 
 
 def _can_symlink() -> str:

--- a/tasks/deny_symlink.py
+++ b/tasks/deny_symlink.py
@@ -1,0 +1,149 @@
+"""Run a command on Windows with symbolic-link creation denied, and report why it is or is not denied.
+
+Windows grants symlink creation through two independent paths, so closing one proves nothing. A process holding
+SeCreateSymbolicLinkPrivilege may always create them; separately, Developer Mode lets an unprivileged process create
+them through SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE. The CI job clears the Developer Mode registry value, and
+this script removes the privilege from its own token.
+
+AdjustTokenPrivileges cannot add a privilege back, and SE_PRIVILEGE_REMOVED is documented as irreversible with
+"privilege checks for removed privileges result in STATUS_PRIVILEGE_NOT_HELD", which is the guarantee this relies on.
+What the documentation does not state is whether a child process inherits the removal, or whether clearing Developer
+Mode takes effect without a reboot. Both decide whether the denied job is real, so this reports the state it observes
+rather than assuming: the token privileges it found, whether a symlink still succeeds after the removal, and the same
+check again from a child. Read those lines in the job log before trusting the job.
+
+Usage: python deny_symlink.py <command> [args...]
+"""
+
+from __future__ import annotations
+
+import ctypes
+import subprocess  # ruff:ignore[suspicious-subprocess-import]  # launching the suite is this script's whole job
+import sys
+import tempfile
+from ctypes import wintypes
+from pathlib import Path
+from typing import Final
+
+_TOKEN_ADJUST_PRIVILEGES: Final[int] = 0x0020
+_TOKEN_QUERY: Final[int] = 0x0008
+_SE_PRIVILEGE_REMOVED: Final[int] = 0x0004
+_ERROR_NOT_ALL_ASSIGNED: Final[int] = 1300
+_PRIVILEGE: Final[str] = "SeCreateSymbolicLinkPrivilege"
+
+
+class _Luid(ctypes.Structure):
+    _fields_ = (("low_part", wintypes.DWORD), ("high_part", wintypes.LONG))
+
+
+class _LuidAndAttributes(ctypes.Structure):
+    _fields_ = (("luid", _Luid), ("attributes", wintypes.DWORD))
+
+
+class _TokenPrivileges(ctypes.Structure):
+    _fields_ = (("privilege_count", wintypes.DWORD), ("privileges", _LuidAndAttributes * 1))
+
+
+def main() -> int:
+    if sys.platform != "win32":
+        print("deny_symlink only applies to Windows")
+        return 1
+
+    print(f"developer mode: {_developer_mode()}")
+    print(f"{_PRIVILEGE} before: {_privilege_state()}")
+    print(f"symlink before: {_can_symlink()}")
+
+    print(f"removal reported: {_remove_privilege()}")
+    print(f"{_PRIVILEGE} after: {_privilege_state()}")
+    print(f"symlink after (this process): {_can_symlink()}")
+
+    child = subprocess.run(
+        [sys.executable, "-c", f"import pathlib,tempfile;{_CAN_SYMLINK_SOURCE}print(can())"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    print(f"symlink after (child process): {child.stdout.strip() or child.stderr.strip()}")
+
+    return subprocess.run(sys.argv[1:], check=False).returncode
+
+
+def _developer_mode() -> str:
+    # main() refuses to run anywhere else; state it so ty can see the Windows-only members from any host.
+    assert sys.platform == "win32"
+    import winreg  # ruff:ignore[import-outside-top-level]  Windows-only, and this module already refuses to run elsewhere
+
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"
+        ) as key:
+            return str(winreg.QueryValueEx(key, "AllowDevelopmentWithoutDevLicense")[0])
+    except OSError as error:
+        return f"unreadable ({error})"
+
+
+def _privilege_state() -> str:
+    result = subprocess.run(
+        ["whoami", "/priv"],  # ruff:ignore[start-process-with-partial-path]  resolved from PATH on every Windows image
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    for line in result.stdout.splitlines():
+        if _PRIVILEGE in line:
+            return line.strip()
+    return "absent from the token"
+
+
+def _remove_privilege() -> str:
+    # main() refuses to run anywhere else; state it so ty can see the Windows-only members from any host.
+    assert sys.platform == "win32"
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    token = wintypes.HANDLE()
+    if not advapi32.OpenProcessToken(
+        kernel32.GetCurrentProcess(), _TOKEN_ADJUST_PRIVILEGES | _TOKEN_QUERY, ctypes.byref(token)
+    ):
+        return f"OpenProcessToken failed with {ctypes.get_last_error()}"
+
+    luid = _Luid()
+    if not advapi32.LookupPrivilegeValueW(None, _PRIVILEGE, ctypes.byref(luid)):
+        return f"LookupPrivilegeValue failed with {ctypes.get_last_error()}"
+
+    privileges = _TokenPrivileges(1, (_LuidAndAttributes * 1)(_LuidAndAttributes(luid, _SE_PRIVILEGE_REMOVED)))
+    if not advapi32.AdjustTokenPrivileges(token, False, ctypes.byref(privileges), 0, None, None):  # ruff:ignore[boolean-positional-value-in-call]
+        return f"AdjustTokenPrivileges failed with {ctypes.get_last_error()}"
+    # The call reports success even when the token never held the privilege, so read the code it leaves behind.
+    if (code := ctypes.get_last_error()) == _ERROR_NOT_ALL_ASSIGNED:
+        return "the token did not hold the privilege"
+    return "removed" if code == 0 else f"unexpected code {code}"
+
+
+_CAN_SYMLINK_SOURCE: Final[str] = (
+    "def can():\n"
+    "    with tempfile.TemporaryDirectory() as d:\n"
+    "        t = pathlib.Path(d, 'target'); t.touch()\n"
+    "        try:\n"
+    "            pathlib.Path(d, 'link').symlink_to(t)\n"
+    "        except OSError as e:\n"
+    "            return f'False ({e.winerror})'\n"
+    "        return 'True'\n"
+)
+
+
+def _can_symlink() -> str:
+    # main() refuses to run anywhere else; state it so ty can see the Windows-only members from any host.
+    assert sys.platform == "win32"
+    with tempfile.TemporaryDirectory() as directory:
+        target = Path(directory, "target")
+        target.touch()
+        try:
+            Path(directory, "link").symlink_to(target)
+        except OSError as error:
+            return f"False (WinError {error.winerror})"
+        return "True"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/deny_symlink.py
+++ b/tasks/deny_symlink.py
@@ -5,12 +5,10 @@ SeCreateSymbolicLinkPrivilege may always create them; separately, Developer Mode
 them through SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE. The CI job clears the Developer Mode registry value, and
 this script removes the privilege from its own token.
 
-AdjustTokenPrivileges cannot add a privilege back, and SE_PRIVILEGE_REMOVED is documented as irreversible with
-"privilege checks for removed privileges result in STATUS_PRIVILEGE_NOT_HELD", which is the guarantee this relies on.
-What the documentation does not state is whether a child process inherits the removal, or whether clearing Developer
-Mode takes effect without a reboot. Both decide whether the denied job is real, so this reports the state it observes
-rather than assuming: the token privileges it found, whether a symlink still succeeds after the removal, and the same
-check again from a child. Read those lines in the job log before trusting the job.
+SE_PRIVILEGE_REMOVED is documented as irreversible, with checks for a removed privilege returning
+STATUS_PRIVILEGE_NOT_HELD, which is the guarantee this relies on. The documentation does not say whether a child
+inherits the removal or whether clearing Developer Mode needs a reboot, so this reports what it observes rather
+than assuming. Read those lines in the job log before trusting the job.
 
 Usage: python deny_symlink.py <command> [args...]
 """
@@ -69,7 +67,7 @@ def main() -> int:
 
 
 def _developer_mode() -> str:
-    # main() refuses to run anywhere else; state it so ty can see the Windows-only members from any host.
+    # ty needs the platform narrowed to see the Windows-only members from any host.
     assert sys.platform == "win32"
     import winreg  # ruff:ignore[import-outside-top-level]  Windows-only, and this module already refuses to run elsewhere
 
@@ -96,7 +94,7 @@ def _privilege_state() -> str:
 
 
 def _remove_privilege() -> str:
-    # main() refuses to run anywhere else; state it so ty can see the Windows-only members from any host.
+    # ty needs the platform narrowed to see the Windows-only members from any host.
     assert sys.platform == "win32"
     advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -153,7 +151,7 @@ with tempfile.TemporaryDirectory() as directory:
 
 
 def _can_symlink() -> str:
-    # main() refuses to run anywhere else; state it so ty can see the Windows-only members from any host.
+    # ty needs the platform narrowed to see the Windows-only members from any host.
     assert sys.platform == "win32"
     with tempfile.TemporaryDirectory() as directory:
         target = Path(directory, "target")

--- a/tests/async_filelock_cancellation_helpers.py
+++ b/tests/async_filelock_cancellation_helpers.py
@@ -25,7 +25,7 @@ def assert_cancellation_message(error: asyncio.CancelledError, message: str) -> 
     assert error.args == ((message,) if sys.version_info >= (3, 11) else ())
 
 
-def get_fcntl() -> FcntlModule:
+def get_fcntl() -> FcntlModule:  # pragma: win32 no cover
     return cast("FcntlModule", importlib.import_module("fcntl"))
 
 
@@ -56,8 +56,8 @@ def _probe_file_lock(lock_file: str, acquired: Synchronized[bool]) -> None:
     try:
         with FileLock(lock_file, timeout=0):
             acquired.value = True
-    except Timeout:
-        pass
+    except Timeout:  # pragma: win32 no cover
+        pass  # pragma: win32 no cover
 
 
 def _hold_file_lock(lock_file: str, holder_started: threading.Event, finish_holder: threading.Event) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,8 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-# Coverage restarts itself inside every subprocess it patches, and that child re-imports the coverage_pragmas plugin
-# named in run.plugins. pytest's own pythonpath setting only reaches this process, so export the directory holding the
-# plugin; otherwise a child dies importing it and the tests that assert on its stderr fail.
+# Coverage restarts in every patched subprocess and re-imports the plugin there; pytest's pythonpath reaches only
+# this process, so export it.
 os.environ["PYTHONPATH"] = os.pathsep.join(
     part for part in (str(Path(__file__).parent.parent / "tasks"), os.environ.get("PYTHONPATH")) if part
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,8 @@ def close_failure(
         # under test. An unrelated close inside a GC finalizer would escape as an unraisable exception.
         if fd == locked_fd:
             raise release_error
-        real_close(fd)
+        real_close(fd)  # pragma: no cover  # only an unrelated close (e.g. a GC finalizer) reaches here
 
     yield capture, release_error, release_cause
-    if locked_fd is not None:
+    if locked_fd is not None:  # pragma: no branch  # every consumer calls capture, so this is always set
         real_close(locked_fd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,6 +10,13 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
     from pytest_mock import MockerFixture
+
+# Coverage restarts itself inside every subprocess it patches, and that child re-imports the coverage_pragmas plugin
+# named in run.plugins. pytest's own pythonpath setting only reaches this process, so export the directory holding the
+# plugin; otherwise a child dies importing it and the tests that assert on its stderr fail.
+os.environ["PYTHONPATH"] = os.pathsep.join(
+    part for part in (str(Path(__file__).parent.parent / "tasks"), os.environ.get("PYTHONPATH")) if part
+)
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,11 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     # StrictSoftFileLock publishes claims with hard links, so tests marked requires_hard_links cannot run where
     # os.link is missing (Termux/Android CPython ships without it). The no-hard-link degradation itself is covered by
     # the os.link tests in test_filelock.py, which carry no marker and run everywhere.
-    if hasattr(os, "link"):
-        return
-    skip = pytest.mark.skip(reason="StrictSoftFileLock requires os.link (hard links), absent on Termux/Android")
-    for item in items:
-        if item.get_closest_marker("requires_hard_links") is not None:
-            item.add_marker(skip)
+    if not hasattr(os, "link"):  # pragma: no cover  # the body runs only on Termux/Android, absent from the CI matrix
+        skip = pytest.mark.skip(reason="StrictSoftFileLock requires os.link (hard links), absent on Termux/Android")
+        for item in items:
+            if item.get_closest_marker("requires_hard_links") is not None:
+                item.add_marker(skip)
 
 
 @pytest.fixture

--- a/tests/fork_helpers.py
+++ b/tests/fork_helpers.py
@@ -27,12 +27,12 @@ _REGISTER_AT_FORK: Final[_RegisterAtFork | None] = cast(
 )
 
 
-def fork_process(child: Callable[[], NoReturn] | None = None) -> int:
+def fork_process(child: Callable[[], NoReturn] | None = None) -> int:  # pragma: win32 no cover
     if _FORK is None:  # pragma: no cover - platform without os.fork
         msg = "os.fork is unavailable"
         raise RuntimeError(msg)
     child_pid = _FORK()
-    if child_pid == 0 and child is not None:
+    if child_pid == 0 and child is not None:  # pragma: win32 no cover
         child()  # pragma: no cover - child coverage starts after fork returns to this frame
     return child_pid
 
@@ -46,13 +46,13 @@ def exit_child(status: int) -> NoReturn:
         os._exit(status)
 
 
-def _restart_coverage_after_fork() -> None:
-    if (coverage := Coverage.current()) is not None:
+def _restart_coverage_after_fork() -> None:  # pragma: win32 no cover
+    if (coverage := Coverage.current()) is not None:  # pragma: win32 no cover
         coverage.stop()
     process_startup(force=True, slug="fork")  # pragma: no cover - coverage is stopped until this call returns
 
 
-if _REGISTER_AT_FORK is not None:
+if _REGISTER_AT_FORK is not None:  # pragma: win32 no cover
     _REGISTER_AT_FORK(after_in_child=_restart_coverage_after_fork)
 
 

--- a/tests/soft_rw/test_soft_rw_async.py
+++ b/tests/soft_rw/test_soft_rw_async.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
@@ -14,14 +15,15 @@ if TYPE_CHECKING:
     from concurrent.futures import Executor
     from pathlib import Path
 
+    from pytest_mock import MockerFixture
+
 
 @pytest.fixture(autouse=True)
 def _clear_singletons() -> Generator[None]:
     SoftReadWriteLock._instances.clear()
     yield
-    for ref in list(SoftReadWriteLock._instances.valuerefs()):
-        if (lock := ref()) is not None:
-            lock.close()
+    for lock in filter(None, (ref() for ref in list(SoftReadWriteLock._instances.valuerefs()))):
+        lock.close()
     SoftReadWriteLock._instances.clear()
 
 
@@ -119,6 +121,33 @@ async def test_async_release_force(tmp_path: Path) -> None:
         await lock.release(force=True)
     finally:
         await lock.close()
+
+
+@pytest.mark.asyncio
+async def test_async_release_and_close_skip_when_pid_differs(tmp_path: Path, mocker: MockerFixture) -> None:
+    # After a fork the running pid no longer matches the creator's, so release and close must leave the parent's
+    # still-held lock untouched. With the guard tripped, a later real release proves the write lock was never dropped.
+    lock = _make(tmp_path)
+    await lock.acquire_write(timeout=2)
+    try:
+        mocker.patch("filelock._soft_rw._async.os.getpid", return_value=os.getpid() + 1)
+        await lock.release(force=True)
+        await lock.close()
+        mocker.stopall()
+        await lock.release()
+    finally:
+        mocker.stopall()
+        await lock.close()
+
+
+@pytest.mark.asyncio
+async def test_async_leaked_singleton_is_closed_on_teardown(tmp_path: Path) -> None:
+    # A singleton left acquired stays reachable through its live heartbeat thread, so the autouse fixture's teardown
+    # finds the inner lock and closes it. The write marker proves the lock was really taken and must be cleaned up.
+    path = tmp_path / "singleton.lock"
+    lock = AsyncSoftReadWriteLock(str(path), heartbeat_interval=0.5, stale_threshold=1.5, poll_interval=0.02)
+    await lock.acquire_write(timeout=2)
+    assert path.with_name("singleton.lock.write").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/soft_rw/test_soft_rw_async.py
+++ b/tests/soft_rw/test_soft_rw_async.py
@@ -125,8 +125,7 @@ async def test_async_release_force(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_async_release_and_close_skip_when_pid_differs(tmp_path: Path, mocker: MockerFixture) -> None:
-    # After a fork the running pid no longer matches the creator's, so release and close must leave the parent's
-    # still-held lock untouched. With the guard tripped, a later real release proves the write lock was never dropped.
+    # A pid that no longer matches the creator's must leave the parent's still-held lock untouched.
     lock = _make(tmp_path)
     await lock.acquire_write(timeout=2)
     try:
@@ -142,8 +141,7 @@ async def test_async_release_and_close_skip_when_pid_differs(tmp_path: Path, moc
 
 @pytest.mark.asyncio
 async def test_async_leaked_singleton_is_closed_on_teardown(tmp_path: Path) -> None:
-    # A singleton left acquired stays reachable through its live heartbeat thread, so the autouse fixture's teardown
-    # finds the inner lock and closes it. The write marker proves the lock was really taken and must be cleaned up.
+    # A live heartbeat thread keeps the singleton reachable, so the autouse teardown finds and closes it.
     path = tmp_path / "singleton.lock"
     lock = AsyncSoftReadWriteLock(str(path), heartbeat_interval=0.5, stale_threshold=1.5, poll_interval=0.02)
     await lock.acquire_write(timeout=2)

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -1034,7 +1034,12 @@ def _cleanup(processes: list[Process]) -> Generator[None]:
         for proc in processes:
             if proc.is_alive():
                 proc.terminate()
-                proc.join(timeout=2)
+                proc.join(timeout=5)
+            # SIGTERM can be slow to land on a loaded runner, and a worker that outlives its test wedges the next one,
+            # so escalate rather than leave it running.
+            if proc.is_alive():  # pragma: no cover  # the terminate lands first whenever the runner is not saturated
+                proc.kill()
+                proc.join(timeout=5)
 
 
 def _sigkill_worker(  # pragma: forked child  # the test SIGKILLs it, so this child never writes its coverage data
@@ -1166,9 +1171,6 @@ def test_cleanup_terminates_a_still_running_process() -> None:
     proc.start()
     with _cleanup([proc]):
         assert proc.is_alive()
-    # _cleanup sends SIGTERM and joins briefly; on a loaded free-threaded runner the reap can land just after that
-    # window, so join again generously before asserting the worker is gone rather than racing its teardown.
-    proc.join(timeout=10)
     assert not proc.is_alive()
 
 

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -1127,3 +1127,34 @@ def test_write_marker_zero_write_rolls_back(lock_file: str, mocker: MockerFixtur
     with pytest.raises(OSError, match="0 bytes"):
         lock.acquire_write(timeout=1)
     assert not Path(f"{lock_file}.write").exists()
+
+
+def test_touch_writer_marker_returns_false_when_marker_missing(lock_file: str) -> None:
+    lock = SoftReadWriteLock(lock_file, is_singleton=False)
+    assert lock._touch_writer_marker_if_ours("0" * 32) is False
+
+
+def test_claim_writer_marker_returns_false_on_create_race(lock_file: str, mocker: MockerFixture) -> None:
+    lock = SoftReadWriteLock(lock_file, is_singleton=False)
+    mocker.patch.object(sync_mod, "_atomic_create_marker", side_effect=FileExistsError)
+    with lock._locks.state:
+        assert lock._claim_writer_marker("0" * 32) is False
+
+
+def test_atomic_create_marker_rolls_back_on_write_failure(tmp_path: Path, mocker: MockerFixture) -> None:
+    marker = str(tmp_path / "marker")
+    mocker.patch.object(sync_mod, "write_all", side_effect=OSError("write boom"))
+    with pytest.raises(OSError, match="write boom"):
+        sync_mod._atomic_create_marker(marker, "0" * 32)
+    assert not Path(marker).exists()
+
+
+def test_same_file_true_for_matching_identity(tmp_path: Path) -> None:
+    target = tmp_path / "present"
+    target.write_bytes(b"x")
+    st = os.lstat(target)
+    assert sync_mod._same_file(str(target), (st.st_dev, st.st_ino), dir_fd=None) is True
+
+
+def test_same_file_false_when_stat_fails(tmp_path: Path) -> None:
+    assert sync_mod._same_file(str(tmp_path / "absent"), (1, 2), dir_fd=None) is False

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import multiprocessing as mp
 import os
+import signal
 import stat
 import sys
 import threading
@@ -13,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
+from coverage_pragmas import CAPABILITIES
 
 from filelock import Timeout
 from filelock import _util as util_mod
@@ -26,11 +28,13 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+_OWNER_READ_WRITE: Final[int] = 0o600
+
 _REQUIRES_POSIX_SIGNALS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    sys.platform == "win32", reason="POSIX signals required"
+    not hasattr(signal, "SIGKILL"), reason="POSIX signals required"
 )
-_REQUIRES_POSIX_PERMISSIONS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    sys.platform == "win32", reason="POSIX file-mode bits not meaningful on Windows"
+_REQUIRES_FILE_MODE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["file-mode"], reason="POSIX file-mode bits required"
 )
 _REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
 
@@ -490,12 +494,10 @@ def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
 
 @_REQUIRES_POSIX_SIGNALS
 @pytest.mark.timeout(20)
-def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: win32 no cover
-    import signal
-
+def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs posix-signals
     held = Event()
     holder = Process(target=_sigkill_worker, args=(lock_file, "write", held, 0.1, 0.5))
-    with _cleanup([holder]):  # pragma: win32 no cover
+    with _cleanup([holder]):
         holder.start()
         assert held.wait(timeout=5)
         pid = holder.pid
@@ -504,8 +506,8 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: win32
         holder.join(timeout=5)
         time.sleep(0.8)
         lock = _make_lock(lock_file)
-        try:  # pragma: win32 no cover
-            with lock.read_lock(timeout=5):  # pragma: win32 no cover
+        try:
+            with lock.read_lock(timeout=5):
                 pass
         finally:
             lock.close()
@@ -514,12 +516,10 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: win32
 
 @_REQUIRES_POSIX_SIGNALS
 @pytest.mark.timeout(20)
-def test_dead_reader_evicted_by_writer(lock_file: str) -> None:  # pragma: win32 no cover
-    import signal
-
+def test_dead_reader_evicted_by_writer(lock_file: str) -> None:  # pragma: needs posix-signals
     held = Event()
     holder = Process(target=_sigkill_worker, args=(lock_file, "read", held, 0.1, 0.5))
-    with _cleanup([holder]):  # pragma: win32 no cover
+    with _cleanup([holder]):
         holder.start()
         assert held.wait(timeout=5)
         pid = holder.pid
@@ -528,8 +528,8 @@ def test_dead_reader_evicted_by_writer(lock_file: str) -> None:  # pragma: win32
         holder.join(timeout=5)
         time.sleep(0.8)
         lock = _make_lock(lock_file)
-        try:  # pragma: win32 no cover
-            with lock.write_lock(timeout=5):  # pragma: win32 no cover
+        try:
+            with lock.write_lock(timeout=5):
                 pass
         finally:
             lock.close()
@@ -731,52 +731,52 @@ def test_stale_malformed_marker_is_evicted(lock_file: str, content: bytes) -> No
         lock.close()
 
 
-def test_fifo_write_marker_does_not_block(lock_file: str) -> None:
+def test_fifo_write_marker_does_not_block(lock_file: str) -> None:  # pragma: needs fifo
     if sys.platform == "win32":  # pragma: win32 cover
         pytest.skip("os.mkfifo is unix-only")  # also narrows sys.platform so ty resolves os.mkfifo below
-    marker = f"{lock_file}.write"  # pragma: win32 no cover
-    os.mkfifo(marker)  # pragma: win32 no cover
-    past = time.time() - 1000  # pragma: win32 no cover
-    os.utime(marker, (past, past))  # pragma: win32 no cover
+    marker = f"{lock_file}.write"
+    os.mkfifo(marker)
+    past = time.time() - 1000
+    os.utime(marker, (past, past))
     # Without O_NONBLOCK this open blocks forever; the lock instead reads the FIFO as a stale marker and evicts it.
-    lock = _make_lock(lock_file)  # pragma: win32 no cover
-    try:  # pragma: win32 no cover
-        with lock.write_lock(timeout=2):  # pragma: win32 no cover
+    lock = _make_lock(lock_file)
+    try:
+        with lock.write_lock(timeout=2):
             pass
     finally:
-        lock.close()  # pragma: win32 no cover
+        lock.close()
 
 
-def test_fifo_write_marker_with_writer_is_evicted(lock_file: str) -> None:
+def test_fifo_write_marker_with_writer_is_evicted(lock_file: str) -> None:  # pragma: needs fifo
     if sys.platform == "win32":  # pragma: win32 cover
         pytest.skip("os.mkfifo is unix-only")  # also narrows sys.platform so ty resolves os.mkfifo below
-    marker = f"{lock_file}.write"  # pragma: win32 no cover
-    os.mkfifo(marker)  # pragma: win32 no cover
-    past = time.time() - 1000  # pragma: win32 no cover
-    os.utime(marker, (past, past))  # pragma: win32 no cover
+    marker = f"{lock_file}.write"
+    os.mkfifo(marker)
+    past = time.time() - 1000
+    os.utime(marker, (past, past))
     # A writer attached to the FIFO makes the non-blocking read raise EAGAIN on all platforms, matching a
     # writerless FIFO on FreeBSD (#587). The lock must evict the stale marker by mtime without reading it, so
     # the acquire completes instead of timing out.
-    reader_fd = os.open(marker, os.O_RDONLY | os.O_NONBLOCK)  # pragma: win32 no cover
-    writer_fd = os.open(marker, os.O_WRONLY)  # pragma: win32 no cover
-    lock = _make_lock(lock_file)  # pragma: win32 no cover
-    try:  # pragma: win32 no cover
-        with lock.write_lock(timeout=2):  # pragma: win32 no cover
+    reader_fd = os.open(marker, os.O_RDONLY | os.O_NONBLOCK)
+    writer_fd = os.open(marker, os.O_WRONLY)
+    lock = _make_lock(lock_file)
+    try:
+        with lock.write_lock(timeout=2):
             pass
     finally:
-        lock.close()  # pragma: win32 no cover
-        os.close(writer_fd)  # pragma: win32 no cover
-        os.close(reader_fd)  # pragma: win32 no cover
+        lock.close()
+        os.close(writer_fd)
+        os.close(reader_fd)
 
 
 @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW required")
-def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:  # pragma: needs o-nofollow
     victim = tmp_path / "victim"
     victim.write_text("do-not-touch")
     Path(f"{lock_file}.write").symlink_to(victim)
     lock = _make_lock(lock_file)
-    try:  # pragma: win32 no cover
-        with pytest.raises((OSError, Timeout)):  # pragma: win32 no cover
+    try:
+        with pytest.raises((OSError, Timeout)):
             lock.acquire_write(timeout=0.5)
     finally:
         lock.close()
@@ -786,7 +786,7 @@ def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> No
 @pytest.mark.skipif(
     os.utime not in os.supports_follow_symlinks, reason="os.utime cannot refuse symlinks on this platform"
 )
-def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:  # pragma: needs utime-nofollow
     # The phase-2 writer-drain touch refreshes the .write marker by path (no held fd); if a peer swaps a
     # symlink in, the touch must land on the link itself, not the file it points at.
     victim = tmp_path / "victim"
@@ -803,7 +803,7 @@ def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None: 
 
 
 @pytest.mark.skipif(not util_mod._SUPPORTS_UTIME_FD, reason="os.utime cannot target an fd on this platform")
-def test_refresh_touches_verified_fd_not_swapped_path(  # pragma: win32 no cover
+def test_refresh_touches_verified_fd_not_swapped_path(  # pragma: needs utime-fd
     lock_file: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # A peer can swap our marker for a symlink in the window after the heartbeat's O_NOFOLLOW open but before
@@ -815,13 +815,13 @@ def test_refresh_touches_verified_fd_not_swapped_path(  # pragma: win32 no cover
 
     lock = _make_lock(lock_file, heartbeat_interval=30, stale_threshold=90)
     lock.acquire_write(timeout=2)
-    try:  # pragma: win32 no cover
+    try:
         marker = Path(f"{lock_file}.write")
         real_open = sync_mod._open_marker
 
-        def swap_after_open(name: str, *, dir_fd: int | None = None) -> int | None:  # pragma: win32 no cover
+        def swap_after_open(name: str, *, dir_fd: int | None = None) -> int | None:
             fd = real_open(name, dir_fd=dir_fd)
-            if fd is not None and Path(name) == marker:  # pragma: win32 no cover
+            if fd is not None and Path(name) == marker:  # pragma: no branch  # the refresh only opens the marker
                 marker.unlink()
                 marker.symlink_to(victim)
             return fd
@@ -835,7 +835,8 @@ def test_refresh_touches_verified_fd_not_swapped_path(  # pragma: win32 no cover
         lock.close()
 
 
-def test_symlinked_readers_directory_is_refused(lock_file: str, tmp_path: Path) -> None:
+@pytest.mark.skipif(not CAPABILITIES["symlink"], reason="staging the readers directory as a symlink")
+def test_symlinked_readers_directory_is_refused(lock_file: str, tmp_path: Path) -> None:  # pragma: needs symlink
     victim_dir = tmp_path / "victim_dir"
     victim_dir.mkdir()
     Path(f"{lock_file}.readers").symlink_to(victim_dir)
@@ -858,21 +859,21 @@ def test_readers_path_as_regular_file_is_refused(lock_file: str) -> None:
         lock.close()
 
 
-@_REQUIRES_POSIX_PERMISSIONS
-def test_write_marker_is_created_with_0600(lock_file: str) -> None:  # pragma: win32 no cover
+@_REQUIRES_FILE_MODE
+def test_write_marker_is_created_with_0600(lock_file: str) -> None:  # pragma: needs file-mode
     lock = _make_lock(lock_file)
-    try:  # pragma: win32 no cover
-        with lock.write_lock(timeout=2):  # pragma: win32 no cover
+    try:
+        with lock.write_lock(timeout=2):
             assert stat.S_IMODE(Path(f"{lock_file}.write").lstat().st_mode) == 0o600
     finally:
         lock.close()
 
 
-@_REQUIRES_POSIX_PERMISSIONS
-def test_readers_directory_is_created_with_0700(lock_file: str) -> None:  # pragma: win32 no cover
+@_REQUIRES_FILE_MODE
+def test_readers_directory_is_created_with_0700(lock_file: str) -> None:  # pragma: needs file-mode
     lock = _make_lock(lock_file)
-    try:  # pragma: win32 no cover
-        with lock.read_lock(timeout=2):  # pragma: win32 no cover
+    try:
+        with lock.read_lock(timeout=2):
             assert stat.S_IMODE(Path(f"{lock_file}.readers").lstat().st_mode) == 0o700
     finally:
         lock.close()
@@ -893,11 +894,11 @@ def test_writer_ignores_housekeeping_files_in_readers_dir(lock_file: str) -> Non
         lock.close()
 
 
-@_REQUIRES_POSIX_PERMISSIONS
-def test_reader_file_is_created_with_0600(lock_file: str) -> None:  # pragma: win32 no cover
+@_REQUIRES_FILE_MODE
+def test_reader_file_is_created_with_0600(lock_file: str) -> None:  # pragma: needs file-mode
     lock = _make_lock(lock_file)
-    try:  # pragma: win32 no cover
-        with lock.read_lock(timeout=2):  # pragma: win32 no cover
+    try:
+        with lock.read_lock(timeout=2):
             entries = list(Path(f"{lock_file}.readers").iterdir())
             assert len(entries) == 1
             assert stat.S_IMODE(entries[0].lstat().st_mode) == 0o600
@@ -907,7 +908,7 @@ def test_reader_file_is_created_with_0600(lock_file: str) -> None:  # pragma: wi
 
 @_REQUIRES_FORK
 @pytest.mark.timeout(15)
-def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(target=_reuse_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
@@ -919,7 +920,7 @@ def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pr
 
 @_REQUIRES_FORK
 @pytest.mark.timeout(15)
-def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(target=_release_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
@@ -931,7 +932,7 @@ def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # p
 
 @_REQUIRES_FORK
 @pytest.mark.timeout(15)
-def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(
@@ -950,11 +951,11 @@ def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None: 
 # process and Python 3.15 warns that it may deadlock. That is the scenario under test, and it is already safe:
 # register_at_fork resets inherited state in the child (any child use raises "invalidated by fork()"). Expected.
 @pytest.mark.filterwarnings("ignore:.*multi-threaded, use of fork.*:DeprecationWarning")
-def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:  # pragma: needs fork
     path = str(tmp_path / "foo.lock")
     lock = SoftReadWriteLock(path, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
     lock.acquire_write(timeout=5)
-    try:  # pragma: win32 no cover
+    try:
         child = _fork_process(target=time.sleep, args=(0.05,))
         child.start()
         child.join(timeout=5)
@@ -966,8 +967,8 @@ def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:  # pragma: win
             poll_interval=0.02,
             is_singleton=False,
         )
-        try:  # pragma: win32 no cover
-            with pytest.raises(Timeout):  # pragma: win32 no cover
+        try:
+            with pytest.raises(Timeout):
                 peer.acquire_write(timeout=0.3)
         finally:
             peer.close()
@@ -1036,7 +1037,7 @@ def _cleanup(processes: list[Process]) -> Generator[None]:
                 proc.join(timeout=2)
 
 
-def _sigkill_worker(  # pragma: no cover  # runs in a child the test SIGKILLs, so its coverage data is never written
+def _sigkill_worker(  # pragma: forked child  # the test SIGKILLs it, so this child never writes its coverage data
     lock_file: str,
     mode: Literal["read", "write"],
     acquired_event: EventType,
@@ -1064,22 +1065,22 @@ def _write_stale_marker(path: str, content: bytes) -> None:
     os.utime(path, (past, past))
 
 
-def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:  # pragma: win32 no cover
+def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:  # pragma: needs fork
     lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
     lock.acquire_write(timeout=5)
     ok = _fork_event()
 
-    def child_entry() -> None:  # pragma: win32 no cover
-        try:  # pragma: win32 no cover
+    def child_entry() -> None:
+        try:
             lock.acquire_read(timeout=1)
-        except RuntimeError as exc:  # pragma: win32 no cover
-            if "invalidated by fork" in str(exc):  # pragma: win32 no cover
+        except RuntimeError as exc:
+            if "invalidated by fork" in str(exc):  # pragma: no branch  # the inherited lock raises nothing else
                 ok.set()
 
     child = _fork_process(target=child_entry)
     child.start()
     child.join(timeout=5)
-    if ok.is_set():  # pragma: win32 no cover
+    if ok.is_set():
         result.set()
     else:  # pragma: no cover  # reached only if the child fails to report the inherited lock, i.e. a regression
         failure.set()
@@ -1087,13 +1088,13 @@ def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType)
     lock.close()
 
 
-def _release_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:  # pragma: win32 no cover
+def _release_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:  # pragma: needs fork
     lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
     lock.acquire_read(timeout=5)
     ok = _fork_event()
 
-    def child_entry() -> None:  # pragma: win32 no cover
-        try:  # pragma: win32 no cover
+    def child_entry() -> None:
+        try:
             lock.release()
         except RuntimeError:  # pragma: no cover  # release on a fork-inherited lock is silent; guards a regression
             return
@@ -1102,7 +1103,7 @@ def _release_inherited_lock(lock_file: str, result: EventType, failure: EventTyp
     child = _fork_process(target=child_entry)
     child.start()
     child.join(timeout=5)
-    if ok.is_set():  # pragma: win32 no cover
+    if ok.is_set():
         result.set()
     else:  # pragma: no cover  # reached only if the child's silent release regresses into raising
         failure.set()
@@ -1110,14 +1111,14 @@ def _release_inherited_lock(lock_file: str, result: EventType, failure: EventTyp
     lock.close()
 
 
-def _reacquire_fresh_lock_in_child(  # pragma: win32 no cover
+def _reacquire_fresh_lock_in_child(  # pragma: needs fork
     lock_file: str, child_path: str, result: EventType, failure: EventType
 ) -> None:
     parent_lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
     parent_lock.acquire_write(timeout=5)
     ok = _fork_event()
 
-    def child_entry() -> None:  # pragma: win32 no cover
+    def child_entry() -> None:
         child_lock = SoftReadWriteLock(
             child_path,
             is_singleton=False,
@@ -1125,8 +1126,8 @@ def _reacquire_fresh_lock_in_child(  # pragma: win32 no cover
             stale_threshold=1.0,
             poll_interval=0.02,
         )
-        try:  # pragma: win32 no cover
-            with child_lock.read_lock(timeout=2):  # pragma: win32 no cover
+        try:
+            with child_lock.read_lock(timeout=2):
                 ok.set()
         finally:
             child_lock.close()
@@ -1134,7 +1135,7 @@ def _reacquire_fresh_lock_in_child(  # pragma: win32 no cover
     child = _fork_process(target=child_entry)
     child.start()
     child.join(timeout=5)
-    if ok.is_set():  # pragma: win32 no cover
+    if ok.is_set():
         result.set()
     else:  # pragma: no cover  # reached only if the child cannot acquire a fresh lock after the fork, i.e. a regression
         failure.set()
@@ -1142,7 +1143,7 @@ def _reacquire_fresh_lock_in_child(  # pragma: win32 no cover
     parent_lock.close()
 
 
-def _fork_process(  # pragma: win32 no cover
+def _fork_process(  # pragma: needs fork
     target: Callable[..., object], args: tuple[object, ...] = ()
 ) -> mp.process.BaseProcess:
     if sys.platform == "win32":  # pragma: win32 cover
@@ -1151,7 +1152,7 @@ def _fork_process(  # pragma: win32 no cover
     return mp.get_context("fork").Process(target=target, args=args)
 
 
-def _fork_event() -> EventType:  # pragma: win32 no cover
+def _fork_event() -> EventType:  # pragma: needs fork
     if sys.platform == "win32":  # pragma: win32 cover
         msg = "fork context is POSIX only"
         raise RuntimeError(msg)

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -135,8 +135,7 @@ def test_get_lock_returns_singleton(lock_file: str) -> None:
 
 
 def test_leaked_acquired_singleton_is_closed_on_teardown(lock_file: str) -> None:
-    # A singleton left acquired stays reachable through its live heartbeat thread, so the autouse fixture's
-    # teardown finds it and closes it. The write marker proves the lock was really taken and must be cleaned up.
+    # A live heartbeat thread keeps the singleton reachable, so the autouse teardown finds and closes it.
     lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.5)
     lock.acquire_write(timeout=2)
     assert Path(f"{lock_file}.write").exists()
@@ -202,8 +201,7 @@ def test_write_lock_is_thread_pinned(lock_file: str) -> None:
 
 
 def test_blocking_acquire_without_timeout_waits_for_release(lock_file: str) -> None:
-    # The default infinite timeout gives the poll loop no deadline, so it sleeps a full poll interval each round
-    # until the writer releases rather than clamping the sleep to a remaining budget.
+    # Without a deadline the poll loop sleeps a full interval each round rather than clamping to a budget.
     holder = _make_lock(lock_file)
     holder.acquire_write(timeout=2)
     acquired = threading.Event()
@@ -1035,14 +1033,13 @@ def _cleanup(processes: list[Process]) -> Generator[None]:
             if proc.is_alive():
                 proc.terminate()
                 proc.join(timeout=5)
-            # SIGTERM can be slow to land on a loaded runner, and a worker that outlives its test wedges the next one,
-            # so escalate rather than leave it running.
+            # A worker that outlives its test wedges the next one, and SIGTERM can be slow on a loaded runner.
             if proc.is_alive():  # pragma: no cover  # the terminate lands first whenever the runner is not saturated
                 proc.kill()
                 proc.join(timeout=5)
 
 
-def _sigkill_worker(  # pragma: forked child  # the test SIGKILLs it, so this child never writes its coverage data
+def _sigkill_worker(  # pragma: forked child
     lock_file: str,
     mode: Literal["read", "write"],
     acquired_event: EventType,
@@ -1165,8 +1162,6 @@ def _fork_event() -> EventType:  # pragma: needs fork
 
 
 def test_cleanup_terminates_a_still_running_process() -> None:
-    # The cleanup helper must stop a worker that outlives its test, so a process still sleeping when the block
-    # exits is terminated and reaped rather than leaked.
     proc = Process(target=time.sleep, args=(30,))
     proc.start()
     with _cleanup([proc]):

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import multiprocessing as mp
 import os
 import signal
+import socket
 import stat
 import sys
 import threading
@@ -1207,3 +1208,17 @@ def test_same_file_true_for_matching_identity(tmp_path: Path) -> None:
 
 def test_same_file_false_when_stat_fails(tmp_path: Path) -> None:
     assert sync_mod._same_file(str(tmp_path / "absent"), (1, 2), dir_fd=None) is False
+
+
+def test_refresh_marker_stops_once_a_peer_owns_the_marker(lock_file: str) -> None:
+    # A peer that evicted our marker and wrote its own owns the file now; refreshing it would keep a stranger's
+    # marker alive, so the heartbeat has to stop instead.
+    lock = _make_lock(lock_file)
+    try:
+        lock.acquire_write(timeout=2)
+        foreign = f"{'0' * 32}\n{os.getpid()}\n{socket.gethostname()}\n".encode("ascii")
+        Path(f"{lock_file}.write").write_bytes(foreign)
+
+        assert lock._refresh_marker() is False
+    finally:
+        lock.close()

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -1165,6 +1165,9 @@ def test_cleanup_terminates_a_still_running_process() -> None:
     proc.start()
     with _cleanup([proc]):
         assert proc.is_alive()
+    # _cleanup sends SIGTERM and joins briefly; on a loaded free-threaded runner the reap can land just after that
+    # window, so join again generously before asserting the worker is gone rather than racing its teardown.
+    proc.join(timeout=10)
     assert not proc.is_alive()
 
 

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -456,12 +456,12 @@ def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
 
 @_REQUIRES_POSIX_SIGNALS
 @pytest.mark.timeout(20)
-def test_dead_writer_evicted_by_reader(lock_file: str) -> None:
+def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: win32 no cover
     import signal
 
     held = Event()
     holder = Process(target=_sigkill_worker, args=(lock_file, "write", held, 0.1, 0.5))
-    with _cleanup([holder]):
+    with _cleanup([holder]):  # pragma: win32 no cover
         holder.start()
         assert held.wait(timeout=5)
         pid = holder.pid
@@ -470,8 +470,8 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:
         holder.join(timeout=5)
         time.sleep(0.8)
         lock = _make_lock(lock_file)
-        try:
-            with lock.read_lock(timeout=5):
+        try:  # pragma: win32 no cover
+            with lock.read_lock(timeout=5):  # pragma: win32 no cover
                 pass
         finally:
             lock.close()
@@ -480,12 +480,12 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:
 
 @_REQUIRES_POSIX_SIGNALS
 @pytest.mark.timeout(20)
-def test_dead_reader_evicted_by_writer(lock_file: str) -> None:
+def test_dead_reader_evicted_by_writer(lock_file: str) -> None:  # pragma: win32 no cover
     import signal
 
     held = Event()
     holder = Process(target=_sigkill_worker, args=(lock_file, "read", held, 0.1, 0.5))
-    with _cleanup([holder]):
+    with _cleanup([holder]):  # pragma: win32 no cover
         holder.start()
         assert held.wait(timeout=5)
         pid = holder.pid
@@ -494,8 +494,8 @@ def test_dead_reader_evicted_by_writer(lock_file: str) -> None:
         holder.join(timeout=5)
         time.sleep(0.8)
         lock = _make_lock(lock_file)
-        try:
-            with lock.write_lock(timeout=5):
+        try:  # pragma: win32 no cover
+            with lock.write_lock(timeout=5):  # pragma: win32 no cover
                 pass
         finally:
             lock.close()
@@ -698,51 +698,51 @@ def test_stale_malformed_marker_is_evicted(lock_file: str, content: bytes) -> No
 
 
 def test_fifo_write_marker_does_not_block(lock_file: str) -> None:
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: win32 cover
         pytest.skip("os.mkfifo is unix-only")  # also narrows sys.platform so ty resolves os.mkfifo below
-    marker = f"{lock_file}.write"
-    os.mkfifo(marker)
-    past = time.time() - 1000
-    os.utime(marker, (past, past))
+    marker = f"{lock_file}.write"  # pragma: win32 no cover
+    os.mkfifo(marker)  # pragma: win32 no cover
+    past = time.time() - 1000  # pragma: win32 no cover
+    os.utime(marker, (past, past))  # pragma: win32 no cover
     # Without O_NONBLOCK this open blocks forever; the lock instead reads the FIFO as a stale marker and evicts it.
-    lock = _make_lock(lock_file)
-    try:
-        with lock.write_lock(timeout=2):
+    lock = _make_lock(lock_file)  # pragma: win32 no cover
+    try:  # pragma: win32 no cover
+        with lock.write_lock(timeout=2):  # pragma: win32 no cover
             pass
     finally:
-        lock.close()
+        lock.close()  # pragma: win32 no cover
 
 
 def test_fifo_write_marker_with_writer_is_evicted(lock_file: str) -> None:
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: win32 cover
         pytest.skip("os.mkfifo is unix-only")  # also narrows sys.platform so ty resolves os.mkfifo below
-    marker = f"{lock_file}.write"
-    os.mkfifo(marker)
-    past = time.time() - 1000
-    os.utime(marker, (past, past))
+    marker = f"{lock_file}.write"  # pragma: win32 no cover
+    os.mkfifo(marker)  # pragma: win32 no cover
+    past = time.time() - 1000  # pragma: win32 no cover
+    os.utime(marker, (past, past))  # pragma: win32 no cover
     # A writer attached to the FIFO makes the non-blocking read raise EAGAIN on all platforms, matching a
     # writerless FIFO on FreeBSD (#587). The lock must evict the stale marker by mtime without reading it, so
     # the acquire completes instead of timing out.
-    reader_fd = os.open(marker, os.O_RDONLY | os.O_NONBLOCK)
-    writer_fd = os.open(marker, os.O_WRONLY)
-    lock = _make_lock(lock_file)
-    try:
-        with lock.write_lock(timeout=2):
+    reader_fd = os.open(marker, os.O_RDONLY | os.O_NONBLOCK)  # pragma: win32 no cover
+    writer_fd = os.open(marker, os.O_WRONLY)  # pragma: win32 no cover
+    lock = _make_lock(lock_file)  # pragma: win32 no cover
+    try:  # pragma: win32 no cover
+        with lock.write_lock(timeout=2):  # pragma: win32 no cover
             pass
     finally:
-        lock.close()
-        os.close(writer_fd)
-        os.close(reader_fd)
+        lock.close()  # pragma: win32 no cover
+        os.close(writer_fd)  # pragma: win32 no cover
+        os.close(reader_fd)  # pragma: win32 no cover
 
 
 @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW required")
-def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:
+def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> None:  # pragma: win32 no cover
     victim = tmp_path / "victim"
     victim.write_text("do-not-touch")
     Path(f"{lock_file}.write").symlink_to(victim)
     lock = _make_lock(lock_file)
-    try:
-        with pytest.raises((OSError, Timeout)):
+    try:  # pragma: win32 no cover
+        with pytest.raises((OSError, Timeout)):  # pragma: win32 no cover
             lock.acquire_write(timeout=0.5)
     finally:
         lock.close()
@@ -752,7 +752,7 @@ def test_symlinked_write_marker_is_refused(lock_file: str, tmp_path: Path) -> No
 @pytest.mark.skipif(
     os.utime not in os.supports_follow_symlinks, reason="os.utime cannot refuse symlinks on this platform"
 )
-def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:
+def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:  # pragma: win32 no cover
     # The phase-2 writer-drain touch refreshes the .write marker by path (no held fd); if a peer swaps a
     # symlink in, the touch must land on the link itself, not the file it points at.
     victim = tmp_path / "victim"
@@ -769,7 +769,7 @@ def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not util_mod._SUPPORTS_UTIME_FD, reason="os.utime cannot target an fd on this platform")
-def test_refresh_touches_verified_fd_not_swapped_path(
+def test_refresh_touches_verified_fd_not_swapped_path(  # pragma: win32 no cover
     lock_file: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # A peer can swap our marker for a symlink in the window after the heartbeat's O_NOFOLLOW open but before
@@ -781,13 +781,13 @@ def test_refresh_touches_verified_fd_not_swapped_path(
 
     lock = _make_lock(lock_file, heartbeat_interval=30, stale_threshold=90)
     lock.acquire_write(timeout=2)
-    try:
+    try:  # pragma: win32 no cover
         marker = Path(f"{lock_file}.write")
         real_open = sync_mod._open_marker
 
-        def swap_after_open(name: str, *, dir_fd: int | None = None) -> int | None:
+        def swap_after_open(name: str, *, dir_fd: int | None = None) -> int | None:  # pragma: win32 no cover
             fd = real_open(name, dir_fd=dir_fd)
-            if fd is not None and Path(name) == marker:
+            if fd is not None and Path(name) == marker:  # pragma: win32 no cover
                 marker.unlink()
                 marker.symlink_to(victim)
             return fd
@@ -825,20 +825,20 @@ def test_readers_path_as_regular_file_is_refused(lock_file: str) -> None:
 
 
 @_REQUIRES_POSIX_PERMISSIONS
-def test_write_marker_is_created_with_0600(lock_file: str) -> None:
+def test_write_marker_is_created_with_0600(lock_file: str) -> None:  # pragma: win32 no cover
     lock = _make_lock(lock_file)
-    try:
-        with lock.write_lock(timeout=2):
+    try:  # pragma: win32 no cover
+        with lock.write_lock(timeout=2):  # pragma: win32 no cover
             assert stat.S_IMODE(Path(f"{lock_file}.write").lstat().st_mode) == 0o600
     finally:
         lock.close()
 
 
 @_REQUIRES_POSIX_PERMISSIONS
-def test_readers_directory_is_created_with_0700(lock_file: str) -> None:
+def test_readers_directory_is_created_with_0700(lock_file: str) -> None:  # pragma: win32 no cover
     lock = _make_lock(lock_file)
-    try:
-        with lock.read_lock(timeout=2):
+    try:  # pragma: win32 no cover
+        with lock.read_lock(timeout=2):  # pragma: win32 no cover
             assert stat.S_IMODE(Path(f"{lock_file}.readers").lstat().st_mode) == 0o700
     finally:
         lock.close()
@@ -860,10 +860,10 @@ def test_writer_ignores_housekeeping_files_in_readers_dir(lock_file: str) -> Non
 
 
 @_REQUIRES_POSIX_PERMISSIONS
-def test_reader_file_is_created_with_0600(lock_file: str) -> None:
+def test_reader_file_is_created_with_0600(lock_file: str) -> None:  # pragma: win32 no cover
     lock = _make_lock(lock_file)
-    try:
-        with lock.read_lock(timeout=2):
+    try:  # pragma: win32 no cover
+        with lock.read_lock(timeout=2):  # pragma: win32 no cover
             entries = list(Path(f"{lock_file}.readers").iterdir())
             assert len(entries) == 1
             assert stat.S_IMODE(entries[0].lstat().st_mode) == 0o600
@@ -873,7 +873,7 @@ def test_reader_file_is_created_with_0600(lock_file: str) -> None:
 
 @_REQUIRES_FORK
 @pytest.mark.timeout(15)
-def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:
+def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pragma: win32 no cover
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(target=_reuse_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
@@ -885,7 +885,7 @@ def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:
 
 @_REQUIRES_FORK
 @pytest.mark.timeout(15)
-def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:
+def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # pragma: win32 no cover
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(target=_release_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
@@ -897,7 +897,7 @@ def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:
 
 @_REQUIRES_FORK
 @pytest.mark.timeout(15)
-def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:
+def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:  # pragma: win32 no cover
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(
@@ -916,11 +916,11 @@ def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:
 # process and Python 3.15 warns that it may deadlock. That is the scenario under test, and it is already safe:
 # register_at_fork resets inherited state in the child (any child use raises "invalidated by fork()"). Expected.
 @pytest.mark.filterwarnings("ignore:.*multi-threaded, use of fork.*:DeprecationWarning")
-def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:
+def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = str(tmp_path / "foo.lock")
     lock = SoftReadWriteLock(path, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
     lock.acquire_write(timeout=5)
-    try:
+    try:  # pragma: win32 no cover
         child = _fork_process(target=time.sleep, args=(0.05,))
         child.start()
         child.join(timeout=5)
@@ -932,8 +932,8 @@ def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:
             poll_interval=0.02,
             is_singleton=False,
         )
-        try:
-            with pytest.raises(Timeout):
+        try:  # pragma: win32 no cover
+            with pytest.raises(Timeout):  # pragma: win32 no cover
                 peer.acquire_write(timeout=0.3)
         finally:
             peer.close()
@@ -1030,22 +1030,22 @@ def _write_stale_marker(path: str, content: bytes) -> None:
     os.utime(path, (past, past))
 
 
-def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:
+def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:  # pragma: win32 no cover
     lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
     lock.acquire_write(timeout=5)
     ok = _fork_event()
 
-    def child_entry() -> None:
-        try:
+    def child_entry() -> None:  # pragma: win32 no cover
+        try:  # pragma: win32 no cover
             lock.acquire_read(timeout=1)
-        except RuntimeError as exc:
-            if "invalidated by fork" in str(exc):
+        except RuntimeError as exc:  # pragma: win32 no cover
+            if "invalidated by fork" in str(exc):  # pragma: win32 no cover
                 ok.set()
 
     child = _fork_process(target=child_entry)
     child.start()
     child.join(timeout=5)
-    if ok.is_set():
+    if ok.is_set():  # pragma: win32 no cover
         result.set()
     else:
         failure.set()
@@ -1053,13 +1053,13 @@ def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType)
     lock.close()
 
 
-def _release_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:
+def _release_inherited_lock(lock_file: str, result: EventType, failure: EventType) -> None:  # pragma: win32 no cover
     lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
     lock.acquire_read(timeout=5)
     ok = _fork_event()
 
-    def child_entry() -> None:
-        try:
+    def child_entry() -> None:  # pragma: win32 no cover
+        try:  # pragma: win32 no cover
             lock.release()
         except RuntimeError:
             return
@@ -1068,7 +1068,7 @@ def _release_inherited_lock(lock_file: str, result: EventType, failure: EventTyp
     child = _fork_process(target=child_entry)
     child.start()
     child.join(timeout=5)
-    if ok.is_set():
+    if ok.is_set():  # pragma: win32 no cover
         result.set()
     else:
         failure.set()
@@ -1081,7 +1081,7 @@ def _reacquire_fresh_lock_in_child(lock_file: str, child_path: str, result: Even
     parent_lock.acquire_write(timeout=5)
     ok = _fork_event()
 
-    def child_entry() -> None:
+    def child_entry() -> None:  # pragma: win32 no cover
         child_lock = SoftReadWriteLock(
             child_path,
             is_singleton=False,
@@ -1089,8 +1089,8 @@ def _reacquire_fresh_lock_in_child(lock_file: str, child_path: str, result: Even
             stale_threshold=1.0,
             poll_interval=0.02,
         )
-        try:
-            with child_lock.read_lock(timeout=2):
+        try:  # pragma: win32 no cover
+            with child_lock.read_lock(timeout=2):  # pragma: win32 no cover
                 ok.set()
         finally:
             child_lock.close()
@@ -1098,7 +1098,7 @@ def _reacquire_fresh_lock_in_child(lock_file: str, child_path: str, result: Even
     child = _fork_process(target=child_entry)
     child.start()
     child.join(timeout=5)
-    if ok.is_set():
+    if ok.is_set():  # pragma: win32 no cover
         result.set()
     else:
         failure.set()
@@ -1107,14 +1107,14 @@ def _reacquire_fresh_lock_in_child(lock_file: str, child_path: str, result: Even
 
 
 def _fork_process(target: Callable[..., object], args: tuple[object, ...] = ()) -> mp.process.BaseProcess:
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: win32 no cover
         msg = "fork context is POSIX only"
         raise RuntimeError(msg)
     return mp.get_context("fork").Process(target=target, args=args)
 
 
-def _fork_event() -> EventType:
-    if sys.platform == "win32":
+def _fork_event() -> EventType:  # pragma: win32 no cover
+    if sys.platform == "win32":  # pragma: win32 no cover
         msg = "fork context is POSIX only"
         raise RuntimeError(msg)
     return mp.get_context("fork").Event()

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -39,9 +39,8 @@ _REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os,
 def _clear_singletons() -> Generator[None]:
     SoftReadWriteLock._instances.clear()
     yield
-    for ref in list(SoftReadWriteLock._instances.valuerefs()):
-        if (lock := ref()) is not None:
-            lock.close()
+    for lock in filter(None, (ref() for ref in list(SoftReadWriteLock._instances.valuerefs()))):
+        lock.close()
     SoftReadWriteLock._instances.clear()
 
 
@@ -131,6 +130,14 @@ def test_get_lock_returns_singleton(lock_file: str) -> None:
         first.close()
 
 
+def test_leaked_acquired_singleton_is_closed_on_teardown(lock_file: str) -> None:
+    # A singleton left acquired stays reachable through its live heartbeat thread, so the autouse fixture's
+    # teardown finds it and closes it. The write marker proves the lock was really taken and must be cleaned up.
+    lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.5)
+    lock.acquire_write(timeout=2)
+    assert Path(f"{lock_file}.write").exists()
+
+
 def test_reentrant_read_holds_and_releases(lock_file: str) -> None:
     lock = _make_lock(lock_file)
     try:
@@ -188,6 +195,33 @@ def test_write_lock_is_thread_pinned(lock_file: str) -> None:
     lock.close()
     assert len(errors) == 1
     assert isinstance(errors[0], (RuntimeError, Timeout))
+
+
+def test_blocking_acquire_without_timeout_waits_for_release(lock_file: str) -> None:
+    # The default infinite timeout gives the poll loop no deadline, so it sleeps a full poll interval each round
+    # until the writer releases rather than clamping the sleep to a remaining budget.
+    holder = _make_lock(lock_file)
+    holder.acquire_write(timeout=2)
+    acquired = threading.Event()
+
+    def waiter() -> None:
+        contender = _make_lock(lock_file)
+        try:
+            contender.acquire_read(timeout=-1)
+            acquired.set()
+            contender.release()
+        finally:
+            contender.close()
+
+    thread = threading.Thread(target=waiter)
+    thread.start()
+    try:
+        assert not acquired.wait(timeout=0.2)
+        holder.release()
+        assert acquired.wait(timeout=5)
+    finally:
+        thread.join(timeout=5)
+        holder.close()
 
 
 def test_release_without_hold_raises(lock_file: str) -> None:
@@ -1002,7 +1036,7 @@ def _cleanup(processes: list[Process]) -> Generator[None]:
                 proc.join(timeout=2)
 
 
-def _sigkill_worker(
+def _sigkill_worker(  # pragma: no cover  # runs in a child the test SIGKILLs, so its coverage data is never written
     lock_file: str,
     mode: Literal["read", "write"],
     acquired_event: EventType,
@@ -1047,7 +1081,7 @@ def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType)
     child.join(timeout=5)
     if ok.is_set():  # pragma: win32 no cover
         result.set()
-    else:
+    else:  # pragma: no cover  # reached only if the child fails to report the inherited lock, i.e. a regression
         failure.set()
     lock.release()
     lock.close()
@@ -1061,7 +1095,7 @@ def _release_inherited_lock(lock_file: str, result: EventType, failure: EventTyp
     def child_entry() -> None:  # pragma: win32 no cover
         try:  # pragma: win32 no cover
             lock.release()
-        except RuntimeError:
+        except RuntimeError:  # pragma: no cover  # release on a fork-inherited lock is silent; guards a regression
             return
         ok.set()
 
@@ -1070,13 +1104,15 @@ def _release_inherited_lock(lock_file: str, result: EventType, failure: EventTyp
     child.join(timeout=5)
     if ok.is_set():  # pragma: win32 no cover
         result.set()
-    else:
+    else:  # pragma: no cover  # reached only if the child's silent release regresses into raising
         failure.set()
     lock.release()
     lock.close()
 
 
-def _reacquire_fresh_lock_in_child(lock_file: str, child_path: str, result: EventType, failure: EventType) -> None:
+def _reacquire_fresh_lock_in_child(  # pragma: win32 no cover
+    lock_file: str, child_path: str, result: EventType, failure: EventType
+) -> None:
     parent_lock = SoftReadWriteLock(lock_file, heartbeat_interval=0.2, stale_threshold=1.0, poll_interval=0.02)
     parent_lock.acquire_write(timeout=5)
     ok = _fork_event()
@@ -1100,24 +1136,36 @@ def _reacquire_fresh_lock_in_child(lock_file: str, child_path: str, result: Even
     child.join(timeout=5)
     if ok.is_set():  # pragma: win32 no cover
         result.set()
-    else:
+    else:  # pragma: no cover  # reached only if the child cannot acquire a fresh lock after the fork, i.e. a regression
         failure.set()
     parent_lock.release()
     parent_lock.close()
 
 
-def _fork_process(target: Callable[..., object], args: tuple[object, ...] = ()) -> mp.process.BaseProcess:
-    if sys.platform == "win32":  # pragma: win32 no cover
+def _fork_process(  # pragma: win32 no cover
+    target: Callable[..., object], args: tuple[object, ...] = ()
+) -> mp.process.BaseProcess:
+    if sys.platform == "win32":  # pragma: win32 cover
         msg = "fork context is POSIX only"
         raise RuntimeError(msg)
     return mp.get_context("fork").Process(target=target, args=args)
 
 
 def _fork_event() -> EventType:  # pragma: win32 no cover
-    if sys.platform == "win32":  # pragma: win32 no cover
+    if sys.platform == "win32":  # pragma: win32 cover
         msg = "fork context is POSIX only"
         raise RuntimeError(msg)
     return mp.get_context("fork").Event()
+
+
+def test_cleanup_terminates_a_still_running_process() -> None:
+    # The cleanup helper must stop a worker that outlives its test, so a process still sleeping when the block
+    # exits is terminated and reaped rather than leaked.
+    proc = Process(target=time.sleep, args=(30,))
+    proc.start()
+    with _cleanup([proc]):
+        assert proc.is_alive()
+    assert not proc.is_alive()
 
 
 def test_write_marker_zero_write_rolls_back(lock_file: str, mocker: MockerFixture) -> None:

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -1115,3 +1115,12 @@ async def test_on_acquired_rollback_group_detaches_release_context(
         callback_error.__traceback__ is not None,
         release_error.__traceback__ is not None,
     ) == ((callback_error, release_error), None, None, callback_cause, release_cause, True, True)
+
+
+def test_async_del_without_any_loop_returns(tmp_path: Path) -> None:
+    # GC can finalize a lock with no loop running and none remembered, where releasing is impossible.
+    lock = AsyncSoftFileLock(str(tmp_path / "a"))
+
+    lock.__del__()  # ruff:ignore[unnecessary-dunder-call]  # a finalizer test cannot ride on collection timing
+
+    assert not lock.is_locked

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -10,10 +10,12 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from errno import EINTR, EIO, ENOSYS
+from importlib.util import find_spec
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
+from coverage_pragmas import CAPABILITIES
 
 from filelock import (
     AsyncFileLock,
@@ -34,7 +36,12 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_UNIX_FLOCK_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="native flock semantics are Unix-only")
+_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    find_spec("fcntl") is None, reason="native flock semantics come from the fcntl module"
+)
+_NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"], reason="creating a symlink needs a privilege this runtime does not grant"
+)
 
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
@@ -363,7 +370,7 @@ async def test_cancel_check_log_message(
 def test_sync_with_raises_not_implemented_error(lock_type: type[BaseAsyncFileLock], tmp_path: Path) -> None:
     # __exit__ must exist so Python can call it after __enter__ raises; without it AttributeError hides the real error
     with pytest.raises(NotImplementedError, match=r"async with"), lock_type(str(tmp_path / "test.lock")):
-        pass  # pragma: no cover
+        pass  # pragma: no cover  # __enter__ raises NotImplementedError, so the body never runs
 
 
 @pytest.mark.parametrize(
@@ -538,9 +545,9 @@ async def test_release_from_different_task_clears_registry(tmp_path: Path, lock_
         pass
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="unix-only symlink test")
+@_NEEDS_SYMLINK
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
-@pytest.mark.asyncio  # pragma: win32 no cover
+@pytest.mark.asyncio  # pragma: needs symlink
 async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
     # A symlinked parent directory resolves to the same canonical key; the final component stays literal.
     real_dir = tmp_path / "real"
@@ -548,13 +555,13 @@ async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseA
     (tmp_path / "link").symlink_to(real_dir)
 
     lock1 = lock_type(str(real_dir / "test.lock"))
-    async with lock1:  # pragma: win32 no cover
+    async with lock1:
         lock2 = lock_type(str(tmp_path / "link" / "test.lock"))
-        with pytest.raises(RuntimeError, match="Deadlock"):  # pragma: win32 no cover
+        with pytest.raises(RuntimeError, match="Deadlock"):
             await lock2.acquire()
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.parametrize(
     ("depth", "force"),
     [
@@ -563,34 +570,34 @@ async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseA
         pytest.param(2, True, id="forced"),
     ],
 )
-@pytest.mark.asyncio  # pragma: win32 no cover
+@pytest.mark.asyncio  # pragma: needs fcntl
 async def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Path, depth: int, force: bool) -> None:
     lock_path, original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     lock = AsyncFileLock(lock_path, run_in_executor=False)
-    for _depth in range(depth):  # pragma: win32 no cover
+    for _depth in range(depth):
         await lock.acquire()
     _retarget_parent(lock_path, replacement_path)
 
-    if force:  # pragma: win32 no cover
+    if force:
         await lock.release(force=True)
-    else:  # pragma: win32 no cover
-        for _depth in range(depth):  # pragma: win32 no cover
+    else:
+        for _depth in range(depth):
             await lock.release()
 
-    async with AsyncFileLock(original_path, run_in_executor=False) as successor:  # pragma: win32 no cover
+    async with AsyncFileLock(original_path, run_in_executor=False) as successor:
         assert successor.is_locked
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.asyncio
-async def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:  # pragma: win32 no cover
+async def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     original = AsyncFileLock(lock_path, run_in_executor=False)
     await original.acquire()
     _retarget_parent(lock_path, replacement_path)
-    async with AsyncFileLock(replacement_path, run_in_executor=False):  # pragma: win32 no cover
+    async with AsyncFileLock(replacement_path, run_in_executor=False):
         await original.release()
-        with pytest.raises(RuntimeError, match="Deadlock"):  # pragma: win32 no cover
+        with pytest.raises(RuntimeError, match="Deadlock"):
             await AsyncFileLock(replacement_path, run_in_executor=False).acquire(cancel_check=lambda: True)
 
 
@@ -622,7 +629,7 @@ async def test_force_release_clears_registry(tmp_path: Path, lock_type: type[Bas
         assert lock2.is_locked
 
 
-def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma: win32 no cover
+def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma: needs fcntl
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"
     original.mkdir()
@@ -632,7 +639,7 @@ def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma:
     return link / "test.lock", original / "test.lock", replacement / "test.lock"
 
 
-def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:  # pragma: win32 no cover
+def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:  # pragma: needs fcntl
     link = lock_path.parent
     link.unlink()
     link.symlink_to(replacement_path.parent, target_is_directory=True)
@@ -645,13 +652,13 @@ async def _acquire_for_mode(lock: BaseAsyncFileLock, mode: Literal["finite", "no
         await lock.acquire(blocking=False)
 
 
-@_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio  # pragma: win32 no cover
+@_NEEDS_FCNTL
+@pytest.mark.asyncio  # pragma: needs fcntl
 async def test_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))
     await lock.acquire()
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[OSError(EIO, "unlock failed"), None])
-    with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="unlock failed"):
         await lock.release()
     assert lock.is_locked
     assert lock.lock_counter == 1
@@ -974,32 +981,32 @@ async def test_context_group_preserves_user_release_cancellation_group(tmp_path:
     await lock.release()
 
 
-def _fail_close_of(mocker: MockerFixture, lock: BaseAsyncFileLock, error: OSError) -> None:  # pragma: win32 no cover
+def _fail_close_of(mocker: MockerFixture, lock: BaseAsyncFileLock, error: OSError) -> None:  # pragma: needs fcntl
     # Fail os.close only for this lock's descriptor, so an unrelated lock's __del__ close during the test is untouched.
     fd = lock._context.lock_file_fd
     real_close = os.close
 
-    def close(target: int) -> None:  # pragma: win32 no cover
-        if target == fd:  # pragma: win32 no cover
+    def close(target: int) -> None:
+        if target == fd:
             raise error
         real_close(target)  # pragma: no cover  # only an unrelated __del__ close during the mock window reaches here
 
     mocker.patch("filelock._api.os.close", side_effect=close)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.asyncio
-async def test_close_error_raise_propagates(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+async def test_close_error_raise_propagates(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: needs fcntl
     lock = AsyncFileLock(str(tmp_path / "a"), close_error_policy="raise")
     await lock.acquire()
     _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
-    with pytest.raises(OSError, match="close failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="close failed"):
         await lock.release()
     assert not lock.is_locked
 
 
-@_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio  # pragma: win32 no cover
+@_NEEDS_FCNTL
+@pytest.mark.asyncio  # pragma: needs fcntl
 async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))  # default policy
     await lock.acquire()
@@ -1008,12 +1015,12 @@ async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: Mo
     assert not lock.is_locked
 
 
-@_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio  # pragma: win32 no cover
+@_NEEDS_FCNTL
+@pytest.mark.asyncio  # pragma: needs fcntl
 async def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = AsyncFileLock(str(tmp_path / "a"), fallback_to_soft=False)
-    with pytest.raises(OSError, match="no flock"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="no flock"):
         await lock.acquire()
     assert not lock.is_locked
     assert type(lock).__name__ == "AsyncUnixFileLock"  # not swapped to the soft class
@@ -1024,9 +1031,9 @@ def test_preserve_lock_file_async_soft_rejects(tmp_path: Path) -> None:
         AsyncSoftFileLock(str(tmp_path / "a"), preserve_lock_file=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.asyncio
-async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -> None:  # pragma: win32 no cover
+async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -> None:  # pragma: needs fcntl
     path = tmp_path / "a"
     lock = AsyncFileLock(str(path), preserve_lock_file=True)
     await lock.acquire()
@@ -1035,7 +1042,7 @@ async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -
     assert type(lock).__name__ == "AsyncUnixFileLock"
 
 
-def _failing_on_acquired(_fd: int) -> None:  # pragma: win32 no cover
+def _failing_on_acquired(_fd: int) -> None:  # pragma: needs fcntl
     msg = "hook failed"
     raise RuntimeError(msg)
 
@@ -1045,32 +1052,32 @@ def test_on_acquired_async_soft_rejects(tmp_path: Path) -> None:
         AsyncSoftFileLock(str(tmp_path / "a"), on_acquired=lambda _fd: None)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.asyncio
-async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:  # pragma: win32 no cover
+async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_thread = -1
     fd_while_held = -1
 
-    def hook(fd: int) -> None:  # pragma: win32 no cover
+    def hook(fd: int) -> None:
         nonlocal hook_thread, fd_while_held
         hook_thread = threading.get_ident()
-        if lock.is_locked:  # pragma: win32 no cover
+        if lock.is_locked:  # pragma: no branch  # on_acquired only ever runs while the lock is held
             fd_while_held = fd
 
     lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, on_acquired=hook)
     await lock.acquire()
-    try:  # pragma: win32 no cover
+    try:
         assert fd_while_held >= 0  # the hook ran while the lock was held, with a real descriptor
         assert hook_thread != threading.get_ident()  # in the backend executor, not the event-loop thread
     finally:
         await lock.release()
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.asyncio
-async def test_on_acquired_async_failure_releases(tmp_path: Path) -> None:  # pragma: win32 no cover
+async def test_on_acquired_async_failure_releases(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, on_acquired=_failing_on_acquired)
-    with pytest.raises(RuntimeError, match="hook failed"):  # pragma: win32 no cover
+    with pytest.raises(RuntimeError, match="hook failed"):
         await lock.acquire()
     assert not lock.is_locked
     assert lock.lock_counter == 0

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -127,7 +127,7 @@ async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) 
 
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         async with lock_3:
-            pass
+            pass  # pragma: no cover  # __aenter__ raises Timeout, so the body never runs
     assert not lock_3.is_locked
     assert lock_1.is_locked
 
@@ -138,7 +138,7 @@ async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) 
 
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         async with lock_4:
-            pass
+            pass  # pragma: no cover  # __aenter__ raises Timeout, so the body never runs
     assert not lock_4.is_locked
     assert lock_1.is_locked
 
@@ -150,7 +150,7 @@ async def test_non_blocking(lock_type: type[BaseAsyncFileLock], tmp_path: Path) 
 
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."):
         async with lock_5:
-            pass
+            pass  # pragma: no cover  # __aenter__ raises Timeout, so the body never runs
     assert not lock_5.is_locked
     assert lock_1.is_locked
 
@@ -195,6 +195,26 @@ async def test_coroutine_function(tmp_path: Path) -> None:
     await lock.release()
     assert acquired
     assert released
+
+
+@pytest.mark.asyncio
+async def test_coroutine_acquire_without_holding_polls_and_skips_on_acquired(tmp_path: Path) -> None:
+    attempts: list[str] = []
+
+    class NeverHoldsLock(BaseAsyncFileLock):
+        async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]
+            attempts.append(self.lock_file)  # returns without setting the fd, so is_locked stays False
+
+        async def _release(self) -> None:  # ty: ignore[invalid-method-override]
+            self._context.lock_file_fd = None  # pragma: no cover  # never held, so release never runs
+
+    lock = NeverHoldsLock(str(tmp_path / "a"), timeout=0.1)
+    with pytest.raises(Timeout):
+        await lock.acquire()
+
+    # The coroutine backend returned without acquiring, so the tracker skipped on_acquired and the poll loop retried.
+    assert len(attempts) >= 2
+    assert not lock.is_locked
 
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
@@ -308,7 +328,7 @@ async def test_cancel_check_not_called_when_lock_available(lock_type: type[BaseA
 
     called = False
 
-    def should_not_be_called() -> bool:
+    def should_not_be_called() -> bool:  # pragma: no cover  # a free lock never consults cancel_check
         nonlocal called
         called = True
         return True
@@ -962,7 +982,7 @@ def _fail_close_of(mocker: MockerFixture, lock: BaseAsyncFileLock, error: OSErro
     def close(target: int) -> None:  # pragma: win32 no cover
         if target == fd:  # pragma: win32 no cover
             raise error
-        real_close(target)
+        real_close(target)  # pragma: no cover  # only an unrelated __del__ close during the mock window reaches here
 
     mocker.patch("filelock._api.os.close", side_effect=close)
 

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -43,6 +43,13 @@ _NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"], reason="creating a symlink needs a privilege this runtime does not grant"
 )
 
+# filelock resolves a lock's parent with abspath on Windows so junctions and reparse points are never followed, which
+# also keeps a symlinked parent a distinct key there. These cases assert the collapsing the realpath platforms do.
+_NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"] or sys.platform == "win32",
+    reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",
+)
+
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.parametrize("path_type", [str, PurePath, Path])
@@ -545,9 +552,9 @@ async def test_release_from_different_task_clears_registry(tmp_path: Path, lock_
         pass
 
 
-@_NEEDS_SYMLINK
+@_NEEDS_PARENT_SYMLINK_COLLAPSE
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
-@pytest.mark.asyncio  # pragma: needs symlink
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
     # A symlinked parent directory resolves to the same canonical key; the final component stays literal.
     real_dir = tmp_path / "real"

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -520,7 +520,7 @@ async def test_release_from_different_task_clears_registry(tmp_path: Path, lock_
 
 @pytest.mark.skipif(sys.platform == "win32", reason="unix-only symlink test")
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
     # A symlinked parent directory resolves to the same canonical key; the final component stays literal.
     real_dir = tmp_path / "real"
@@ -528,9 +528,9 @@ async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseA
     (tmp_path / "link").symlink_to(real_dir)
 
     lock1 = lock_type(str(real_dir / "test.lock"))
-    async with lock1:
+    async with lock1:  # pragma: win32 no cover
         lock2 = lock_type(str(tmp_path / "link" / "test.lock"))
-        with pytest.raises(RuntimeError, match="Deadlock"):
+        with pytest.raises(RuntimeError, match="Deadlock"):  # pragma: win32 no cover
             await lock2.acquire()
 
 
@@ -543,34 +543,34 @@ async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseA
         pytest.param(2, True, id="forced"),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Path, depth: int, force: bool) -> None:
     lock_path, original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     lock = AsyncFileLock(lock_path, run_in_executor=False)
-    for _depth in range(depth):
+    for _depth in range(depth):  # pragma: win32 no cover
         await lock.acquire()
     _retarget_parent(lock_path, replacement_path)
 
-    if force:
+    if force:  # pragma: win32 no cover
         await lock.release(force=True)
-    else:
-        for _depth in range(depth):
+    else:  # pragma: win32 no cover
+        for _depth in range(depth):  # pragma: win32 no cover
             await lock.release()
 
-    async with AsyncFileLock(original_path, run_in_executor=False) as successor:
+    async with AsyncFileLock(original_path, run_in_executor=False) as successor:  # pragma: win32 no cover
         assert successor.is_locked
 
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:
+async def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     original = AsyncFileLock(lock_path, run_in_executor=False)
     await original.acquire()
     _retarget_parent(lock_path, replacement_path)
-    async with AsyncFileLock(replacement_path, run_in_executor=False):
+    async with AsyncFileLock(replacement_path, run_in_executor=False):  # pragma: win32 no cover
         await original.release()
-        with pytest.raises(RuntimeError, match="Deadlock"):
+        with pytest.raises(RuntimeError, match="Deadlock"):  # pragma: win32 no cover
             await AsyncFileLock(replacement_path, run_in_executor=False).acquire(cancel_check=lambda: True)
 
 
@@ -602,7 +602,7 @@ async def test_force_release_clears_registry(tmp_path: Path, lock_type: type[Bas
         assert lock2.is_locked
 
 
-def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma: win32 no cover
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"
     original.mkdir()
@@ -612,7 +612,7 @@ def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
     return link / "test.lock", original / "test.lock", replacement / "test.lock"
 
 
-def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:
+def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:  # pragma: win32 no cover
     link = lock_path.parent
     link.unlink()
     link.symlink_to(replacement_path.parent, target_is_directory=True)
@@ -626,12 +626,12 @@ async def _acquire_for_mode(lock: BaseAsyncFileLock, mode: Literal["finite", "no
 
 
 @_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))
     await lock.acquire()
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[OSError(EIO, "unlock failed"), None])
-    with pytest.raises(OSError, match="unlock failed"):
+    with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 no cover
         await lock.release()
     assert lock.is_locked
     assert lock.lock_counter == 1
@@ -954,13 +954,13 @@ async def test_context_group_preserves_user_release_cancellation_group(tmp_path:
     await lock.release()
 
 
-def _fail_close_of(mocker: MockerFixture, lock: BaseAsyncFileLock, error: OSError) -> None:
+def _fail_close_of(mocker: MockerFixture, lock: BaseAsyncFileLock, error: OSError) -> None:  # pragma: win32 no cover
     # Fail os.close only for this lock's descriptor, so an unrelated lock's __del__ close during the test is untouched.
     fd = lock._context.lock_file_fd
     real_close = os.close
 
-    def close(target: int) -> None:
-        if target == fd:
+    def close(target: int) -> None:  # pragma: win32 no cover
+        if target == fd:  # pragma: win32 no cover
             raise error
         real_close(target)
 
@@ -969,17 +969,17 @@ def _fail_close_of(mocker: MockerFixture, lock: BaseAsyncFileLock, error: OSErro
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_close_error_raise_propagates(tmp_path: Path, mocker: MockerFixture) -> None:
+async def test_close_error_raise_propagates(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     lock = AsyncFileLock(str(tmp_path / "a"), close_error_policy="raise")
     await lock.acquire()
     _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
-    with pytest.raises(OSError, match="close failed"):
+    with pytest.raises(OSError, match="close failed"):  # pragma: win32 no cover
         await lock.release()
     assert not lock.is_locked
 
 
 @_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))  # default policy
     await lock.acquire()
@@ -989,11 +989,11 @@ async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: Mo
 
 
 @_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = AsyncFileLock(str(tmp_path / "a"), fallback_to_soft=False)
-    with pytest.raises(OSError, match="no flock"):
+    with pytest.raises(OSError, match="no flock"):  # pragma: win32 no cover
         await lock.acquire()
     assert not lock.is_locked
     assert type(lock).__name__ == "AsyncUnixFileLock"  # not swapped to the soft class
@@ -1006,7 +1006,7 @@ def test_preserve_lock_file_async_soft_rejects(tmp_path: Path) -> None:
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -> None:
+async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = tmp_path / "a"
     lock = AsyncFileLock(str(path), preserve_lock_file=True)
     await lock.acquire()
@@ -1015,7 +1015,7 @@ async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -
     assert type(lock).__name__ == "AsyncUnixFileLock"
 
 
-def _failing_on_acquired(_fd: int) -> None:
+def _failing_on_acquired(_fd: int) -> None:  # pragma: win32 no cover
     msg = "hook failed"
     raise RuntimeError(msg)
 
@@ -1027,19 +1027,19 @@ def test_on_acquired_async_soft_rejects(tmp_path: Path) -> None:
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:
+async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:  # pragma: win32 no cover
     hook_thread = -1
     fd_while_held = -1
 
-    def hook(fd: int) -> None:
+    def hook(fd: int) -> None:  # pragma: win32 no cover
         nonlocal hook_thread, fd_while_held
         hook_thread = threading.get_ident()
-        if lock.is_locked:
+        if lock.is_locked:  # pragma: win32 no cover
             fd_while_held = fd
 
     lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, on_acquired=hook)
     await lock.acquire()
-    try:
+    try:  # pragma: win32 no cover
         assert fd_while_held >= 0  # the hook ran while the lock was held, with a real descriptor
         assert hook_thread != threading.get_ident()  # in the backend executor, not the event-loop thread
     finally:
@@ -1048,9 +1048,9 @@ async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_on_acquired_async_failure_releases(tmp_path: Path) -> None:
+async def test_on_acquired_async_failure_releases(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, on_acquired=_failing_on_acquired)
-    with pytest.raises(RuntimeError, match="hook failed"):
+    with pytest.raises(RuntimeError, match="hook failed"):  # pragma: win32 no cover
         await lock.acquire()
     assert not lock.is_locked
     assert lock.lock_counter == 0

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -824,7 +824,9 @@ async def test_context_group_detaches_release_context(
     ) == ((body_error, release_error), None, None, body_cause, release_cause, True, True)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="standard exception-group rendering requires Python 3.11")
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="standard exception-group rendering requires Python 3.11"
+)  # pragma: >=3.11 cover
 @pytest.mark.parametrize(
     "use_proxy",
     [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -27,7 +27,7 @@ from filelock import (
 )
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
-    from builtins import BaseExceptionGroup, ExceptionGroup
+    from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: no cover (<py311)
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -1117,9 +1117,11 @@ async def test_on_acquired_rollback_group_detaches_release_context(
     ) == ((callback_error, release_error), None, None, callback_cause, release_cause, True, True)
 
 
-def test_async_del_without_any_loop_returns(tmp_path: Path) -> None:
-    # GC can finalize a lock with no loop running and none remembered, where releasing is impossible.
+def test_async_del_without_any_loop_returns(tmp_path: Path, mocker: MockerFixture) -> None:
+    # GC can finalize a lock with no loop running and none remembered, where releasing is impossible. Raise the lookup
+    # rather than rely on no loop running here, which the surrounding tests decide.
     lock = AsyncSoftFileLock(str(tmp_path / "a"))
+    mocker.patch("filelock.asyncio.asyncio.get_running_loop", side_effect=RuntimeError)
 
     lock.__del__()  # ruff:ignore[unnecessary-dunder-call]  # a finalizer test cannot ride on collection timing
 

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -43,8 +43,7 @@ _NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"], reason="creating a symlink needs a privilege this runtime does not grant"
 )
 
-# filelock resolves a lock's parent with abspath on Windows so junctions and reparse points are never followed, which
-# also keeps a symlinked parent a distinct key there. These cases assert the collapsing the realpath platforms do.
+# Windows resolves a lock's parent with abspath, so a symlinked parent stays a distinct key and never collapses.
 _NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"] or sys.platform == "win32",
     reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",

--- a/tests/test_async_filelock_acquire_cancellation.py
+++ b/tests/test_async_filelock_acquire_cancellation.py
@@ -6,6 +6,7 @@ import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from errno import EIO
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Final
 
 import pytest
@@ -27,8 +28,8 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    sys.platform == "win32", reason="native flock semantics are Unix-only"
+_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    find_spec("fcntl") is None, reason="native flock semantics come from the fcntl module"
 )
 
 
@@ -154,14 +155,14 @@ async def test_acquire_cancellation_before_executor_start_rolls_back(tmp_path: P
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.asyncio
-async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path) -> None:  # pragma: win32 no cover
+async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def block_hook(_fd: int) -> None:
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -171,7 +172,7 @@ async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path)
     second_acquire = asyncio.create_task(lock.acquire())
     first_acquire.cancel("cancel first acquire")
     finish_hook.set()
-    with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
+    with pytest.raises(asyncio.CancelledError) as info:
         await first_acquire
     assert_cancellation_message(info.value, "cancel first acquire")
     await second_acquire
@@ -182,14 +183,14 @@ async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path)
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.asyncio
-async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path) -> None:  # pragma: win32 no cover
+async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def block_hook(_fd: int) -> None:
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -199,7 +200,7 @@ async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path
     queued_acquire = asyncio.create_task(lock.acquire())
     await asyncio.sleep(0)
     queued_acquire.cancel("cancel queued acquire")
-    with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
+    with pytest.raises(asyncio.CancelledError) as info:
         await queued_acquire
     assert_cancellation_message(info.value, "cancel queued acquire")
     assert lock.lock_counter == 1
@@ -213,8 +214,8 @@ async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio  # pragma: win32 no cover
+@_NEEDS_FCNTL
+@pytest.mark.asyncio  # pragma: needs fcntl
 async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, mocker: MockerFixture) -> None:
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
@@ -222,11 +223,11 @@ async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, 
     finish_rollback = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def block_hook(_fd: int) -> None:
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
-    def block_rollback(_fd: int, _operation: int) -> None:  # pragma: win32 no cover
+    def block_rollback(_fd: int, _operation: int) -> None:
         loop.call_soon_threadsafe(rollback_started.set)
         assert finish_rollback.wait(timeout=5)
 
@@ -239,7 +240,7 @@ async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, 
     await rollback_started.wait()
     task.cancel("second cancellation")
     finish_rollback.set()
-    with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
+    with pytest.raises(asyncio.CancelledError) as info:
         await task
 
     assert_cancellation_message(info.value, "first cancellation")
@@ -247,10 +248,10 @@ async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, 
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
-async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pragma: win32 no cover
+async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pragma: needs fcntl
     tmp_path: Path, policy: ContextErrorPolicy
 ) -> None:
     hook_started = asyncio.Event()
@@ -260,7 +261,7 @@ async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pr
     prior_context = LookupError("prior callback failure")
     callback_error.__context__ = prior_context
 
-    def fail_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def fail_hook(_fd: int) -> None:
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
         raise callback_error
@@ -270,13 +271,13 @@ async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pr
     await hook_started.wait()
     task.cancel("cancel acquire")
     finish_hook.set()
-    if policy == "chain":  # pragma: win32 no cover
-        with pytest.raises(ValueError, match="hook failed") as info:  # pragma: win32 no cover
+    if policy == "chain":
+        with pytest.raises(ValueError, match="hook failed") as info:
             await task
         cancellation = info.value.__context__
         assert info.value is callback_error
-    else:  # pragma: win32 no cover
-        with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    else:
+        with pytest.raises(BaseExceptionGroup) as info:
             await task
         cancellation, grouped_callback_error = info.value.exceptions
         assert grouped_callback_error is callback_error
@@ -292,13 +293,13 @@ async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pr
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.parametrize(
     ("context_message", "preserved"),
     [pytest.param("unrelated", True, id="distinct"), pytest.param("attempt", False, id="equivalent")],
 )
 @pytest.mark.asyncio
-async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma: win32 no cover
+async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma: needs fcntl
     tmp_path: Path, context_message: str, *, preserved: bool
 ) -> None:
     hook_started = asyncio.Event()
@@ -309,7 +310,7 @@ async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma:
     prior_context = ExceptionGroup(context_message, (nested_leaf,))
     callback_group.__context__ = prior_context
 
-    def fail_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def fail_hook(_fd: int) -> None:
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
         raise callback_group
@@ -319,7 +320,7 @@ async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma:
     await hook_started.wait()
     task.cancel("cancel acquire")
     finish_hook.set()
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         await task
 
     cancellation, grouped_callback_error = info.value.exceptions
@@ -343,10 +344,10 @@ async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma:
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
-async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: win32 no cover
+async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: needs fcntl
     tmp_path: Path,
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
@@ -356,7 +357,7 @@ async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: win32 no
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def block_hook(_fd: int) -> None:
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -367,13 +368,13 @@ async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: win32 no
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[rollback_error, None])
     task.cancel("cancel acquire")
     finish_hook.set()
-    if policy == "chain":  # pragma: win32 no cover
-        with pytest.raises(OSError, match="rollback failed") as info:  # pragma: win32 no cover
+    if policy == "chain":
+        with pytest.raises(OSError, match="rollback failed") as info:
             await task
         cancellation = info.value.__context__
         assert info.value is rollback_error
-    else:  # pragma: win32 no cover
-        with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    else:
+        with pytest.raises(BaseExceptionGroup) as info:
             await task
         cancellation, grouped_rollback_error = info.value.exceptions
         assert grouped_rollback_error is rollback_error
@@ -391,10 +392,10 @@ async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: win32 no
     await lock.release()
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
-async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(  # pragma: win32 no cover
+async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(  # pragma: needs fcntl
     tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
 ) -> None:
     hook_started = asyncio.Event()
@@ -402,7 +403,7 @@ async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(  # pra
     loop = asyncio.get_running_loop()
     callback_error = ValueError("hook failed")
 
-    def fail_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def fail_hook(_fd: int) -> None:
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
         raise callback_error
@@ -418,14 +419,14 @@ async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(  # pra
     )
     task.cancel("cancel acquire")
     finish_hook.set()
-    if policy == "chain":  # pragma: win32 no cover
-        with pytest.raises(OSError, match="cancellation rollback failed") as info:  # pragma: win32 no cover
+    if policy == "chain":
+        with pytest.raises(OSError, match="cancellation rollback failed") as info:
             await task
         attempt_error = info.value.__context__
         cancellation = attempt_error.__context__ if attempt_error is not None else None
         assert info.value is second_rollback_error
-    else:  # pragma: win32 no cover
-        with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    else:
+        with pytest.raises(BaseExceptionGroup) as info:
             await task
         cancellation, attempt_error, grouped_rollback_error = info.value.exceptions
         assert grouped_rollback_error is second_rollback_error

--- a/tests/test_async_filelock_acquire_cancellation.py
+++ b/tests/test_async_filelock_acquire_cancellation.py
@@ -156,12 +156,12 @@ async def test_acquire_cancellation_before_executor_start_rolls_back(tmp_path: P
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path) -> None:
+async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path) -> None:  # pragma: win32 no cover
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:
+    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -171,7 +171,7 @@ async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path)
     second_acquire = asyncio.create_task(lock.acquire())
     first_acquire.cancel("cancel first acquire")
     finish_hook.set()
-    with pytest.raises(asyncio.CancelledError) as info:
+    with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
         await first_acquire
     assert_cancellation_message(info.value, "cancel first acquire")
     await second_acquire
@@ -184,12 +184,12 @@ async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path)
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path) -> None:
+async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path) -> None:  # pragma: win32 no cover
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:
+    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -199,7 +199,7 @@ async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path
     queued_acquire = asyncio.create_task(lock.acquire())
     await asyncio.sleep(0)
     queued_acquire.cancel("cancel queued acquire")
-    with pytest.raises(asyncio.CancelledError) as info:
+    with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
         await queued_acquire
     assert_cancellation_message(info.value, "cancel queued acquire")
     assert lock.lock_counter == 1
@@ -214,7 +214,7 @@ async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path
 
 
 @_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, mocker: MockerFixture) -> None:
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
@@ -222,11 +222,11 @@ async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, 
     finish_rollback = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:
+    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
-    def block_rollback(_fd: int, _operation: int) -> None:
+    def block_rollback(_fd: int, _operation: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(rollback_started.set)
         assert finish_rollback.wait(timeout=5)
 
@@ -239,7 +239,7 @@ async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, 
     await rollback_started.wait()
     task.cancel("second cancellation")
     finish_rollback.set()
-    with pytest.raises(asyncio.CancelledError) as info:
+    with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
         await task
 
     assert_cancellation_message(info.value, "first cancellation")
@@ -250,7 +250,7 @@ async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
-async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(
+async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pragma: win32 no cover
     tmp_path: Path, policy: ContextErrorPolicy
 ) -> None:
     hook_started = asyncio.Event()
@@ -260,7 +260,7 @@ async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(
     prior_context = LookupError("prior callback failure")
     callback_error.__context__ = prior_context
 
-    def fail_hook(_fd: int) -> None:
+    def fail_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
         raise callback_error
@@ -270,13 +270,13 @@ async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(
     await hook_started.wait()
     task.cancel("cancel acquire")
     finish_hook.set()
-    if policy == "chain":
-        with pytest.raises(ValueError, match="hook failed") as info:
+    if policy == "chain":  # pragma: win32 no cover
+        with pytest.raises(ValueError, match="hook failed") as info:  # pragma: win32 no cover
             await task
         cancellation = info.value.__context__
         assert info.value is callback_error
-    else:
-        with pytest.raises(BaseExceptionGroup) as info:
+    else:  # pragma: win32 no cover
+        with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
             await task
         cancellation, grouped_callback_error = info.value.exceptions
         assert grouped_callback_error is callback_error
@@ -298,7 +298,7 @@ async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(
     [pytest.param("unrelated", True, id="distinct"), pytest.param("attempt", False, id="equivalent")],
 )
 @pytest.mark.asyncio
-async def test_acquire_cancellation_group_reconciles_attempt_context(
+async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma: win32 no cover
     tmp_path: Path, context_message: str, *, preserved: bool
 ) -> None:
     hook_started = asyncio.Event()
@@ -309,7 +309,7 @@ async def test_acquire_cancellation_group_reconciles_attempt_context(
     prior_context = ExceptionGroup(context_message, (nested_leaf,))
     callback_group.__context__ = prior_context
 
-    def fail_hook(_fd: int) -> None:
+    def fail_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
         raise callback_group
@@ -319,7 +319,7 @@ async def test_acquire_cancellation_group_reconciles_attempt_context(
     await hook_started.wait()
     task.cancel("cancel acquire")
     finish_hook.set()
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         await task
 
     cancellation, grouped_callback_error = info.value.exceptions
@@ -346,7 +346,7 @@ async def test_acquire_cancellation_group_reconciles_attempt_context(
 @_UNIX_FLOCK_ONLY
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
-async def test_acquire_cancellation_surfaces_rollback_error(
+async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: win32 no cover
     tmp_path: Path,
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
@@ -356,7 +356,7 @@ async def test_acquire_cancellation_surfaces_rollback_error(
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:
+    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -367,13 +367,13 @@ async def test_acquire_cancellation_surfaces_rollback_error(
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[rollback_error, None])
     task.cancel("cancel acquire")
     finish_hook.set()
-    if policy == "chain":
-        with pytest.raises(OSError, match="rollback failed") as info:
+    if policy == "chain":  # pragma: win32 no cover
+        with pytest.raises(OSError, match="rollback failed") as info:  # pragma: win32 no cover
             await task
         cancellation = info.value.__context__
         assert info.value is rollback_error
-    else:
-        with pytest.raises(BaseExceptionGroup) as info:
+    else:  # pragma: win32 no cover
+        with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
             await task
         cancellation, grouped_rollback_error = info.value.exceptions
         assert grouped_rollback_error is rollback_error
@@ -394,7 +394,7 @@ async def test_acquire_cancellation_surfaces_rollback_error(
 @_UNIX_FLOCK_ONLY
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
-async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(
+async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(  # pragma: win32 no cover
     tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
 ) -> None:
     hook_started = asyncio.Event()
@@ -402,7 +402,7 @@ async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(
     loop = asyncio.get_running_loop()
     callback_error = ValueError("hook failed")
 
-    def fail_hook(_fd: int) -> None:
+    def fail_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
         raise callback_error
@@ -418,14 +418,14 @@ async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(
     )
     task.cancel("cancel acquire")
     finish_hook.set()
-    if policy == "chain":
-        with pytest.raises(OSError, match="cancellation rollback failed") as info:
+    if policy == "chain":  # pragma: win32 no cover
+        with pytest.raises(OSError, match="cancellation rollback failed") as info:  # pragma: win32 no cover
             await task
         attempt_error = info.value.__context__
         cancellation = attempt_error.__context__ if attempt_error is not None else None
         assert info.value is second_rollback_error
-    else:
-        with pytest.raises(BaseExceptionGroup) as info:
+    else:  # pragma: win32 no cover
+        with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
             await task
         cancellation, attempt_error, grouped_rollback_error = info.value.exceptions
         assert grouped_rollback_error is second_rollback_error

--- a/tests/test_async_filelock_acquire_cancellation.py
+++ b/tests/test_async_filelock_acquire_cancellation.py
@@ -19,7 +19,7 @@ from filelock import (
 )
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
-    from builtins import BaseExceptionGroup, ExceptionGroup
+    from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: no cover (<py311)
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 

--- a/tests/test_async_filelock_release_cancellation.py
+++ b/tests/test_async_filelock_release_cancellation.py
@@ -19,7 +19,7 @@ from async_filelock_cancellation_helpers import (
 from filelock import AsyncFileLock, BaseAsyncFileLock, ContextErrorPolicy
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
-    from builtins import BaseExceptionGroup, ExceptionGroup
+    from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: no cover (<py311)
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 

--- a/tests/test_async_filelock_release_cancellation.py
+++ b/tests/test_async_filelock_release_cancellation.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import threading
 from errno import EIO
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Final
 
 import pytest
@@ -27,13 +28,13 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    sys.platform == "win32", reason="native flock semantics are Unix-only"
+_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    find_spec("fcntl") is None, reason="native flock semantics come from the fcntl module"
 )
 
 
-@_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio  # pragma: win32 no cover
+@_NEEDS_FCNTL
+@pytest.mark.asyncio  # pragma: needs fcntl
 async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))
     await lock.acquire()
@@ -41,7 +42,7 @@ async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: Mo
     finish_release = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_unlock(_fd: int, _operation: int) -> None:  # pragma: win32 no cover
+    def block_unlock(_fd: int, _operation: int) -> None:
         loop.call_soon_threadsafe(release_started.set)
         assert finish_release.wait(timeout=5)
 
@@ -50,14 +51,14 @@ async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: Mo
     await release_started.wait()
     task.cancel("cancel release")
     finish_release.set()
-    with pytest.raises(asyncio.CancelledError):  # pragma: win32 no cover
+    with pytest.raises(asyncio.CancelledError):
         await task
     assert (lock.is_locked, lock.lock_counter) == (False, 0)
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio  # pragma: win32 no cover
+@_NEEDS_FCNTL
+@pytest.mark.asyncio  # pragma: needs fcntl
 async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(tmp_path / "a")
     await lock.acquire()
@@ -68,9 +69,9 @@ async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path,
     real_flock = fcntl.flock
     blocked = False
 
-    def block_first_unlock(fd: int, operation: int) -> None:  # pragma: win32 no cover
+    def block_first_unlock(fd: int, operation: int) -> None:
         nonlocal blocked
-        if operation & fcntl.LOCK_UN and not blocked:  # pragma: win32 no cover
+        if operation & fcntl.LOCK_UN and not blocked:
             blocked = True
             loop.call_soon_threadsafe(release_started.set)
             assert finish_release.wait(timeout=5)
@@ -82,8 +83,8 @@ async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path,
     second_release = asyncio.create_task(lock.release())
     await asyncio.sleep(0)
     second_release.cancel("abandon queued release")
-    try:  # pragma: win32 no cover
-        with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
+    try:
+        with pytest.raises(asyncio.CancelledError) as info:
             await second_release
         assert_cancellation_message(info.value, "abandon queued release")
         acquire = asyncio.create_task(lock.acquire())
@@ -97,14 +98,14 @@ async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path,
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.asyncio
-async def test_release_waits_for_provisional_acquire(tmp_path: Path) -> None:  # pragma: win32 no cover
+async def test_release_waits_for_provisional_acquire(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def block_hook(_fd: int) -> None:
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -113,7 +114,7 @@ async def test_release_waits_for_provisional_acquire(tmp_path: Path) -> None:  #
     await hook_started.wait()
     release_started = asyncio.Event()
 
-    async def release() -> None:  # pragma: win32 no cover
+    async def release() -> None:
         release_started.set()
         await lock.release()
 
@@ -154,10 +155,10 @@ async def test_release_returns_while_acquire_waits_for_external_holder(tmp_path:
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
-async def test_release_cancellation_surfaces_backend_error(  # pragma: win32 no cover
+async def test_release_cancellation_surfaces_backend_error(  # pragma: needs fcntl
     tmp_path: Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture, policy: ContextErrorPolicy
 ) -> None:
     lock = AsyncFileLock(tmp_path / "a", context_error_policy=policy)
@@ -168,10 +169,10 @@ async def test_release_cancellation_surfaces_backend_error(  # pragma: win32 no 
     release_error = OSError(EIO, "release failed")
     release_count = 0
 
-    def fail_first_unlock(_fd: int, _operation: int) -> None:  # pragma: win32 no cover
+    def fail_first_unlock(_fd: int, _operation: int) -> None:
         nonlocal release_count
         release_count += 1
-        if release_count == 1:  # pragma: win32 no cover
+        if release_count == 1:
             loop.call_soon_threadsafe(release_started.set)
             assert finish_release.wait(timeout=5)
             raise release_error
@@ -182,13 +183,13 @@ async def test_release_cancellation_surfaces_backend_error(  # pragma: win32 no 
     task.cancel("cancel release")
     finish_release.set()
 
-    if policy == "chain":  # pragma: win32 no cover
-        with pytest.raises(OSError, match="release failed") as info:  # pragma: win32 no cover
+    if policy == "chain":
+        with pytest.raises(OSError, match="release failed") as info:
             await task
         cancellation = info.value.__context__
         assert info.value is release_error
-    else:  # pragma: win32 no cover
-        with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    else:
+        with pytest.raises(BaseExceptionGroup) as info:
             await task
         cancellation, grouped_release_error = info.value.exceptions
         assert grouped_release_error is release_error

--- a/tests/test_async_filelock_release_cancellation.py
+++ b/tests/test_async_filelock_release_cancellation.py
@@ -33,7 +33,7 @@ _UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
 
 
 @_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))
     await lock.acquire()
@@ -41,7 +41,7 @@ async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: Mo
     finish_release = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_unlock(_fd: int, _operation: int) -> None:
+    def block_unlock(_fd: int, _operation: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(release_started.set)
         assert finish_release.wait(timeout=5)
 
@@ -50,14 +50,14 @@ async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: Mo
     await release_started.wait()
     task.cancel("cancel release")
     finish_release.set()
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(asyncio.CancelledError):  # pragma: win32 no cover
         await task
     assert (lock.is_locked, lock.lock_counter) == (False, 0)
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
 @_UNIX_FLOCK_ONLY
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(tmp_path / "a")
     await lock.acquire()
@@ -68,9 +68,9 @@ async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path,
     real_flock = fcntl.flock
     blocked = False
 
-    def block_first_unlock(fd: int, operation: int) -> None:
+    def block_first_unlock(fd: int, operation: int) -> None:  # pragma: win32 no cover
         nonlocal blocked
-        if operation & fcntl.LOCK_UN and not blocked:
+        if operation & fcntl.LOCK_UN and not blocked:  # pragma: win32 no cover
             blocked = True
             loop.call_soon_threadsafe(release_started.set)
             assert finish_release.wait(timeout=5)
@@ -82,8 +82,8 @@ async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path,
     second_release = asyncio.create_task(lock.release())
     await asyncio.sleep(0)
     second_release.cancel("abandon queued release")
-    try:
-        with pytest.raises(asyncio.CancelledError) as info:
+    try:  # pragma: win32 no cover
+        with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
             await second_release
         assert_cancellation_message(info.value, "abandon queued release")
         acquire = asyncio.create_task(lock.acquire())
@@ -99,12 +99,12 @@ async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path,
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_release_waits_for_provisional_acquire(tmp_path: Path) -> None:
+async def test_release_waits_for_provisional_acquire(tmp_path: Path) -> None:  # pragma: win32 no cover
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:
+    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -113,7 +113,7 @@ async def test_release_waits_for_provisional_acquire(tmp_path: Path) -> None:
     await hook_started.wait()
     release_started = asyncio.Event()
 
-    async def release() -> None:
+    async def release() -> None:  # pragma: win32 no cover
         release_started.set()
         await lock.release()
 
@@ -157,7 +157,7 @@ async def test_release_returns_while_acquire_waits_for_external_holder(tmp_path:
 @_UNIX_FLOCK_ONLY
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
-async def test_release_cancellation_surfaces_backend_error(
+async def test_release_cancellation_surfaces_backend_error(  # pragma: win32 no cover
     tmp_path: Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture, policy: ContextErrorPolicy
 ) -> None:
     lock = AsyncFileLock(tmp_path / "a", context_error_policy=policy)
@@ -168,10 +168,10 @@ async def test_release_cancellation_surfaces_backend_error(
     release_error = OSError(EIO, "release failed")
     release_count = 0
 
-    def fail_first_unlock(_fd: int, _operation: int) -> None:
+    def fail_first_unlock(_fd: int, _operation: int) -> None:  # pragma: win32 no cover
         nonlocal release_count
         release_count += 1
-        if release_count == 1:
+        if release_count == 1:  # pragma: win32 no cover
             loop.call_soon_threadsafe(release_started.set)
             assert finish_release.wait(timeout=5)
             raise release_error
@@ -182,13 +182,13 @@ async def test_release_cancellation_surfaces_backend_error(
     task.cancel("cancel release")
     finish_release.set()
 
-    if policy == "chain":
-        with pytest.raises(OSError, match="release failed") as info:
+    if policy == "chain":  # pragma: win32 no cover
+        with pytest.raises(OSError, match="release failed") as info:  # pragma: win32 no cover
             await task
         cancellation = info.value.__context__
         assert info.value is release_error
-    else:
-        with pytest.raises(BaseExceptionGroup) as info:
+    else:  # pragma: win32 no cover
+        with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
             await task
         cancellation, grouped_release_error = info.value.exceptions
         assert grouped_release_error is release_error

--- a/tests/test_async_filelock_rollback_agnostic.py
+++ b/tests/test_async_filelock_rollback_agnostic.py
@@ -10,7 +10,7 @@ import pytest
 from filelock import AsyncFileLock, BaseAsyncFileLock
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
-    from builtins import BaseExceptionGroup, ExceptionGroup
+    from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: no cover (<py311)
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 

--- a/tests/test_async_filelock_rollback_agnostic.py
+++ b/tests/test_async_filelock_rollback_agnostic.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from errno import EIO
+from typing import TYPE_CHECKING
+
+import pytest
+
+from filelock import AsyncFileLock, BaseAsyncFileLock
+
+if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+    from builtins import BaseExceptionGroup, ExceptionGroup
+else:  # pragma: no cover (<py311)
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_release_serialized_skips_when_peer_already_released(tmp_path: Path) -> None:
+    release_started = asyncio.Event()
+    finish_release = asyncio.Event()
+    releases = 0
+
+    class Lock(BaseAsyncFileLock):
+        async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]
+            self._context.lock_file_fd = 1
+
+        async def _release(self) -> None:  # ty: ignore[invalid-method-override]
+            nonlocal releases
+            releases += 1
+            release_started.set()
+            await finish_release.wait()
+            self._context.lock_file_fd = None
+
+    lock = Lock(tmp_path / "a", run_in_executor=False)
+    await lock.acquire()
+    first = asyncio.create_task(lock.release())
+    await release_started.wait()
+    second = asyncio.create_task(lock.release())
+    await asyncio.sleep(0)  # let the queued release block on the transition gate before the holder unlocks
+    finish_release.set()
+    await first
+    await second
+
+    assert releases == 1  # the queued release found the lock already gone and did no backend work
+    assert (lock.is_locked, lock.lock_counter) == (False, 0)
+
+
+@pytest.mark.asyncio
+async def test_release_cancellation_surfaces_backend_error(tmp_path: Path) -> None:
+    backend_error = OSError(EIO, "backend release failed")
+    release_started = asyncio.Event()
+    finish_release = asyncio.Event()
+    fail_release = True
+
+    class Lock(BaseAsyncFileLock):
+        async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]
+            self._context.lock_file_fd = 1
+
+        async def _release(self) -> None:  # ty: ignore[invalid-method-override]
+            if fail_release:
+                release_started.set()
+                await finish_release.wait()
+                raise backend_error
+            self._context.lock_file_fd = None
+
+    lock = Lock(tmp_path / "a", run_in_executor=False)
+    await lock.acquire()
+    task = asyncio.create_task(lock.release())
+    await release_started.wait()
+    task.cancel("cancel release")
+    finish_release.set()
+
+    with pytest.raises(OSError, match="backend release failed") as info:
+        await task
+    assert info.value is backend_error
+    assert isinstance(info.value.__context__, asyncio.CancelledError)
+    assert (lock.is_locked, lock.lock_counter) == (True, 1)  # backend failed before unlocking, so state is kept
+
+    fail_release = False
+    await lock.release()
+    assert (lock.is_locked, lock.lock_counter) == (False, 0)
+
+
+@pytest.mark.asyncio
+async def test_acquire_cancellation_rollback_failure_surfaces_backend_error(tmp_path: Path) -> None:
+    rollback_error = OSError(EIO, "rollback release failed")
+    acquire_started = asyncio.Event()
+    finish_acquire = asyncio.Event()
+    fail_release = True
+
+    class Lock(BaseAsyncFileLock):
+        async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]
+            acquire_started.set()
+            await finish_acquire.wait()
+            self._context.lock_file_fd = 1
+
+        async def _release(self) -> None:  # ty: ignore[invalid-method-override]
+            if fail_release:
+                raise rollback_error
+            self._context.lock_file_fd = None
+
+    lock = Lock(tmp_path / "a", run_in_executor=False)
+    task = asyncio.create_task(lock.acquire())
+    await acquire_started.wait()
+    task.cancel("cancel acquire")
+    finish_acquire.set()  # let the backend finish acquiring, so cancellation must roll the acquired lock back
+
+    with pytest.raises(OSError, match="rollback release failed") as info:
+        await task
+    assert info.value is rollback_error
+    assert isinstance(info.value.__context__, asyncio.CancelledError)
+    assert (lock.is_locked, lock.lock_counter) == (True, 1)  # rollback failed before unlocking, so state is kept
+
+    fail_release = False
+    await lock.release()
+    assert (lock.is_locked, lock.lock_counter) == (False, 0)
+
+
+@pytest.mark.asyncio
+async def test_registration_failure_rolls_back_and_surfaces_cleanup(tmp_path: Path) -> None:
+    registration_error = RuntimeError("registration failed")
+    rollback_error = OSError(EIO, "rollback release failed")
+    fail_release = True
+
+    class Lock(BaseAsyncFileLock):
+        async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]
+            self._context.lock_file_fd = 1
+
+        async def _release(self) -> None:  # ty: ignore[invalid-method-override]
+            if fail_release:
+                raise rollback_error
+            self._context.lock_file_fd = None
+
+        def _register_context_descriptor(self) -> None:  # ruff:ignore[no-self-use]  # overrides a base instance method
+            raise registration_error
+
+    lock = Lock(tmp_path / "a", run_in_executor=False)
+    with pytest.raises(ExceptionGroup) as info:
+        await lock.acquire()
+    assert info.value.message == "descriptor registration cleanup failed"
+    assert info.value.exceptions == (registration_error, rollback_error)
+    assert (lock.is_locked, lock.lock_counter) == (True, 1)  # rollback failed before unlocking, so state is kept
+
+    fail_release = False
+    await lock.release()
+    assert (lock.is_locked, lock.lock_counter) == (False, 0)
+
+
+@pytest.mark.parametrize(
+    "rollback_fails",
+    [pytest.param(True, id="rollback-fails"), pytest.param(False, id="rollback-succeeds")],
+)
+@pytest.mark.asyncio
+async def test_acquire_failure_with_registration_failure_rolls_back(tmp_path: Path, *, rollback_fails: bool) -> None:
+    acquisition_error = RuntimeError("acquire failed")
+    registration_error = LookupError("registration failed")
+    rollback_error = OSError(EIO, "rollback release failed")
+    fail_release = rollback_fails
+
+    class Lock(BaseAsyncFileLock):
+        async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]
+            self._context.lock_file_fd = 1
+            raise acquisition_error
+
+        async def _release(self) -> None:  # ty: ignore[invalid-method-override]
+            if fail_release:
+                raise rollback_error
+            self._context.lock_file_fd = None
+
+        def _register_context_descriptor(self) -> None:  # ruff:ignore[no-self-use]  # overrides a base instance method
+            raise registration_error
+
+    lock = Lock(tmp_path / "a", run_in_executor=False)
+    with pytest.raises(ExceptionGroup) as info:
+        await lock.acquire()
+    assert info.value.message == "lock acquisition cleanup failed"
+    if rollback_fails:
+        assert info.value.exceptions == (acquisition_error, registration_error, rollback_error)
+        assert (lock.is_locked, lock.lock_counter) == (True, 1)  # rollback failed before unlocking, so state is kept
+        fail_release = False
+        await lock.release()
+    else:
+        assert info.value.exceptions == (acquisition_error, registration_error)
+    assert (lock.is_locked, lock.lock_counter) == (False, 0)
+
+
+@pytest.mark.asyncio
+async def test_context_group_reconciles_release_cancellation_with_backend_error(tmp_path: Path) -> None:
+    body_error = ValueError("body failed")
+    backend_error = OSError(EIO, "backend release failed")
+    release_started = asyncio.Event()
+    finish_release = asyncio.Event()
+    fail_release = True
+
+    class Lock(BaseAsyncFileLock):
+        async def _acquire(self) -> None:  # ty: ignore[invalid-method-override]
+            self._context.lock_file_fd = 1
+
+        async def _release(self) -> None:  # ty: ignore[invalid-method-override]
+            if fail_release:
+                release_started.set()
+                await finish_release.wait()
+                raise backend_error
+            self._context.lock_file_fd = None
+
+    lock = Lock(tmp_path / "a", run_in_executor=False, context_error_policy="group")
+
+    async def run_context() -> None:
+        async with lock:
+            raise body_error
+
+    task = asyncio.create_task(run_context())
+    await release_started.wait()
+    task.cancel("cancel release")
+    finish_release.set()
+
+    with pytest.raises(BaseExceptionGroup) as info:
+        await task
+    grouped_body, grouped_cancellation, grouped_backend = info.value.exceptions
+    assert info.value.message == "context body, release cancellation, and backend release failed"
+    assert (grouped_body, grouped_backend) == (body_error, backend_error)
+    assert isinstance(grouped_cancellation, asyncio.CancelledError)
+    assert (lock.is_locked, lock.lock_counter) == (True, 1)  # backend failed before unlocking, so state is kept
+
+    fail_release = False
+    await lock.release()
+    assert (lock.is_locked, lock.lock_counter) == (False, 0)
+
+
+def test_sync_context_exit_is_unsupported(tmp_path: Path) -> None:
+    # __enter__ already raises, so the with-statement never reaches __exit__; call the protocol method directly.
+    lock = AsyncFileLock(str(tmp_path / "a"))
+    with pytest.raises(NotImplementedError, match=r"async with"):
+        lock.__exit__(None, None, None)

--- a/tests/test_async_filelock_runner_shutdown.py
+++ b/tests/test_async_filelock_runner_shutdown.py
@@ -30,7 +30,7 @@ _T = TypeVar("_T")
 
 
 class _CancellationObservedTask(asyncio.Task[_T]):
-    def __init__(
+    def __init__(  # pragma: win32 no cover
         self,
         coroutine: Coroutine[None, None, _T],
         cancellation_seen: threading.Event,
@@ -40,19 +40,19 @@ class _CancellationObservedTask(asyncio.Task[_T]):
         self._cancellation_seen = cancellation_seen
         super().__init__(coroutine, loop=loop)
 
-    def cancel(self, msg: object | None = None) -> bool:
+    def cancel(self, msg: object | None = None) -> bool:  # pragma: win32 no cover
         # Task.cancel accepts arbitrary payloads; object is the narrowest accurate type for its public contract.
         self._cancellation_seen.set()
         return super().cancel(msg)
 
 
 @_UNIX_FLOCK_ONLY
-def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> None:
+def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> None:  # pragma: win32 no cover
     hook_started = threading.Event()
     finish_hook = threading.Event()
     cancellation_seen = threading.Event()
 
-    def block_hook(_fd: int) -> None:
+    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
         hook_started.set()
         assert finish_hook.wait(timeout=5)
 
@@ -63,7 +63,7 @@ def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> 
         args=(lock, hook_started, cancellation_seen, tasks),
     )
     runner.start()
-    try:
+    try:  # pragma: win32 no cover
         tasks.get(timeout=5)
         assert hook_started.wait(timeout=5)
         assert cancellation_seen.wait(timeout=5), "asyncio runner did not cancel the pending lock task"
@@ -77,7 +77,7 @@ def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> 
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
-def test_runner_shutdown_preserves_body_cancellation_and_release_errors(
+def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # pragma: win32 no cover
     tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
 ) -> None:
     body_error = ValueError("body failed")
@@ -90,9 +90,9 @@ def test_runner_shutdown_preserves_body_cancellation_and_release_errors(
     fcntl = get_fcntl()
     real_flock = fcntl.flock
 
-    def fail_first_unlock(fd: int, operation: int) -> None:
+    def fail_first_unlock(fd: int, operation: int) -> None:  # pragma: win32 no cover
         nonlocal failed
-        if operation & fcntl.LOCK_UN and not failed:
+        if operation & fcntl.LOCK_UN and not failed:  # pragma: win32 no cover
             failed = True
             release_started.set()
             assert finish_release.wait(timeout=5)
@@ -106,7 +106,7 @@ def test_runner_shutdown_preserves_body_cancellation_and_release_errors(
         body_error,
         release_started,
     )
-    try:
+    try:  # pragma: win32 no cover
         assert release_started.wait(timeout=5)
         assert cancellation_seen.wait(timeout=5), "asyncio runner did not cancel the pending lock task"
     finally:
@@ -115,12 +115,12 @@ def test_runner_shutdown_preserves_body_cancellation_and_release_errors(
 
     assert (runner.is_alive(), task.done()) == (False, True)
     error = task.exception()
-    if policy == "chain":
+    if policy == "chain":  # pragma: win32 no cover
         assert error is release_error
         cancellation = release_error.__context__
         assert isinstance(cancellation, asyncio.CancelledError)
         assert (cancellation.__context__, prior_error.__context__) == (prior_error, body_error)
-    else:
+    else:  # pragma: win32 no cover
         assert isinstance(error, BaseExceptionGroup)
         cancellation = error.exceptions[1]
         assert isinstance(cancellation, asyncio.CancelledError)
@@ -136,13 +136,13 @@ def test_runner_shutdown_preserves_body_cancellation_and_release_errors(
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-def _run_unawaited_acquire(
+def _run_unawaited_acquire(  # pragma: win32 no cover
     lock: AsyncFileLock,
     hook_started: threading.Event,
     cancellation_seen: threading.Event,
     tasks: Queue[asyncio.Task[AsyncAcquireReturnProxy]],
 ) -> None:
-    async def start_acquire() -> None:
+    async def start_acquire() -> None:  # pragma: win32 no cover
         tasks.put(
             _CancellationObservedTask(
                 lock.acquire(),
@@ -155,7 +155,7 @@ def _run_unawaited_acquire(
     asyncio.run(start_acquire())
 
 
-def _start_unawaited_context_failure(
+def _start_unawaited_context_failure(  # pragma: win32 no cover
     lock: AsyncFileLock,
     body_error: BaseException,
     release_started: threading.Event,
@@ -171,18 +171,18 @@ def _start_unawaited_context_failure(
     return runner, task, cancellation_seen
 
 
-def _run_unawaited_context_failure(
+def _run_unawaited_context_failure(  # pragma: win32 no cover
     lock: AsyncFileLock,
     body_error: BaseException,
     release_started: threading.Event,
     cancellation_seen: threading.Event,
     tasks: Queue[asyncio.Task[None]],
 ) -> None:
-    async def fail_in_context() -> None:
-        async with lock:
+    async def fail_in_context() -> None:  # pragma: win32 no cover
+        async with lock:  # pragma: win32 no cover
             raise body_error
 
-    async def start_context() -> None:
+    async def start_context() -> None:  # pragma: win32 no cover
         tasks.put(
             _CancellationObservedTask(
                 fail_in_context(),

--- a/tests/test_async_filelock_runner_shutdown.py
+++ b/tests/test_async_filelock_runner_shutdown.py
@@ -4,6 +4,7 @@ import asyncio
 import sys
 import threading
 from errno import EIO
+from importlib.util import find_spec
 from queue import Queue
 from typing import TYPE_CHECKING, Final, TypeVar
 
@@ -23,14 +24,14 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    sys.platform == "win32", reason="native flock semantics are Unix-only"
+_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    find_spec("fcntl") is None, reason="native flock semantics come from the fcntl module"
 )
 _T = TypeVar("_T")
 
 
-class _CancellationObservedTask(asyncio.Task[_T]):
-    def __init__(  # pragma: win32 no cover
+class _CancellationObservedTask(asyncio.Task[_T]):  # pragma: needs fcntl
+    def __init__(
         self,
         coroutine: Coroutine[None, None, _T],
         cancellation_seen: threading.Event,
@@ -40,19 +41,19 @@ class _CancellationObservedTask(asyncio.Task[_T]):
         self._cancellation_seen = cancellation_seen
         super().__init__(coroutine, loop=loop)
 
-    def cancel(self, msg: object | None = None) -> bool:  # pragma: win32 no cover
+    def cancel(self, msg: object | None = None) -> bool:
         # Task.cancel accepts arbitrary payloads; object is the narrowest accurate type for its public contract.
         self._cancellation_seen.set()
         return super().cancel(msg)
 
 
-@_UNIX_FLOCK_ONLY
-def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL
+def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_started = threading.Event()
     finish_hook = threading.Event()
     cancellation_seen = threading.Event()
 
-    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def block_hook(_fd: int) -> None:
         hook_started.set()
         assert finish_hook.wait(timeout=5)
 
@@ -63,7 +64,7 @@ def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> 
         args=(lock, hook_started, cancellation_seen, tasks),
     )
     runner.start()
-    try:  # pragma: win32 no cover
+    try:
         tasks.get(timeout=5)
         assert hook_started.wait(timeout=5)
         assert cancellation_seen.wait(timeout=5), "asyncio runner did not cancel the pending lock task"
@@ -75,9 +76,9 @@ def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> 
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
-def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # pragma: win32 no cover
+def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # pragma: needs fcntl
     tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
 ) -> None:
     body_error = ValueError("body failed")
@@ -90,9 +91,9 @@ def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # prag
     fcntl = get_fcntl()
     real_flock = fcntl.flock
 
-    def fail_first_unlock(fd: int, operation: int) -> None:  # pragma: win32 no cover
+    def fail_first_unlock(fd: int, operation: int) -> None:
         nonlocal failed
-        if operation & fcntl.LOCK_UN and not failed:  # pragma: win32 no cover
+        if operation & fcntl.LOCK_UN and not failed:
             failed = True
             release_started.set()
             assert finish_release.wait(timeout=5)
@@ -106,7 +107,7 @@ def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # prag
         body_error,
         release_started,
     )
-    try:  # pragma: win32 no cover
+    try:
         assert release_started.wait(timeout=5)
         assert cancellation_seen.wait(timeout=5), "asyncio runner did not cancel the pending lock task"
     finally:
@@ -115,12 +116,12 @@ def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # prag
 
     assert (runner.is_alive(), task.done()) == (False, True)
     error = task.exception()
-    if policy == "chain":  # pragma: win32 no cover
+    if policy == "chain":
         assert error is release_error
         cancellation = release_error.__context__
         assert isinstance(cancellation, asyncio.CancelledError)
         assert (cancellation.__context__, prior_error.__context__) == (prior_error, body_error)
-    else:  # pragma: win32 no cover
+    else:
         assert isinstance(error, BaseExceptionGroup)
         cancellation = error.exceptions[1]
         assert isinstance(cancellation, asyncio.CancelledError)
@@ -136,13 +137,13 @@ def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # prag
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-def _run_unawaited_acquire(  # pragma: win32 no cover
+def _run_unawaited_acquire(  # pragma: needs fcntl
     lock: AsyncFileLock,
     hook_started: threading.Event,
     cancellation_seen: threading.Event,
     tasks: Queue[asyncio.Task[AsyncAcquireReturnProxy]],
 ) -> None:
-    async def start_acquire() -> None:  # pragma: win32 no cover
+    async def start_acquire() -> None:
         tasks.put(
             _CancellationObservedTask(
                 lock.acquire(),
@@ -155,7 +156,7 @@ def _run_unawaited_acquire(  # pragma: win32 no cover
     asyncio.run(start_acquire())
 
 
-def _start_unawaited_context_failure(  # pragma: win32 no cover
+def _start_unawaited_context_failure(  # pragma: needs fcntl
     lock: AsyncFileLock,
     body_error: BaseException,
     release_started: threading.Event,
@@ -171,18 +172,18 @@ def _start_unawaited_context_failure(  # pragma: win32 no cover
     return runner, task, cancellation_seen
 
 
-def _run_unawaited_context_failure(  # pragma: win32 no cover
+def _run_unawaited_context_failure(  # pragma: needs fcntl
     lock: AsyncFileLock,
     body_error: BaseException,
     release_started: threading.Event,
     cancellation_seen: threading.Event,
     tasks: Queue[asyncio.Task[None]],
 ) -> None:
-    async def fail_in_context() -> None:  # pragma: win32 no cover
-        async with lock:  # pragma: win32 no cover
+    async def fail_in_context() -> None:
+        async with lock:
             raise body_error
 
-    async def start_context() -> None:  # pragma: win32 no cover
+    async def start_context() -> None:
         tasks.put(
             _CancellationObservedTask(
                 fail_in_context(),

--- a/tests/test_async_filelock_runner_shutdown.py
+++ b/tests/test_async_filelock_runner_shutdown.py
@@ -14,7 +14,7 @@ from async_filelock_cancellation_helpers import assert_file_lock_state, get_fcnt
 from filelock import AsyncAcquireReturnProxy, AsyncFileLock, ContextErrorPolicy
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
-    from builtins import BaseExceptionGroup
+    from builtins import BaseExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: no cover (<py311)
     from exceptiongroup import BaseExceptionGroup
 

--- a/tests/test_async_filelock_transition_admission.py
+++ b/tests/test_async_filelock_transition_admission.py
@@ -80,12 +80,12 @@ async def test_queued_acquire_honors_own_admission_policy(
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
-async def test_queued_acquire_proceeds_after_prior_waiter_cancels(tmp_path: Path) -> None:
+async def test_queued_acquire_proceeds_after_prior_waiter_cancels(tmp_path: Path) -> None:  # pragma: win32 no cover
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
     loop = asyncio.get_running_loop()
 
-    def block_hook(_fd: int) -> None:
+    def block_hook(_fd: int) -> None:  # pragma: win32 no cover
         loop.call_soon_threadsafe(hook_started.set)
         assert finish_hook.wait(timeout=5)
 
@@ -97,8 +97,8 @@ async def test_queued_acquire_proceeds_after_prior_waiter_cancels(tmp_path: Path
     third_task, third_started = _start_signaled_acquire(lock)
     await third_started.wait()
     second_task.cancel("abandon queued acquire")
-    try:
-        with pytest.raises(asyncio.CancelledError) as info:
+    try:  # pragma: win32 no cover
+        with pytest.raises(asyncio.CancelledError) as info:  # pragma: win32 no cover
             await second_task
         assert_cancellation_message(info.value, "abandon queued acquire")
     finally:
@@ -113,10 +113,10 @@ async def test_queued_acquire_proceeds_after_prior_waiter_cancels(tmp_path: Path
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-def _start_signaled_acquire(lock: AsyncFileLock) -> tuple[asyncio.Task[None], asyncio.Event]:
+def _start_signaled_acquire(lock: AsyncFileLock) -> tuple[asyncio.Task[None], asyncio.Event]:  # pragma: win32 no cover
     started = asyncio.Event()
 
-    async def acquire() -> None:
+    async def acquire() -> None:  # pragma: win32 no cover
         started.set()
         await lock.acquire()
 

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -253,6 +253,15 @@ async def test_context_manager_uses_instance_defaults(lock_file: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_context_manager_overrides_defaults(lock_file: str) -> None:
+    lock = AsyncReadWriteLock(lock_file, timeout=10.0, blocking=False, is_singleton=False)
+    async with lock.read_lock(timeout=5.0, blocking=True):
+        assert_mode_held(lock_file, "read")
+    async with lock.write_lock(timeout=5.0, blocking=True):
+        assert_mode_held(lock_file, "write")
+
+
+@pytest.mark.asyncio
 async def test_sequential_mode_switch(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     async with lock.read_lock():

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -22,7 +22,7 @@ def _clear_singleton_cache() -> Generator[None]:
     ReadWriteLock._instances.clear()
     yield
     for ref in list(ReadWriteLock._instances.valuerefs()):
-        if (lock := ref()) is not None:
+        if (lock := ref()) is not None:  # pragma: no cover  # cache is normally emptied before teardown
             lock.close()
     ReadWriteLock._instances.clear()
 

--- a/tests/test_async_read_write_cancellation.py
+++ b/tests/test_async_read_write_cancellation.py
@@ -357,7 +357,7 @@ def _cancel_queued_read_write_acquire(lock_file: str, cancel_caller: bool, cance
             await task
         except asyncio.CancelledError as error:
             context = error.__context__
-            if cancel_caller and sys.version_info >= (3, 11):
+            if cancel_caller and sys.version_info >= (3, 11):  # pragma: >=3.11 cover
                 canceled.value = isinstance(context, asyncio.CancelledError) and context.args == ("caller canceled",)
             else:
                 canceled.value = True

--- a/tests/test_async_soft_contracts.py
+++ b/tests/test_async_soft_contracts.py
@@ -23,7 +23,7 @@ def marker(tmp_path: Path) -> Path:
 
 @pytest.mark.requires_hard_links
 @pytest.mark.asyncio
-async def test_async_strict_treats_a_foreign_marker_as_contention(marker: Path) -> None:
+async def test_async_strict_treats_a_foreign_marker_as_contention(marker: Path) -> None:  # pragma: needs hard-link
     await asyncio.to_thread(marker.write_text, "filelock/2\npid=999999\nhost=nowhere\nmode=strict\n", encoding="utf-8")
     lock = AsyncStrictSoftFileLock(str(marker), timeout=0.2)
 
@@ -34,7 +34,7 @@ async def test_async_strict_treats_a_foreign_marker_as_contention(marker: Path) 
 
 @pytest.mark.requires_hard_links
 @pytest.mark.asyncio
-async def test_async_strict_publishes_a_held_claim(marker: Path) -> None:
+async def test_async_strict_publishes_a_held_claim(marker: Path) -> None:  # pragma: needs hard-link
     lock = AsyncStrictSoftFileLock(str(marker))
 
     async with lock:

--- a/tests/test_async_soft_contracts.py
+++ b/tests/test_async_soft_contracts.py
@@ -59,13 +59,13 @@ async def test_async_lease_heartbeat_keeps_a_live_claim(marker: Path) -> None:
     reason="Windows keeps an open marker undeletable, so no peer can take it from a live holder",
 )
 @pytest.mark.asyncio
-async def test_async_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:
+async def test_async_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:  # pragma: win32 no cover
     seen: list[LeaseCompromise] = []
     lease = AsyncSoftFileLease(
         str(marker), lease_duration=_DURATION, heartbeat_interval=_HEARTBEAT, on_compromise=seen.append
     )
 
-    async with lease:
+    async with lease:  # pragma: win32 no cover
         await asyncio.to_thread(marker.unlink)
         await asyncio.sleep(_HEARTBEAT * 5)
 

--- a/tests/test_async_transition_gate.py
+++ b/tests/test_async_transition_gate.py
@@ -81,7 +81,6 @@ async def test_wait_for_predecessor_returns_immediately_when_already_done() -> N
     predecessor: ConcurrentFuture[None] = ConcurrentFuture()
     predecessor.set_result(None)
 
-    # An already-resolved predecessor means the wait loop never runs its body: the guard falls straight through.
     await _AsyncTransitionGate._wait_for_predecessor(
         predecessor, blocking=True, cancel_check=None, deadline=None, poll_interval=0.01
     )

--- a/tests/test_async_transition_gate.py
+++ b/tests/test_async_transition_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import Future as ConcurrentFuture
 
 import pytest
 
@@ -49,7 +50,7 @@ async def test_hold_canceled_while_waiting_lets_the_predecessor_free_the_ticket(
 
     async def second() -> None:
         async with gate.hold():  # never reached: canceled while waiting on first
-            pass
+            pass  # pragma: no cover  # the hold body never runs: the waiter is canceled while parked in hold()
 
     first_task = asyncio.create_task(first())
     await first_holding.wait()
@@ -72,3 +73,17 @@ async def test_hold_canceled_while_waiting_lets_the_predecessor_free_the_ticket(
 
     await asyncio.wait_for(third(), timeout=1)
     assert entered.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_wait_for_predecessor_returns_immediately_when_already_done() -> None:
+    predecessor: ConcurrentFuture[None] = ConcurrentFuture()
+    predecessor.set_result(None)
+
+    # An already-resolved predecessor means the wait loop never runs its body: the guard falls straight through.
+    await _AsyncTransitionGate._wait_for_predecessor(
+        predecessor, blocking=True, cancel_check=None, deadline=None, poll_interval=0.01
+    )
+
+    assert predecessor.done()

--- a/tests/test_async_transition_gate.py
+++ b/tests/test_async_transition_gate.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from filelock._async import _AsyncTransitionGate
+
+
+@pytest.mark.asyncio
+async def test_hold_waits_for_a_predecessor_before_entering() -> None:
+    gate = _AsyncTransitionGate()
+    order: list[str] = []
+    first_holding = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def first() -> None:
+        async with gate.hold():
+            first_holding.set()
+            order.append("first-in")
+            await release_first.wait()
+        order.append("first-out")
+
+    async def second() -> None:
+        async with gate.hold():
+            order.append("second-in")
+
+    first_task = asyncio.create_task(first())
+    await first_holding.wait()
+    second_task = asyncio.create_task(second())
+    await asyncio.sleep(0.05)  # second parks on the predecessor instead of entering
+    assert order == ["first-in"]
+
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+    assert order == ["first-in", "first-out", "second-in"]
+
+
+@pytest.mark.asyncio
+async def test_hold_canceled_while_waiting_lets_the_predecessor_free_the_ticket() -> None:
+    gate = _AsyncTransitionGate()
+    first_holding = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def first() -> None:
+        async with gate.hold():
+            first_holding.set()
+            await release_first.wait()
+
+    async def second() -> None:
+        async with gate.hold():  # never reached: canceled while waiting on first
+            pass
+
+    first_task = asyncio.create_task(first())
+    await first_holding.wait()
+    second_task = asyncio.create_task(second())
+    await asyncio.sleep(0.05)  # second is parked on the predecessor
+    second_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await second_task
+
+    release_first.set()
+    await first_task
+
+    # The canceled waiter registered a callback so the predecessor frees its abandoned ticket; a fresh holder must
+    # then enter without waiting on a tail that no coroutine will ever leave.
+    entered = asyncio.Event()
+
+    async def third() -> None:
+        async with gate.hold():
+            entered.set()
+
+    await asyncio.wait_for(third(), timeout=1)
+    assert entered.is_set()

--- a/tests/test_default_mode.py
+++ b/tests/test_default_mode.py
@@ -53,12 +53,12 @@ def test_open_mode(lock_type: type[BaseFileLock], mode: int, expected: int, tmp_
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not apply umask to file permissions")
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_default_mode_respects_umask(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+def test_default_mode_respects_umask(lock_type: type[BaseFileLock], tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "a.lock"
     lock = lock_type(str(lock_path))
 
     initial_umask = os.umask(0o022)
-    try:
+    try:  # pragma: win32 no cover
         lock.acquire()
         assert lock.is_locked
         assert filemode(lock_path.stat().st_mode) == "-rw-r--r--"
@@ -69,7 +69,7 @@ def test_default_mode_respects_umask(lock_type: type[BaseFileLock], tmp_path: Pa
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fchmod only on Unix")
-def test_default_mode_skips_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
+def test_default_mode_skips_fchmod(tmp_path: Path, mocker: MagicMock) -> None:  # pragma: win32 no cover
     lock = FileLock(str(tmp_path / "a.lock"))
 
     fchmod_spy = mocker.patch("os.fchmod")
@@ -80,7 +80,7 @@ def test_default_mode_skips_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fchmod only on Unix")
-def test_explicit_mode_calls_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
+def test_explicit_mode_calls_fchmod(tmp_path: Path, mocker: MagicMock) -> None:  # pragma: win32 no cover
     lock = FileLock(str(tmp_path / "a.lock"), mode=0o644)
 
     fchmod_spy = mocker.spy(os, "fchmod")
@@ -92,12 +92,12 @@ def test_explicit_mode_calls_fchmod(tmp_path: Path, mocker: MagicMock) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fchmod only on Unix")
-def test_explicit_mode_overrides_umask(tmp_path: Path) -> None:
+def test_explicit_mode_overrides_umask(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "a.lock"
     lock = FileLock(str(lock_path), mode=0o666)
 
     initial_umask = os.umask(0o022)
-    try:
+    try:  # pragma: win32 no cover
         lock.acquire()
         assert lock.is_locked
         assert filemode(lock_path.stat().st_mode) == "-rw-rw-rw-"

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -34,7 +34,7 @@ from filelock import (
     lock_descriptor,
     unlock_descriptor,
 )
-from filelock._api import _raise_grouped_errors
+from filelock._api import _append_exception_context, _raise_grouped_errors, _registry
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup, ExceptionGroup
@@ -310,7 +310,7 @@ def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path)
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     if sys.platform == "win32" and (hasattr(sys, "pypy_version_info") or lock_type.__name__ == "SoftFileLock"):
-        pytest.skip("SoftFileLock on Windows has race conditions under heavy threading")
+        pytest.skip("SoftFileLock on Windows has race conditions under heavy threading")  # pragma: win32 cover
 
     def t_1() -> None:
         for _ in range(1000):
@@ -384,7 +384,7 @@ def test_non_blocking(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     assert lock_1.is_locked
 
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."), lock_3:
-        pass
+        pass  # pragma: no cover  # __enter__ raises Timeout, so the body never runs
     assert not lock_3.is_locked
     assert lock_1.is_locked
 
@@ -394,7 +394,7 @@ def test_non_blocking(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     assert lock_1.is_locked
 
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."), lock_4:
-        pass
+        pass  # pragma: no cover  # __enter__ raises Timeout, so the body never runs
     assert not lock_4.is_locked
     assert lock_1.is_locked
 
@@ -405,7 +405,7 @@ def test_non_blocking(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     assert lock_1.is_locked
 
     with pytest.raises(Timeout, match=r"The file lock '.*' could not be acquired."), lock_5:
-        pass
+        pass  # pragma: no cover  # __enter__ raises Timeout, so the body never runs
     assert not lock_5.is_locked
     assert lock_1.is_locked
 
@@ -983,7 +983,7 @@ def test_concurrent_acquire_release_keeps_lock_file(tmp_path: Path) -> None:  # 
                 lock = FileLock(str(lock_path), is_singleton=False)
                 with lock:  # pragma: win32 no cover
                     pass
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover  # a healthy run never raises here
             errors.append(exc)
 
     threads = [threading.Thread(target=worker) for _ in range(4)]
@@ -1095,7 +1095,9 @@ def test_permission_error_propagates_when_file_missing(tmp_path: Path, mocker: M
     def open_always_permission_error(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
         if "test.lock" in path:  # pragma: win32 no cover
             raise PermissionError(13, "Permission denied", path)
-        return real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
+        return (  # pragma: no cover  # every os.open during this acquire targets the lock path
+            real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
+        )
 
     mocker.patch("os.open", side_effect=open_always_permission_error)
     with pytest.raises(PermissionError, match="Permission denied"):  # pragma: win32 no cover
@@ -1172,7 +1174,7 @@ def test_cancel_check_not_called_when_lock_available(lock_type: type[BaseFileLoc
 
     called = False
 
-    def should_not_be_called() -> bool:
+    def should_not_be_called() -> bool:  # pragma: no cover  # a free lock never consults cancel_check
         nonlocal called
         called = True
         return True
@@ -1497,7 +1499,7 @@ def test_windows_reparse_point_lock_file_rejected(tmp_path: Path) -> None:  # pr
     link = tmp_path / "resource.lock"
     try:  # pragma: win32 cover
         link.symlink_to(target)
-    except OSError:
+    except OSError:  # pragma: no cover  # the CI grants symlink rights, so this skip never runs
         pytest.skip("cannot create symlinks (needs Developer Mode or administrator)")
 
     with pytest.raises(OSError, match="reparse point"):  # pragma: win32 cover
@@ -1840,7 +1842,7 @@ def _fail_close_of(mocker: MockerFixture, lock: BaseFileLock, error: OSError) ->
         if target == fd:
             attempts.append(target)
             raise error
-        real_close(target)
+        real_close(target)  # pragma: no cover  # only an unrelated __del__ close during the mock window reaches here
 
     mocker.patch("filelock._api.os.close", side_effect=close)
     return attempts
@@ -2301,18 +2303,29 @@ def test_on_acquired_property_reflects_argument(tmp_path: Path) -> None:
     assert FileLock(str(tmp_path / "a"), on_acquired=_noop_on_acquired).on_acquired is _noop_on_acquired
 
 
+def test_on_acquired_noop_hook_allows_acquire(tmp_path: Path) -> None:
+    lock = FileLock(str(tmp_path / "a"), on_acquired=_noop_on_acquired)
+    lock.acquire()  # the no-op hook runs during acquisition
+    try:
+        assert lock.is_locked
+    finally:
+        lock.release()
+
+
 def test_on_acquired_runs_before_acquire_returns(tmp_path: Path) -> None:
     fd_while_held = -1
+    locked_during_hook = False
 
     def hook(fd: int) -> None:
-        nonlocal fd_while_held
-        if lock.is_locked:
-            fd_while_held = fd
+        nonlocal fd_while_held, locked_during_hook
+        locked_during_hook = lock.is_locked
+        fd_while_held = fd
 
     lock = FileLock(str(tmp_path / "a"), on_acquired=hook)
     lock.acquire()
     try:
-        assert fd_while_held >= 0  # the hook ran, saw the lock held, and got a real descriptor, all before acquire()
+        assert locked_during_hook  # the hook ran while the lock was held ...
+        assert fd_while_held >= 0  # ... and got a real descriptor, all before acquire() returned
     finally:
         lock.release()
 
@@ -2567,3 +2580,98 @@ def test_soft_windows_unlink_stops_on_non_permission_error(tmp_path: Path, mocke
     lock._windows_unlink_if_ours((st.st_dev, st.st_ino))
 
     assert path.exists()
+
+
+@pytest.mark.timeout(5)
+def test_append_exception_context_terminates_on_a_cycle() -> None:
+    first = RuntimeError("first")
+    second = RuntimeError("second")
+    first.__context__ = second
+    second.__context__ = first  # a cycle that never reaches the context below
+    context = ValueError("context")
+
+    _append_exception_context(first, context)
+
+    # The walk hit the already-seen tail and stopped instead of looping forever or threading context into the ring.
+    assert first.__context__ is second
+    assert second.__context__ is first
+
+
+def test_undo_acquire_keeps_registry_entry_while_still_held(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = FileLock(str(tmp_path / "a"), is_singleton=False)
+    lock.acquire()
+    key = lock._context.lock_file_key
+    assert _registry.held.get(key) == id(lock)
+
+    # A reentrant acquire that fails while the lock reports unheld routes through _undo_acquire with the counter
+    # still above zero, so the registry entry the outer hold owns must survive.
+    held_fd = lock._context.lock_file_fd
+    lock._context.lock_file_fd = None  # is_locked now reports False
+    mocker.patch.object(lock, "_poll_until_acquired", side_effect=Timeout(lock.lock_file))
+    with pytest.raises(Timeout):
+        lock.acquire(timeout=0)
+
+    assert lock._context.lock_counter == 1  # decremented from 2, the deeper hold remains
+    assert _registry.held.get(key) == id(lock)  # entry preserved because the counter did not reach zero
+
+    lock._context.lock_file_fd = held_fd
+    lock.release()
+
+
+def test_soft_marker_omits_start_line_without_a_start_token(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("filelock._soft.process_start_token", return_value=None)
+    lock = SoftFileLock(str(tmp_path / "a"))
+    with lock:
+        lines = Path(lock.lock_file).read_text(encoding="utf-8").splitlines()
+
+    assert len(lines) == 2  # pid and hostname only; the optional start-token line is omitted
+    assert lines[0] == str(os.getpid())
+
+
+def test_soft_is_lock_held_by_us_false_for_unparseable_marker(tmp_path: Path) -> None:
+    lock_path = tmp_path / "a"
+    lock_path.write_text("garbage-not-a-marker", encoding="utf-8")
+    lock = SoftFileLock(str(lock_path))
+
+    assert lock.is_lock_held_by_us is False  # an unreadable holder is nobody, so certainly not us
+
+
+@_UNIX_FLOCK_ONLY
+def test_unix_acquire_without_o_nofollow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:  # pragma: win32 no cover
+    monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+    lock = FileLock(str(tmp_path / "a"), is_singleton=False)
+    lock.acquire()
+    try:
+        assert lock.is_locked  # acquisition still works on a platform without O_NOFOLLOW
+    finally:
+        lock.release()
+
+
+@_UNIX_FLOCK_ONLY
+def test_unix_soft_fallback_keeps_a_replaced_file(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:  # pragma: win32 no cover
+    lock_path = tmp_path / "a"
+    lock = FileLock(str(lock_path), is_singleton=False)
+    target = lock.lock_file
+    mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
+
+    real_lstat = os.lstat
+
+    def lstat_swapped_identity(path: str) -> os.stat_result:
+        st = real_lstat(path)
+        if str(path) != target:
+            return st
+        fields = list(st)
+        fields[1] += 1  # bump st_ino so the on-disk identity no longer matches the opened fd
+        return os.stat_result(fields)
+
+    mocker.patch("filelock._unix.os.lstat", side_effect=lstat_swapped_identity)
+
+    with pytest.raises(Timeout), pytest.warns(UserWarning, match="falling back to SoftFileLock"):
+        lock.acquire(timeout=0.2)
+
+    assert isinstance(lock, SoftFileLock)  # fell back after refusing to unlink the mismatched file
+    assert lock_path.exists()  # the replacement file was left in place

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1021,8 +1021,7 @@ def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
 
 @_NEEDS_FCNTL  # pragma: needs fcntl
 def test_waiter_fd_cannot_split_lock_after_release(tmp_path: Path) -> None:
-    # typeshed guards fcntl's members behind a non-Windows platform, so state the invariant the fcntl capability
-    # gate already enforces; without it ty cannot see flock when it checks on Windows.
+    # typeshed hides fcntl's members off POSIX, so state the invariant the capability gate already enforces.
     assert sys.platform != "win32"
     import fcntl
 
@@ -1344,8 +1343,7 @@ _NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
 )
 
-# filelock resolves a lock's parent with abspath on Windows so junctions and reparse points are never followed, which
-# also keeps a symlinked parent a distinct key there. These cases assert the collapsing the realpath platforms do.
+# Windows resolves a lock's parent with abspath, so a symlinked parent stays a distinct key and never collapses.
 _NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"] or sys.platform == "win32",
     reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",
@@ -1616,8 +1614,7 @@ def test_windows_permanent_denial_raises_without_timeout(tmp_path: Path, mocker:
 
 @_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_delete_in_progress_is_contention_not_denial(tmp_path: Path) -> None:
-    # sys.platform is what narrows ctypes.windll for the type checker; the marker is what skips the run, so the
-    # guard only ever goes one way.
+    # The marker skips the run; this only narrows ctypes.windll for ty, so it goes one way.
     if sys.platform == "win32":  # pragma: no branch
         import ctypes
 
@@ -2468,8 +2465,7 @@ def test_on_acquired_rollback_group_detaches_release_context(
 
 
 def test_grouped_errors_keep_a_context_that_is_a_distinct_group() -> None:
-    # _same_exception_tree rejects two same-typed groups whose message or arity differ, so a member's group-valued
-    # __context__ that is genuinely distinct survives the detach rather than being treated as a duplicate to strip.
+    # A genuinely distinct group-valued __context__ must survive the detach rather than read as a duplicate.
     context = ExceptionGroup("context group", [ValueError("a")])
     member = ExceptionGroup("member group", [KeyError("b"), KeyError("c")])
     member.__context__ = context
@@ -2482,8 +2478,7 @@ def test_grouped_errors_keep_a_context_that_is_a_distinct_group() -> None:
 
 
 def test_grouped_errors_detach_a_context_already_nested_in_a_sibling() -> None:
-    # _contains_exception walks a sibling group's tree; finding the exact context object there drops that member's
-    # __context__ so the raised group never carries the same leaf twice.
+    # A context already present in a sibling's tree is dropped so the group never carries the same leaf twice.
     shared = ValueError("shared leaf")
     sibling = ExceptionGroup("sibling", [shared])
     member = RuntimeError("boom")

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -11,6 +11,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from errno import EAGAIN, EINTR, EIO, ENOSPC, ENOSYS, EWOULDBLOCK
+from importlib.util import find_spec
 from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IMODE, S_IWGRP, S_IWOTH, S_IWUSR, filemode
@@ -20,6 +21,7 @@ from uuid import uuid4
 from weakref import WeakValueDictionary
 
 import pytest
+from coverage_pragmas import CAPABILITIES
 
 from filelock import (
     BaseFileLock,
@@ -36,9 +38,9 @@ from filelock import (
 )
 from filelock._api import _append_exception_context, _raise_grouped_errors, _registry
 
-if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from builtins import BaseExceptionGroup, ExceptionGroup
-else:  # pragma: no cover (<py311)
+else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
 if TYPE_CHECKING:
@@ -87,21 +89,26 @@ def make_ro(path: Path) -> Iterator[None]:
         path.chmod(path.stat().st_mode | write)
 
 
+_NEEDS_FILE_MODE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["file-mode"], reason="a read-only folder needs POSIX permission bits"
+)
+
+
 @pytest.fixture
-def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:  # pragma: win32 no cover
-    with make_ro(tmp_path):  # pragma: win32 no cover
+def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:  # pragma: needs file-mode
+    with make_ro(tmp_path):
         yield tmp_path
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have read only folders")
+@_NEEDS_FILE_MODE  # pragma: needs file-mode
 @pytest.mark.skipif(
     sys.platform != "win32" and os.geteuid() == 0,
     reason="Cannot make a read only file (that the current user: root can't read)",
 )
-def test_ro_folder(lock_type: type[BaseFileLock], tmp_path_ro: Path) -> None:  # pragma: win32 no cover
+def test_ro_folder(lock_type: type[BaseFileLock], tmp_path_ro: Path) -> None:
     lock = lock_type(str(tmp_path_ro / "a"))
-    with pytest.raises(PermissionError, match="Permission denied"):  # pragma: win32 no cover
+    with pytest.raises(PermissionError, match="Permission denied"):
         lock.acquire()
 
 
@@ -125,8 +132,8 @@ def test_ro_file(lock_type: type[BaseFileLock], tmp_file_ro: Path) -> None:
 
 
 _WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-_UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    sys.platform == "win32", reason="native flock semantics are Unix-only"
+_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    find_spec("fcntl") is None, reason="native flock semantics need the fcntl module"
 )
 _INVALID_DESCRIPTOR_POLL_INTERVALS: Final = (
     pytest.param(0.0, id="zero"),
@@ -270,13 +277,13 @@ class ExThread(threading.Thread):
     def run(self) -> None:
         try:
             super().run()
-        except Exception:  # pragma: no cover
-            self.ex = sys.exc_info()  # pragma: no cover
+        except Exception:  # pragma: no cover  # a worker that raises fails the test; a healthy run never lands here
+            self.ex = sys.exc_info()
 
     def join(self, timeout: float | None = None) -> None:
         super().join(timeout=timeout)
         if self.ex is not None:
-            raise RuntimeError from self.ex[1]  # pragma: no cover
+            raise RuntimeError from self.ex[1]  # pragma: no cover  # only a worker that raised gets re-raised here
 
 
 # 100 threads x 100 acquisitions is thousands of lock cycles; the 20s default is tight on a loaded Windows runner.
@@ -511,9 +518,9 @@ def test_poll_intervall_deprecated(lock_type: type[BaseFileLock], tmp_path: Path
         lock.acquire(poll_intervall=0.05)
         frame_info = getframeinfo(stack()[0][0])  # lineno here is one past the acquire() call above
         for warning in checker:
-            if warning.filename == frame_info.filename and warning.lineno + 1 == frame_info.lineno:  # pragma: no cover
+            if warning.filename == frame_info.filename and warning.lineno + 1 == frame_info.lineno:  # pragma: no branch
                 break
-        else:  # pragma: no cover
+        else:  # pragma: no cover  # the stacklevel=2 warning is always found, so the failure arm never runs
             pytest.fail("No warnings of stacklevel=2 matching.")
 
 
@@ -660,12 +667,12 @@ def test_wrong_platform(tmp_path: Path) -> None:
         lock._release()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="flock not run on windows")
-@pytest.mark.filterwarnings("default::UserWarning")
-def test_flock_not_implemented_unix(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+@pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
+def test_flock_not_implemented_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("fcntl.flock", side_effect=OSError(ENOSYS, "mock error"))
     lock = FileLock(tmp_path / "a.lock")
-    with lock:  # pragma: win32 no cover
+    with lock:
         assert lock.is_locked
         assert isinstance(lock, SoftFileLock)
 
@@ -972,31 +979,31 @@ def test_lock_file_removed_after_release(tmp_path: Path, lock_type: type[BaseFil
     assert not lock_path.exists()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
-def test_concurrent_acquire_release_keeps_lock_file(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_concurrent_acquire_release_keeps_lock_file(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     errors: list[Exception] = []
 
-    def worker() -> None:  # pragma: win32 no cover
-        try:  # pragma: win32 no cover
-            for _ in range(20):  # pragma: win32 no cover
+    def worker() -> None:
+        try:
+            for _ in range(20):
                 lock = FileLock(str(lock_path), is_singleton=False)
-                with lock:  # pragma: win32 no cover
+                with lock:
                     pass
         except Exception as exc:  # pragma: no cover  # a healthy run never raises here
             errors.append(exc)
 
     threads = [threading.Thread(target=worker) for _ in range(4)]
-    for thread in threads:  # pragma: win32 no cover
+    for thread in threads:
         thread.start()
-    for thread in threads:  # pragma: win32 no cover
+    for thread in threads:
         thread.join(timeout=30)
     assert not errors, errors
     assert lock_path.exists()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
-def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     first = FileLock(str(lock_path), is_singleton=False)
     second = FileLock(str(lock_path), is_singleton=False)
@@ -1012,45 +1019,44 @@ def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:  # prag
     assert lock_path.exists()
 
 
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_waiter_fd_cannot_split_lock_after_release(tmp_path: Path) -> None:
-    if sys.platform == "win32":  # pragma: win32 cover  # Unix flock semantics; also narrows fcntl for the type checker
-        return
-    import fcntl  # pragma: win32 no cover
+    import fcntl
 
-    lock_path = tmp_path / "test.lock"  # pragma: win32 no cover
-    first = FileLock(str(lock_path), is_singleton=False)  # pragma: win32 no cover
-    replacement = FileLock(str(lock_path), is_singleton=False)  # pragma: win32 no cover
+    lock_path = tmp_path / "test.lock"
+    first = FileLock(str(lock_path), is_singleton=False)
+    replacement = FileLock(str(lock_path), is_singleton=False)
 
-    first.acquire()  # pragma: win32 no cover
-    waiter_fd = os.open(lock_path, os.O_RDWR)  # pragma: win32 no cover
+    first.acquire()
+    waiter_fd = os.open(lock_path, os.O_RDWR)
 
-    try:  # pragma: win32 no cover
+    try:
         first.release()
         assert lock_path.exists()
 
         replacement.acquire()
-        try:  # pragma: win32 no cover
-            with pytest.raises(BlockingIOError) as exc_info:  # pragma: win32 no cover
+        try:
+            with pytest.raises(BlockingIOError) as exc_info:
                 fcntl.flock(waiter_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             assert exc_info.value.errno in {EAGAIN, EWOULDBLOCK}
         finally:
             replacement.release()
     finally:
-        os.close(waiter_fd)  # pragma: win32 no cover
+        os.close(waiter_fd)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
-def test_stale_inode_retry_on_unlinked_lock(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_stale_inode_retry_on_unlinked_lock(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
 
     real_fstat = os.fstat
     call_count = 0
 
-    def fstat_unlinked_once(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def fstat_unlinked_once(fd: int) -> os.stat_result:
         nonlocal call_count
         call_count += 1
-        if call_count == 1:  # pragma: win32 no cover
+        if call_count == 1:
             Path(lock_path).unlink()
             return real_fstat(fd)
         return real_fstat(fd)
@@ -1062,7 +1068,7 @@ def test_stale_inode_retry_on_unlinked_lock(tmp_path: Path, mocker: MockerFixtur
     lock.release()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_permission_error_fallback_without_o_creat(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
@@ -1074,7 +1080,7 @@ def test_permission_error_fallback_without_o_creat(tmp_path: Path, mocker: Mocke
     def open_no_creat(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
         nonlocal call_count
         call_count += 1
-        if call_count == 1 and flags & os.O_CREAT:  # pragma: win32 no cover
+        if call_count == 1 and flags & os.O_CREAT:
             raise PermissionError(13, "Permission denied", path)
         return real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
 
@@ -1085,7 +1091,7 @@ def test_permission_error_fallback_without_o_creat(tmp_path: Path, mocker: Mocke
     lock.release()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_permission_error_propagates_when_file_missing(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
@@ -1093,18 +1099,18 @@ def test_permission_error_propagates_when_file_missing(tmp_path: Path, mocker: M
     real_open = os.open
 
     def open_always_permission_error(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
-        if "test.lock" in path:  # pragma: win32 no cover
+        if "test.lock" in path:
             raise PermissionError(13, "Permission denied", path)
         return (  # pragma: no cover  # every os.open during this acquire targets the lock path
             real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
         )
 
     mocker.patch("os.open", side_effect=open_always_permission_error)
-    with pytest.raises(PermissionError, match="Permission denied"):  # pragma: win32 no cover
+    with pytest.raises(PermissionError, match="Permission denied"):
         lock.acquire(timeout=0)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_sticky_bit_fallback_handles_concurrent_unlink(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
@@ -1116,9 +1122,9 @@ def test_sticky_bit_fallback_handles_concurrent_unlink(tmp_path: Path, mocker: M
     def open_permission_then_unlink(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
         nonlocal call_count
         call_count += 1
-        if call_count == 1 and flags & os.O_CREAT and "test.lock" in path:  # pragma: win32 no cover
+        if call_count == 1 and flags & os.O_CREAT and "test.lock" in path:
             raise PermissionError(13, "Permission denied", path)
-        if call_count == 2 and not (flags & os.O_CREAT) and "test.lock" in path:  # pragma: win32 no cover
+        if call_count == 2 and not (flags & os.O_CREAT) and "test.lock" in path:
             lock_path.unlink(missing_ok=True)
             raise FileNotFoundError(2, "No such file or directory", path)
         return real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
@@ -1211,8 +1217,8 @@ def test_cancel_check_log_message(
     lock_1.release()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="unix-only test")
-def test_filenotfound_on_fuse_nfs_retries(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_filenotfound_on_fuse_nfs_retries(tmp_path: Path, mocker: MockerFixture) -> None:
     """Retry recovers from the FUSE/NFS os.open(O_CREAT) race that raises FileNotFoundError."""
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
@@ -1331,9 +1337,14 @@ def test_different_threads_no_false_positive(tmp_path: Path, lock_type: type[Bas
     assert not isinstance(error, RuntimeError), "Should not raise RuntimeError in different thread"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="unix-only symlink test")
+_NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
+)
+
+
+@_NEEDS_SYMLINK  # pragma: needs symlink
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:  # pragma: win32 no cover
+def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     # A symlinked parent directory resolves to the same canonical key (the final component is kept literal, so a final
     # symlink stays distinct — see test_final_symlink_stays_a_distinct_key).
     real_dir = tmp_path / "real"
@@ -1341,14 +1352,14 @@ def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLoc
     (tmp_path / "link").symlink_to(real_dir)
 
     lock1 = lock_type(str(real_dir / "test.lock"))
-    with lock1:  # pragma: win32 no cover
+    with lock1:
         lock2 = lock_type(str(tmp_path / "link" / "test.lock"))
-        with pytest.raises(RuntimeError, match="Deadlock"):  # pragma: win32 no cover
+        with pytest.raises(RuntimeError, match="Deadlock"):
             lock2.acquire()
 
 
-@_UNIX_FLOCK_ONLY
-@pytest.mark.parametrize(  # pragma: win32 no cover
+@_NEEDS_SYMLINK  # pragma: needs symlink
+@pytest.mark.parametrize(
     ("depth", "force"),
     [
         pytest.param(1, False, id="direct"),
@@ -1359,29 +1370,29 @@ def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLoc
 def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Path, depth: int, force: bool) -> None:
     lock_path, original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     lock = FileLock(lock_path)
-    for _depth in range(depth):  # pragma: win32 no cover
+    for _depth in range(depth):
         lock.acquire()
     _retarget_parent(lock_path, replacement_path)
 
-    if force:  # pragma: win32 no cover
+    if force:
         lock.release(force=True)
-    else:  # pragma: win32 no cover
-        for _depth in range(depth):  # pragma: win32 no cover
+    else:
+        for _depth in range(depth):
             lock.release()
 
-    with FileLock(original_path) as successor:  # pragma: win32 no cover
+    with FileLock(original_path) as successor:
         assert successor.is_locked
 
 
-@_UNIX_FLOCK_ONLY
-def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_SYMLINK  # pragma: needs symlink
+def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:
     lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     original = FileLock(lock_path)
     original.acquire()
     _retarget_parent(lock_path, replacement_path)
-    with FileLock(replacement_path):  # pragma: win32 no cover
+    with FileLock(replacement_path):
         original.release()
-        with pytest.raises(RuntimeError, match="Deadlock"):  # pragma: win32 no cover
+        with pytest.raises(RuntimeError, match="Deadlock"):
             FileLock(replacement_path).acquire(cancel_check=lambda: True)
 
 
@@ -1411,7 +1422,7 @@ def test_force_release_cleans_registry(tmp_path: Path, lock_type: type[BaseFileL
         assert lock2.is_locked
 
 
-def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma: win32 no cover
+def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma: needs symlink
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"
     original.mkdir()
@@ -1421,7 +1432,7 @@ def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma:
     return link / "test.lock", original / "test.lock", replacement / "test.lock"
 
 
-def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:  # pragma: win32 no cover
+def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:  # pragma: needs symlink
     link = lock_path.parent
     link.unlink()
     link.symlink_to(replacement_path.parent, target_is_directory=True)
@@ -1435,74 +1446,73 @@ def _acquire_for_mode(lock: BaseFileLock, mode: Literal["finite", "nonblocking"]
 
 
 @pytest.fixture
-def held_lock_path(tmp_path: Path) -> Iterator[Path]:  # pragma: win32 no cover
+def held_lock_path(tmp_path: Path) -> Iterator[Path]:  # pragma: needs fcntl
     path = tmp_path / "resource.lock"
-    with FileLock(path, timeout=0):  # pragma: win32 no cover
+    with FileLock(path, timeout=0):
         yield path
 
 
-@_UNIX_FLOCK_ONLY
-def test_winner_truncates_stale_content(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_winner_truncates_stale_content(tmp_path: Path) -> None:
     lock_path = tmp_path / "resource.lock"
     lock_path.write_text("stale from a previous holder", encoding="utf-8")
 
-    with FileLock(lock_path, timeout=0):  # pragma: win32 no cover
+    with FileLock(lock_path, timeout=0):
         assert lock_path.stat().st_size == 0
 
 
-@_UNIX_FLOCK_ONLY
-def test_contender_preserves_holder_contents(held_lock_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_contender_preserves_holder_contents(held_lock_path: Path) -> None:
     held_lock_path.write_text("holder metadata", encoding="utf-8")
 
-    with pytest.raises(Timeout):  # pragma: win32 no cover
+    with pytest.raises(Timeout):
         FileLock(held_lock_path, timeout=0).acquire()
 
     assert held_lock_path.read_text(encoding="utf-8") == "holder metadata"
 
 
-@_UNIX_FLOCK_ONLY
-def test_contender_preserves_holder_mode(held_lock_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_contender_preserves_holder_mode(held_lock_path: Path) -> None:
     held_lock_path.chmod(0o600)
 
-    with pytest.raises(Timeout):  # pragma: win32 no cover
+    with pytest.raises(Timeout):
         FileLock(held_lock_path, timeout=0, mode=0o644).acquire()
 
     assert S_IMODE(held_lock_path.stat().st_mode) == 0o600
 
 
-@_UNIX_FLOCK_ONLY
-def test_contender_does_not_fchmod(held_lock_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_contender_does_not_fchmod(held_lock_path: Path, mocker: MockerFixture) -> None:
     fchmod_spy = mocker.spy(os, "fchmod")
 
-    with pytest.raises(Timeout):  # pragma: win32 no cover
+    with pytest.raises(Timeout):
         FileLock(held_lock_path, timeout=0, mode=0o644).acquire()
 
     fchmod_spy.assert_not_called()
 
 
-@_UNIX_FLOCK_ONLY
-def test_post_lock_truncate_failure_closes_fd(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_post_lock_truncate_failure_closes_fd(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("os.ftruncate", side_effect=OSError(ENOSPC, "No space left on device"))
     open_spy = mocker.spy(os, "open")
     close_spy = mocker.spy(os, "close")
 
-    with pytest.raises(OSError, match="No space left on device"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="No space left on device"):
         FileLock(tmp_path / "resource.lock", timeout=0).acquire()
 
     assert any(call.args and call.args[0] == open_spy.spy_return for call in close_spy.call_args_list)
 
 
-@_WINDOWS_ONLY
-def test_windows_reparse_point_lock_file_rejected(tmp_path: Path) -> None:  # pragma: win32 cover
+# Only a Windows run that also holds the symlink privilege reaches this body, so both exclusions apply.
+@_WINDOWS_ONLY  # pragma: win32 cover  # pragma: needs symlink
+@_NEEDS_SYMLINK
+def test_windows_reparse_point_lock_file_rejected(tmp_path: Path) -> None:
     target = tmp_path / "target.txt"
     target.write_text("sensitive", encoding="utf-8")
     link = tmp_path / "resource.lock"
-    try:  # pragma: win32 cover
-        link.symlink_to(target)
-    except OSError:  # pragma: no cover  # the CI grants symlink rights, so this skip never runs
-        pytest.skip("cannot create symlinks (needs Developer Mode or administrator)")
+    link.symlink_to(target)
 
-    with pytest.raises(OSError, match="reparse point"):  # pragma: win32 cover
+    with pytest.raises(OSError, match="reparse point"):
         FileLock(link).acquire()
 
     assert target.read_text(encoding="utf-8") == "sensitive"
@@ -1529,12 +1539,12 @@ def test_forced_release_drops_all_holds(tmp_path: Path) -> None:
     assert lock.lock_counter == 0
 
 
-@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_unix_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))
     lock.acquire()
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[OSError(EIO, "unlock failed"), None])
-    with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="unlock failed"):
         lock.release()
     assert lock.is_locked
     assert lock.lock_counter == 1
@@ -1542,12 +1552,12 @@ def test_unix_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: 
     assert not lock.is_locked
 
 
-@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_unix_context_exit_propagates_unlock_failure(tmp_path: Path, mocker: MockerFixture) -> None:
     # One LOCK_EX for acquire, then one LOCK_UN per release; fail only the first unlock so __exit__ propagates it.
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[None, OSError(EIO, "unlock failed"), None])
     lock = FileLock(str(tmp_path / "a"))
-    with pytest.raises(OSError, match="unlock failed"), lock:  # pragma: win32 no cover
+    with pytest.raises(OSError, match="unlock failed"), lock:
         assert lock.is_locked
     assert lock.is_locked
     lock.release()
@@ -1559,7 +1569,7 @@ def test_windows_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocke
     lock = FileLock(str(tmp_path / "a"))
     lock.acquire()
     mocker.patch("filelock._windows._unlock_fd", side_effect=[OSError(EIO, "unlock failed"), None])
-    with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 cover
+    with pytest.raises(OSError, match="unlock failed"):
         lock.release()
     assert lock.is_locked
     assert lock.lock_counter == 1
@@ -1574,7 +1584,7 @@ def test_windows_close_failure_still_commits_release(tmp_path: Path, mocker: Moc
     # The OS unlock succeeds, so the lock is released; the later close failure propagates but must not leave the
     # counter or registry believing the lock is still held.
     mocker.patch("filelock._windows.os.close", side_effect=OSError(EIO, "close failed"))
-    with pytest.raises(OSError, match="close failed"):  # pragma: win32 cover
+    with pytest.raises(OSError, match="close failed"):
         lock.release()
     assert not lock.is_locked
     assert lock.lock_counter == 0
@@ -1583,43 +1593,44 @@ def test_windows_close_failure_still_commits_release(tmp_path: Path, mocker: Moc
 @_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_delete_pending_is_treated_as_contention(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._windows._nt_open", return_value=(0, 0xC0000056))  # STATUS_DELETE_PENDING
-    with pytest.raises(Timeout):  # pragma: win32 cover
+    with pytest.raises(Timeout):
         FileLock(str(tmp_path / "a"), timeout=0.2).acquire()
 
 
 @_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_permanent_denial_raises_without_timeout(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._windows._nt_open", return_value=(0, 0xC0000022))  # STATUS_ACCESS_DENIED
-    with pytest.raises(PermissionError):  # pragma: win32 cover
+    with pytest.raises(PermissionError):
         FileLock(str(tmp_path / "a"), timeout=5).acquire()
 
 
+@_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_delete_in_progress_is_contention_not_denial(tmp_path: Path) -> None:
-    if sys.platform != "win32":  # pragma: win32 no cover
-        pytest.skip("windows-only")
-    import ctypes  # pragma: win32 cover
+    # sys.platform is what narrows ctypes.windll for the type checker; the marker is what skips the run.
+    if sys.platform == "win32":
+        import ctypes
 
-    target = str(tmp_path / "dp.lock")  # pragma: win32 cover
-    kernel32 = ctypes.windll.kernel32  # pragma: win32 cover
-    delete_access, generic_read, share_all, create_always, delete_on_close = (  # pragma: win32 cover
-        0x10000,
-        0x80000000,
-        0x1 | 0x2 | 0x4,
-        2,
-        0x04000000,
-    )
-    # Open with delete-on-close so the name is marked for deletion but the live handle keeps it around: a fresh open
-    # sees the deletion in progress (delete-pending or a sharing violation), which acquire must retry rather than
-    # mistake for a permanent PermissionError.
-    handle = kernel32.CreateFileW(  # pragma: win32 cover
-        target, delete_access | generic_read, share_all, None, create_always, delete_on_close, None
-    )
-    assert handle not in {0, ctypes.c_void_p(-1).value}  # pragma: win32 cover
-    try:  # pragma: win32 cover
-        with pytest.raises(Timeout):  # pragma: win32 cover
-            FileLock(target, timeout=0.3).acquire()
-    finally:
-        kernel32.CloseHandle(handle)  # pragma: win32 cover
+        target = str(tmp_path / "dp.lock")
+        kernel32 = ctypes.windll.kernel32
+        delete_access, generic_read, share_all, create_always, delete_on_close = (
+            0x10000,
+            0x80000000,
+            0x1 | 0x2 | 0x4,
+            2,
+            0x04000000,
+        )
+        # Open with delete-on-close so the name is marked for deletion but the live handle keeps it around: a fresh
+        # open sees the deletion in progress (delete-pending or a sharing violation), which acquire must retry rather
+        # than mistake for a permanent PermissionError.
+        handle = kernel32.CreateFileW(
+            target, delete_access | generic_read, share_all, None, create_always, delete_on_close, None
+        )
+        assert handle not in {0, ctypes.c_void_p(-1).value}
+        try:
+            with pytest.raises(Timeout):
+                FileLock(target, timeout=0.3).acquire()
+        finally:
+            kernel32.CloseHandle(handle)
 
 
 @pytest.mark.parametrize(
@@ -1848,7 +1859,7 @@ def _fail_close_of(mocker: MockerFixture, lock: BaseFileLock, error: OSError) ->
     return attempts
 
 
-@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))  # default policy
     lock.acquire()
@@ -1857,12 +1868,12 @@ def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFi
     assert not lock.is_locked
 
 
-@_WINDOWS_ONLY
-def test_close_error_default_raises_on_windows(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 cover
+@_WINDOWS_ONLY  # pragma: win32 cover
+def test_close_error_default_raises_on_windows(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))  # default policy
     lock.acquire()
     _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
-    with pytest.raises(OSError, match="close failed"):  # pragma: win32 cover
+    with pytest.raises(OSError, match="close failed"):
         lock.release()
     assert not lock.is_locked
 
@@ -1889,8 +1900,8 @@ def test_close_error_raise_is_exact_and_committed(tmp_path: Path, mocker: Mocker
     assert lock.lock_counter == 0
 
 
-@_UNIX_FLOCK_ONLY
-def test_close_not_reached_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_close_not_reached_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"), close_error_policy="raise")
     lock.acquire()
     fd = lock._context.lock_file_fd
@@ -1898,7 +1909,7 @@ def test_close_not_reached_when_unlock_fails(tmp_path: Path, mocker: MockerFixtu
     real_close = os.close
     closed: list[int] = []
     mocker.patch("filelock._api.os.close", side_effect=lambda target: closed.append(target) or real_close(target))
-    with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="unlock failed"):
         lock.release()
     assert lock.is_locked  # the kernel unlock failed, so the lock is still held
     assert fd not in closed  # close is not reached while the lock is still held
@@ -1945,39 +1956,39 @@ def test_singleton_shares_across_equivalent_spellings(tmp_path: Path) -> None:
         absolute.release(force=True)
 
 
-@_UNIX_FLOCK_ONLY
-def test_singleton_shares_through_symlinked_parent(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_SYMLINK  # pragma: needs symlink
+def test_singleton_shares_through_symlinked_parent(tmp_path: Path) -> None:
     real = tmp_path / "real"
     real.mkdir()
     (tmp_path / "link").symlink_to(real)
     via_real = FileLock(str(real / "a"), is_singleton=True)
     via_link = FileLock(str(tmp_path / "link" / "a"), is_singleton=True)
-    try:  # pragma: win32 no cover
+    try:
         assert via_real is via_link  # a symlinked parent directory resolves to the same key
     finally:
         via_real.release(force=True)
 
 
-@_UNIX_FLOCK_ONLY
-def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_SYMLINK  # pragma: needs symlink
+def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.write_text("")
     (tmp_path / "link").symlink_to(target)
     on_link = FileLock(str(tmp_path / "link"), is_singleton=True)
     on_target = FileLock(str(target), is_singleton=True)
-    try:  # pragma: win32 no cover
+    try:
         assert on_link is not on_target  # the final component is not resolved, so the symlink is its own key
     finally:
         on_link.release(force=True)
         on_target.release(force=True)
 
 
-@_UNIX_FLOCK_ONLY
-def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:
     (tmp_path / "target").write_text("")
     (tmp_path / "link").symlink_to(tmp_path / "target")
     # Keeping the final symlink a distinct key is safe because the backend still refuses to lock through it.
-    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link"):
         FileLock(str(tmp_path / "link")).acquire()
 
 
@@ -1992,11 +2003,11 @@ def test_separate_lock_classes_keep_separate_registries(tmp_path: Path) -> None:
         soft.release(force=True)
 
 
-@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), fallback_to_soft=False)
-    with pytest.raises(OSError, match="no flock") as info:  # pragma: win32 no cover
+    with pytest.raises(OSError, match="no flock") as info:
         lock.acquire()
     assert info.value.errno == ENOSYS  # the original error, not a soft-lock timeout
     assert not lock.is_locked
@@ -2004,35 +2015,35 @@ def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerF
     assert lock.lock_counter == 0  # the failed acquire left no holder count
 
 
-@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_fallback_to_soft_default_switches_to_soft(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"))  # default fallback_to_soft=True
-    with pytest.warns(UserWarning, match="falling back to SoftFileLock"):  # pragma: win32 no cover
+    with pytest.warns(UserWarning, match="falling back to SoftFileLock"):
         lock.acquire()
-    try:  # pragma: win32 no cover
+    try:
         assert lock.is_locked
         assert isinstance(lock, SoftFileLock)  # switched to existence-lock semantics
     finally:
         lock.release()
 
 
-@_UNIX_FLOCK_ONLY
-def test_fallback_disabled_recursive_reraises(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_fallback_disabled_recursive_reraises(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), fallback_to_soft=False)
-    for _ in range(2):  # a repeat acquire keeps failing the same way, never a soft downgrade  # pragma: win32 no cover
-        with pytest.raises(OSError, match="no flock"):  # pragma: win32 no cover
+    for _ in range(2):  # a repeat acquire keeps failing the same way, never a soft downgrade
+        with pytest.raises(OSError, match="no flock"):
             lock.acquire()
         assert not lock.is_locked
 
 
-@_UNIX_FLOCK_ONLY
-def test_singleton_rejects_different_fallback_to_soft(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_singleton_rejects_different_fallback_to_soft(tmp_path: Path) -> None:
     path = str(tmp_path / "a")
     first = FileLock(path, is_singleton=True, fallback_to_soft=True)
-    try:  # pragma: win32 no cover
-        with pytest.raises(ValueError, match="fallback_to_soft"):  # pragma: win32 no cover
+    try:
+        with pytest.raises(ValueError, match="fallback_to_soft"):
             FileLock(path, is_singleton=True, fallback_to_soft=False)
     finally:
         first.release(force=True)
@@ -2117,11 +2128,11 @@ def test_filelock_and_descriptor_contend(tmp_path: Path, direction: str) -> None
         os.close(fd)
 
 
-@_UNIX_FLOCK_ONLY
-def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:
     path = tmp_path / "a"
     fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
-    try:  # pragma: win32 no cover
+    try:
         os.write(fd, b"payload")
         before = os.fstat(fd)
         assert lock_descriptor(fd, blocking=False) is True
@@ -2141,13 +2152,13 @@ def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:  # pragma: wi
         os.close(fd)
 
 
-@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_unlock_descriptor_failure_allows_retry(tmp_path: Path, mocker: MockerFixture) -> None:
     fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
-    try:  # pragma: win32 no cover
+    try:
         assert lock_descriptor(fd, blocking=False) is True
         mocker.patch("filelock._unix.fcntl.flock", side_effect=[OSError(EIO, "unlock failed"), None])
-        with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 no cover
+        with pytest.raises(OSError, match="unlock failed"):
             unlock_descriptor(fd)
         unlock_descriptor(fd)  # the same descriptor can retry
     finally:
@@ -2222,8 +2233,8 @@ def test_singleton_rejects_different_preserve_lock_file(tmp_path: Path) -> None:
         first.release(force=True)
 
 
-@_UNIX_FLOCK_ONLY
-def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
     lock.acquire()
@@ -2232,18 +2243,18 @@ def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:  # prag
     assert type(lock).__name__ == "UnixFileLock"
 
 
-@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_preserve_lock_file_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), preserve_lock_file=True)  # fallback_to_soft still defaults to True
-    with pytest.raises(OSError, match="no flock"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="no flock"):
         lock.acquire()
     assert not lock.is_locked
     assert type(lock).__name__ == "UnixFileLock"  # preserve overrides the soft fallback that would unlink to release
 
 
-@_WINDOWS_ONLY
-def test_preserve_lock_file_windows_default_removes_file(tmp_path: Path) -> None:  # pragma: win32 cover
+@_WINDOWS_ONLY  # pragma: win32 cover
+def test_preserve_lock_file_windows_default_removes_file(tmp_path: Path) -> None:
     path = tmp_path / "a"
     lock = FileLock(str(path))
     lock.acquire()
@@ -2251,8 +2262,8 @@ def test_preserve_lock_file_windows_default_removes_file(tmp_path: Path) -> None
     assert not path.exists()  # the default Windows cleanup unlinks the lock file
 
 
-@_WINDOWS_ONLY
-def test_preserve_lock_file_windows_keeps_file(tmp_path: Path) -> None:  # pragma: win32 cover
+@_WINDOWS_ONLY  # pragma: win32 cover
+def test_preserve_lock_file_windows_keeps_file(tmp_path: Path) -> None:
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
     lock.acquire()
@@ -2260,23 +2271,23 @@ def test_preserve_lock_file_windows_keeps_file(tmp_path: Path) -> None:  # pragm
     assert path.exists()  # preserve_lock_file skips the post-release unlink
 
 
-@_WINDOWS_ONLY
-def test_preserve_lock_file_windows_reacquires_same_identity(tmp_path: Path) -> None:  # pragma: win32 cover
+@_WINDOWS_ONLY  # pragma: win32 cover
+def test_preserve_lock_file_windows_reacquires_same_identity(tmp_path: Path) -> None:
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
     lock.acquire()
     lock.release()
     kept = path.stat()
     lock.acquire()
-    try:  # pragma: win32 cover
+    try:
         current = path.stat()
         assert (current.st_dev, current.st_ino) == (kept.st_dev, kept.st_ino)  # same file across acquisitions
     finally:
         lock.release()
 
 
-@_WINDOWS_ONLY
-def test_preserve_lock_file_windows_kept_after_forced_release(tmp_path: Path) -> None:  # pragma: win32 cover
+@_WINDOWS_ONLY  # pragma: win32 cover
+def test_preserve_lock_file_windows_kept_after_forced_release(tmp_path: Path) -> None:
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
     lock.acquire()
@@ -2356,37 +2367,37 @@ def test_on_acquired_not_called_for_contender(tmp_path: Path) -> None:
         holder.release()
 
 
-@_UNIX_FLOCK_ONLY
-def test_on_acquired_runs_after_truncation_and_mode(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_on_acquired_runs_after_truncation_and_mode(tmp_path: Path) -> None:
     path = tmp_path / "a"
     path.write_bytes(b"stale content")
     seen: dict[str, int] = {}
 
-    def hook(fd: int) -> None:  # pragma: win32 no cover
+    def hook(fd: int) -> None:
         stat_result = os.fstat(fd)
         seen["size"] = stat_result.st_size
         seen["mode"] = S_IMODE(stat_result.st_mode)
 
     lock = FileLock(str(path), mode=0o600, on_acquired=hook)
     lock.acquire()
-    try:  # pragma: win32 no cover
+    try:
         assert seen == {"size": 0, "mode": 0o600}  # backend truncation and mode setup finished before the hook
     finally:
         lock.release()
 
 
-@_UNIX_FLOCK_ONLY
-def test_on_acquired_writes_survive_contention(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_on_acquired_writes_survive_contention(tmp_path: Path) -> None:
     path = str(tmp_path / "a")
 
-    def write_metadata(fd: int) -> None:  # pragma: win32 no cover
+    def write_metadata(fd: int) -> None:
         os.write(fd, b"holder-metadata")
 
     writer = FileLock(path, on_acquired=write_metadata)
     writer.acquire()
-    try:  # pragma: win32 no cover
+    try:
         contender = FileLock(path)
-        with pytest.raises(Timeout):  # pragma: win32 no cover
+        with pytest.raises(Timeout):
             contender.acquire(timeout=0.1)  # a losing contender must not truncate the holder's file
         assert Path(path).read_bytes() == b"holder-metadata"
     finally:
@@ -2405,12 +2416,12 @@ def test_on_acquired_failure_releases_lock(tmp_path: Path) -> None:
     other.release()
 
 
-@_UNIX_FLOCK_ONLY
-def test_on_acquired_and_release_failure_group(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_on_acquired_and_release_failure_group(tmp_path: Path, mocker: MockerFixture) -> None:
     path = str(tmp_path / "a")
     lock = FileLock(path, on_acquired=_failing_on_acquired)
     mocker.patch("filelock._unix._unlock_fd", side_effect=[OSError(EIO, "unlock failed"), None])
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         lock.acquire()
     assert {type(error) for error in info.value.exceptions} == {RuntimeError, OSError}
     assert lock.is_locked  # the OS unlock failed, so the lock stays held for a retry
@@ -2494,12 +2505,12 @@ def test_rollback_failed_acquire_groups_registration_and_release_failures(
         lock.release(force=True)
 
 
-@_UNIX_FLOCK_ONLY
-def test_on_acquired_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_on_acquired_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     calls: list[int] = []
     lock = FileLock(str(tmp_path / "a"), on_acquired=calls.append)
-    with pytest.raises(OSError, match="no flock"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="no flock"):
         lock.acquire()
     assert not lock.is_locked
     assert type(lock).__name__ == "UnixFileLock"  # a soft lock cannot run the hook, so no fallback
@@ -2636,10 +2647,8 @@ def test_soft_is_lock_held_by_us_false_for_unparseable_marker(tmp_path: Path) ->
     assert lock.is_lock_held_by_us is False  # an unreadable holder is nobody, so certainly not us
 
 
-@_UNIX_FLOCK_ONLY
-def test_unix_acquire_without_o_nofollow(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_unix_acquire_without_o_nofollow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
     lock = FileLock(str(tmp_path / "a"), is_singleton=False)
     lock.acquire()
@@ -2649,10 +2658,8 @@ def test_unix_acquire_without_o_nofollow(
         lock.release()
 
 
-@_UNIX_FLOCK_ONLY
-def test_unix_soft_fallback_keeps_a_replaced_file(
-    tmp_path: Path, mocker: MockerFixture
-) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
+def test_unix_soft_fallback_keeps_a_replaced_file(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "a"
     lock = FileLock(str(lock_path), is_singleton=False)
     target = lock.lock_file

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1432,7 +1432,7 @@ def test_force_release_cleans_registry(tmp_path: Path, lock_type: type[BaseFileL
         assert lock2.is_locked
 
 
-def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma: needs symlink
+def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma: win32 no cover
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"
     original.mkdir()
@@ -1442,7 +1442,7 @@ def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma:
     return link / "test.lock", original / "test.lock", replacement / "test.lock"
 
 
-def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:  # pragma: needs symlink
+def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:  # pragma: win32 no cover
     link = lock_path.parent
     link.unlink()
     link.symlink_to(replacement_path.parent, target_is_directory=True)
@@ -1616,8 +1616,9 @@ def test_windows_permanent_denial_raises_without_timeout(tmp_path: Path, mocker:
 
 @_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_delete_in_progress_is_contention_not_denial(tmp_path: Path) -> None:
-    # sys.platform is what narrows ctypes.windll for the type checker; the marker is what skips the run.
-    if sys.platform == "win32":
+    # sys.platform is what narrows ctypes.windll for the type checker; the marker is what skips the run, so the
+    # guard only ever goes one way.
+    if sys.platform == "win32":  # pragma: no branch
         import ctypes
 
         target = str(tmp_path / "dp.lock")
@@ -1739,7 +1740,9 @@ def test_context_group_preserves_distinct_shared_exception_dag(
     )
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="standard exception-group rendering requires Python 3.11")
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="standard exception-group rendering requires Python 3.11"
+)  # pragma: >=3.11 cover
 @pytest.mark.parametrize(
     "use_proxy",
     [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -87,8 +87,8 @@ def make_ro(path: Path) -> Iterator[None]:
 
 
 @pytest.fixture
-def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:
-    with make_ro(tmp_path):
+def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:  # pragma: win32 no cover
+    with make_ro(tmp_path):  # pragma: win32 no cover
         yield tmp_path
 
 
@@ -98,9 +98,9 @@ def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:
     sys.platform != "win32" and os.geteuid() == 0,
     reason="Cannot make a read only file (that the current user: root can't read)",
 )
-def test_ro_folder(lock_type: type[BaseFileLock], tmp_path_ro: Path) -> None:
+def test_ro_folder(lock_type: type[BaseFileLock], tmp_path_ro: Path) -> None:  # pragma: win32 no cover
     lock = lock_type(str(tmp_path_ro / "a"))
-    with pytest.raises(PermissionError, match="Permission denied"):
+    with pytest.raises(PermissionError, match="Permission denied"):  # pragma: win32 no cover
         lock.acquire()
 
 
@@ -282,7 +282,7 @@ class ExThread(threading.Thread):
 @pytest.mark.timeout(60)
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    if sys.platform == "win32" and lock_type.__name__ == "SoftFileLock":
+    if sys.platform == "win32" and lock_type.__name__ == "SoftFileLock":  # pragma: win32 cover
         pytest.skip(
             "SoftFileLock uses file-existence locking — on Windows, unlink can silently fail under heavy "
             "thread contention (EACCES from antivirus/indexer), orphaning the lock file with no recovery path"
@@ -661,10 +661,10 @@ def test_wrong_platform(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="flock not run on windows")
 @pytest.mark.filterwarnings("default::UserWarning")
-def test_flock_not_implemented_unix(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_flock_not_implemented_unix(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     mocker.patch("fcntl.flock", side_effect=OSError(ENOSYS, "mock error"))
     lock = FileLock(tmp_path / "a.lock")
-    with lock:
+    with lock:  # pragma: win32 no cover
         assert lock.is_locked
         assert isinstance(lock, SoftFileLock)
 
@@ -972,30 +972,30 @@ def test_lock_file_removed_after_release(tmp_path: Path, lock_type: type[BaseFil
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
-def test_concurrent_acquire_release_keeps_lock_file(tmp_path: Path) -> None:
+def test_concurrent_acquire_release_keeps_lock_file(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "test.lock"
     errors: list[Exception] = []
 
-    def worker() -> None:
-        try:
-            for _ in range(20):
+    def worker() -> None:  # pragma: win32 no cover
+        try:  # pragma: win32 no cover
+            for _ in range(20):  # pragma: win32 no cover
                 lock = FileLock(str(lock_path), is_singleton=False)
-                with lock:
+                with lock:  # pragma: win32 no cover
                     pass
         except Exception as exc:
             errors.append(exc)
 
     threads = [threading.Thread(target=worker) for _ in range(4)]
-    for thread in threads:
+    for thread in threads:  # pragma: win32 no cover
         thread.start()
-    for thread in threads:
+    for thread in threads:  # pragma: win32 no cover
         thread.join(timeout=30)
     assert not errors, errors
     assert lock_path.exists()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
-def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
+def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "test.lock"
     first = FileLock(str(lock_path), is_singleton=False)
     second = FileLock(str(lock_path), is_singleton=False)
@@ -1014,42 +1014,42 @@ def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
 def test_waiter_fd_cannot_split_lock_after_release(tmp_path: Path) -> None:
     if sys.platform == "win32":  # pragma: win32 cover  # Unix flock semantics; also narrows fcntl for the type checker
         return
-    import fcntl
+    import fcntl  # pragma: win32 no cover
 
-    lock_path = tmp_path / "test.lock"
-    first = FileLock(str(lock_path), is_singleton=False)
-    replacement = FileLock(str(lock_path), is_singleton=False)
+    lock_path = tmp_path / "test.lock"  # pragma: win32 no cover
+    first = FileLock(str(lock_path), is_singleton=False)  # pragma: win32 no cover
+    replacement = FileLock(str(lock_path), is_singleton=False)  # pragma: win32 no cover
 
-    first.acquire()
-    waiter_fd = os.open(lock_path, os.O_RDWR)
+    first.acquire()  # pragma: win32 no cover
+    waiter_fd = os.open(lock_path, os.O_RDWR)  # pragma: win32 no cover
 
-    try:
+    try:  # pragma: win32 no cover
         first.release()
         assert lock_path.exists()
 
         replacement.acquire()
-        try:
-            with pytest.raises(BlockingIOError) as exc_info:
+        try:  # pragma: win32 no cover
+            with pytest.raises(BlockingIOError) as exc_info:  # pragma: win32 no cover
                 fcntl.flock(waiter_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             assert exc_info.value.errno in {EAGAIN, EWOULDBLOCK}
         finally:
             replacement.release()
     finally:
-        os.close(waiter_fd)
+        os.close(waiter_fd)  # pragma: win32 no cover
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
-def test_stale_inode_retry_on_unlinked_lock(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_stale_inode_retry_on_unlinked_lock(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
 
     real_fstat = os.fstat
     call_count = 0
 
-    def fstat_unlinked_once(fd: int) -> os.stat_result:
+    def fstat_unlinked_once(fd: int) -> os.stat_result:  # pragma: win32 no cover
         nonlocal call_count
         call_count += 1
-        if call_count == 1:
+        if call_count == 1:  # pragma: win32 no cover
             Path(lock_path).unlink()
             return real_fstat(fd)
         return real_fstat(fd)
@@ -1061,7 +1061,7 @@ def test_stale_inode_retry_on_unlinked_lock(tmp_path: Path, mocker: MockerFixtur
     lock.release()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")  # pragma: win32 no cover
 def test_permission_error_fallback_without_o_creat(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
@@ -1073,7 +1073,7 @@ def test_permission_error_fallback_without_o_creat(tmp_path: Path, mocker: Mocke
     def open_no_creat(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
         nonlocal call_count
         call_count += 1
-        if call_count == 1 and flags & os.O_CREAT:
+        if call_count == 1 and flags & os.O_CREAT:  # pragma: win32 no cover
             raise PermissionError(13, "Permission denied", path)
         return real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
 
@@ -1084,7 +1084,7 @@ def test_permission_error_fallback_without_o_creat(tmp_path: Path, mocker: Mocke
     lock.release()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")  # pragma: win32 no cover
 def test_permission_error_propagates_when_file_missing(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
@@ -1092,16 +1092,16 @@ def test_permission_error_propagates_when_file_missing(tmp_path: Path, mocker: M
     real_open = os.open
 
     def open_always_permission_error(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
-        if "test.lock" in path:
+        if "test.lock" in path:  # pragma: win32 no cover
             raise PermissionError(13, "Permission denied", path)
         return real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
 
     mocker.patch("os.open", side_effect=open_always_permission_error)
-    with pytest.raises(PermissionError, match="Permission denied"):
+    with pytest.raises(PermissionError, match="Permission denied"):  # pragma: win32 no cover
         lock.acquire(timeout=0)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix flock semantics")  # pragma: win32 no cover
 def test_sticky_bit_fallback_handles_concurrent_unlink(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
@@ -1113,9 +1113,9 @@ def test_sticky_bit_fallback_handles_concurrent_unlink(tmp_path: Path, mocker: M
     def open_permission_then_unlink(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
         nonlocal call_count
         call_count += 1
-        if call_count == 1 and flags & os.O_CREAT and "test.lock" in path:
+        if call_count == 1 and flags & os.O_CREAT and "test.lock" in path:  # pragma: win32 no cover
             raise PermissionError(13, "Permission denied", path)
-        if call_count == 2 and not (flags & os.O_CREAT) and "test.lock" in path:
+        if call_count == 2 and not (flags & os.O_CREAT) and "test.lock" in path:  # pragma: win32 no cover
             lock_path.unlink(missing_ok=True)
             raise FileNotFoundError(2, "No such file or directory", path)
         return real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
@@ -1209,7 +1209,7 @@ def test_cancel_check_log_message(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="unix-only test")
-def test_filenotfound_on_fuse_nfs_retries(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_filenotfound_on_fuse_nfs_retries(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     """Retry recovers from the FUSE/NFS os.open(O_CREAT) race that raises FileNotFoundError."""
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
@@ -1330,7 +1330,7 @@ def test_different_threads_no_false_positive(tmp_path: Path, lock_type: type[Bas
 
 @pytest.mark.skipif(sys.platform == "win32", reason="unix-only symlink test")
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
+def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:  # pragma: win32 no cover
     # A symlinked parent directory resolves to the same canonical key (the final component is kept literal, so a final
     # symlink stays distinct — see test_final_symlink_stays_a_distinct_key).
     real_dir = tmp_path / "real"
@@ -1338,14 +1338,14 @@ def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLoc
     (tmp_path / "link").symlink_to(real_dir)
 
     lock1 = lock_type(str(real_dir / "test.lock"))
-    with lock1:
+    with lock1:  # pragma: win32 no cover
         lock2 = lock_type(str(tmp_path / "link" / "test.lock"))
-        with pytest.raises(RuntimeError, match="Deadlock"):
+        with pytest.raises(RuntimeError, match="Deadlock"):  # pragma: win32 no cover
             lock2.acquire()
 
 
 @_UNIX_FLOCK_ONLY
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # pragma: win32 no cover
     ("depth", "force"),
     [
         pytest.param(1, False, id="direct"),
@@ -1356,29 +1356,29 @@ def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLoc
 def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Path, depth: int, force: bool) -> None:
     lock_path, original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     lock = FileLock(lock_path)
-    for _depth in range(depth):
+    for _depth in range(depth):  # pragma: win32 no cover
         lock.acquire()
     _retarget_parent(lock_path, replacement_path)
 
-    if force:
+    if force:  # pragma: win32 no cover
         lock.release(force=True)
-    else:
-        for _depth in range(depth):
+    else:  # pragma: win32 no cover
+        for _depth in range(depth):  # pragma: win32 no cover
             lock.release()
 
-    with FileLock(original_path) as successor:
+    with FileLock(original_path) as successor:  # pragma: win32 no cover
         assert successor.is_locked
 
 
 @_UNIX_FLOCK_ONLY
-def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:
+def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     original = FileLock(lock_path)
     original.acquire()
     _retarget_parent(lock_path, replacement_path)
-    with FileLock(replacement_path):
+    with FileLock(replacement_path):  # pragma: win32 no cover
         original.release()
-        with pytest.raises(RuntimeError, match="Deadlock"):
+        with pytest.raises(RuntimeError, match="Deadlock"):  # pragma: win32 no cover
             FileLock(replacement_path).acquire(cancel_check=lambda: True)
 
 
@@ -1408,7 +1408,7 @@ def test_force_release_cleans_registry(tmp_path: Path, lock_type: type[BaseFileL
         assert lock2.is_locked
 
 
-def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:  # pragma: win32 no cover
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"
     original.mkdir()
@@ -1418,7 +1418,7 @@ def _symlinked_lock_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
     return link / "test.lock", original / "test.lock", replacement / "test.lock"
 
 
-def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:
+def _retarget_parent(lock_path: Path, replacement_path: Path) -> None:  # pragma: win32 no cover
     link = lock_path.parent
     link.unlink()
     link.symlink_to(replacement_path.parent, target_is_directory=True)
@@ -1432,74 +1432,74 @@ def _acquire_for_mode(lock: BaseFileLock, mode: Literal["finite", "nonblocking"]
 
 
 @pytest.fixture
-def held_lock_path(tmp_path: Path) -> Iterator[Path]:
+def held_lock_path(tmp_path: Path) -> Iterator[Path]:  # pragma: win32 no cover
     path = tmp_path / "resource.lock"
-    with FileLock(path, timeout=0):
+    with FileLock(path, timeout=0):  # pragma: win32 no cover
         yield path
 
 
 @_UNIX_FLOCK_ONLY
-def test_winner_truncates_stale_content(tmp_path: Path) -> None:
+def test_winner_truncates_stale_content(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "resource.lock"
     lock_path.write_text("stale from a previous holder", encoding="utf-8")
 
-    with FileLock(lock_path, timeout=0):
+    with FileLock(lock_path, timeout=0):  # pragma: win32 no cover
         assert lock_path.stat().st_size == 0
 
 
 @_UNIX_FLOCK_ONLY
-def test_contender_preserves_holder_contents(held_lock_path: Path) -> None:
+def test_contender_preserves_holder_contents(held_lock_path: Path) -> None:  # pragma: win32 no cover
     held_lock_path.write_text("holder metadata", encoding="utf-8")
 
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 no cover
         FileLock(held_lock_path, timeout=0).acquire()
 
     assert held_lock_path.read_text(encoding="utf-8") == "holder metadata"
 
 
 @_UNIX_FLOCK_ONLY
-def test_contender_preserves_holder_mode(held_lock_path: Path) -> None:
+def test_contender_preserves_holder_mode(held_lock_path: Path) -> None:  # pragma: win32 no cover
     held_lock_path.chmod(0o600)
 
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 no cover
         FileLock(held_lock_path, timeout=0, mode=0o644).acquire()
 
     assert S_IMODE(held_lock_path.stat().st_mode) == 0o600
 
 
 @_UNIX_FLOCK_ONLY
-def test_contender_does_not_fchmod(held_lock_path: Path, mocker: MockerFixture) -> None:
+def test_contender_does_not_fchmod(held_lock_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     fchmod_spy = mocker.spy(os, "fchmod")
 
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 no cover
         FileLock(held_lock_path, timeout=0, mode=0o644).acquire()
 
     fchmod_spy.assert_not_called()
 
 
 @_UNIX_FLOCK_ONLY
-def test_post_lock_truncate_failure_closes_fd(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_post_lock_truncate_failure_closes_fd(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     mocker.patch("os.ftruncate", side_effect=OSError(ENOSPC, "No space left on device"))
     open_spy = mocker.spy(os, "open")
     close_spy = mocker.spy(os, "close")
 
-    with pytest.raises(OSError, match="No space left on device"):
+    with pytest.raises(OSError, match="No space left on device"):  # pragma: win32 no cover
         FileLock(tmp_path / "resource.lock", timeout=0).acquire()
 
     assert any(call.args and call.args[0] == open_spy.spy_return for call in close_spy.call_args_list)
 
 
 @_WINDOWS_ONLY
-def test_windows_reparse_point_lock_file_rejected(tmp_path: Path) -> None:
+def test_windows_reparse_point_lock_file_rejected(tmp_path: Path) -> None:  # pragma: win32 cover
     target = tmp_path / "target.txt"
     target.write_text("sensitive", encoding="utf-8")
     link = tmp_path / "resource.lock"
-    try:
+    try:  # pragma: win32 cover
         link.symlink_to(target)
     except OSError:
         pytest.skip("cannot create symlinks (needs Developer Mode or administrator)")
 
-    with pytest.raises(OSError, match="reparse point"):
+    with pytest.raises(OSError, match="reparse point"):  # pragma: win32 cover
         FileLock(link).acquire()
 
     assert target.read_text(encoding="utf-8") == "sensitive"
@@ -1526,12 +1526,12 @@ def test_forced_release_drops_all_holds(tmp_path: Path) -> None:
     assert lock.lock_counter == 0
 
 
-@_UNIX_FLOCK_ONLY
+@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
 def test_unix_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))
     lock.acquire()
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[OSError(EIO, "unlock failed"), None])
-    with pytest.raises(OSError, match="unlock failed"):
+    with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 no cover
         lock.release()
     assert lock.is_locked
     assert lock.lock_counter == 1
@@ -1539,24 +1539,24 @@ def test_unix_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: 
     assert not lock.is_locked
 
 
-@_UNIX_FLOCK_ONLY
+@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
 def test_unix_context_exit_propagates_unlock_failure(tmp_path: Path, mocker: MockerFixture) -> None:
     # One LOCK_EX for acquire, then one LOCK_UN per release; fail only the first unlock so __exit__ propagates it.
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[None, OSError(EIO, "unlock failed"), None])
     lock = FileLock(str(tmp_path / "a"))
-    with pytest.raises(OSError, match="unlock failed"), lock:
+    with pytest.raises(OSError, match="unlock failed"), lock:  # pragma: win32 no cover
         assert lock.is_locked
     assert lock.is_locked
     lock.release()
     assert not lock.is_locked
 
 
-@_WINDOWS_ONLY
+@_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))
     lock.acquire()
     mocker.patch("filelock._windows._unlock_fd", side_effect=[OSError(EIO, "unlock failed"), None])
-    with pytest.raises(OSError, match="unlock failed"):
+    with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 cover
         lock.release()
     assert lock.is_locked
     assert lock.lock_counter == 1
@@ -1564,41 +1564,41 @@ def test_windows_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocke
     assert not lock.is_locked
 
 
-@_WINDOWS_ONLY
+@_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_close_failure_still_commits_release(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))
     lock.acquire()
     # The OS unlock succeeds, so the lock is released; the later close failure propagates but must not leave the
     # counter or registry believing the lock is still held.
     mocker.patch("filelock._windows.os.close", side_effect=OSError(EIO, "close failed"))
-    with pytest.raises(OSError, match="close failed"):
+    with pytest.raises(OSError, match="close failed"):  # pragma: win32 cover
         lock.release()
     assert not lock.is_locked
     assert lock.lock_counter == 0
 
 
-@_WINDOWS_ONLY
+@_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_delete_pending_is_treated_as_contention(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._windows._nt_open", return_value=(0, 0xC0000056))  # STATUS_DELETE_PENDING
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 cover
         FileLock(str(tmp_path / "a"), timeout=0.2).acquire()
 
 
-@_WINDOWS_ONLY
+@_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_permanent_denial_raises_without_timeout(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._windows._nt_open", return_value=(0, 0xC0000022))  # STATUS_ACCESS_DENIED
-    with pytest.raises(PermissionError):
+    with pytest.raises(PermissionError):  # pragma: win32 cover
         FileLock(str(tmp_path / "a"), timeout=5).acquire()
 
 
 def test_windows_delete_in_progress_is_contention_not_denial(tmp_path: Path) -> None:
-    if sys.platform != "win32":
+    if sys.platform != "win32":  # pragma: win32 no cover
         pytest.skip("windows-only")
-    import ctypes
+    import ctypes  # pragma: win32 cover
 
-    target = str(tmp_path / "dp.lock")
-    kernel32 = ctypes.windll.kernel32
-    delete_access, generic_read, share_all, create_always, delete_on_close = (
+    target = str(tmp_path / "dp.lock")  # pragma: win32 cover
+    kernel32 = ctypes.windll.kernel32  # pragma: win32 cover
+    delete_access, generic_read, share_all, create_always, delete_on_close = (  # pragma: win32 cover
         0x10000,
         0x80000000,
         0x1 | 0x2 | 0x4,
@@ -1608,15 +1608,15 @@ def test_windows_delete_in_progress_is_contention_not_denial(tmp_path: Path) -> 
     # Open with delete-on-close so the name is marked for deletion but the live handle keeps it around: a fresh open
     # sees the deletion in progress (delete-pending or a sharing violation), which acquire must retry rather than
     # mistake for a permanent PermissionError.
-    handle = kernel32.CreateFileW(
+    handle = kernel32.CreateFileW(  # pragma: win32 cover
         target, delete_access | generic_read, share_all, None, create_always, delete_on_close, None
     )
-    assert handle not in {0, ctypes.c_void_p(-1).value}
-    try:
-        with pytest.raises(Timeout):
+    assert handle not in {0, ctypes.c_void_p(-1).value}  # pragma: win32 cover
+    try:  # pragma: win32 cover
+        with pytest.raises(Timeout):  # pragma: win32 cover
             FileLock(target, timeout=0.3).acquire()
     finally:
-        kernel32.CloseHandle(handle)
+        kernel32.CloseHandle(handle)  # pragma: win32 cover
 
 
 @pytest.mark.parametrize(
@@ -1845,7 +1845,7 @@ def _fail_close_of(mocker: MockerFixture, lock: BaseFileLock, error: OSError) ->
     return attempts
 
 
-@_UNIX_FLOCK_ONLY
+@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
 def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))  # default policy
     lock.acquire()
@@ -1855,11 +1855,11 @@ def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFi
 
 
 @_WINDOWS_ONLY
-def test_close_error_default_raises_on_windows(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_close_error_default_raises_on_windows(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 cover
     lock = FileLock(str(tmp_path / "a"))  # default policy
     lock.acquire()
     _fail_close_of(mocker, lock, OSError(EIO, "close failed"))
-    with pytest.raises(OSError, match="close failed"):
+    with pytest.raises(OSError, match="close failed"):  # pragma: win32 cover
         lock.release()
     assert not lock.is_locked
 
@@ -1887,7 +1887,7 @@ def test_close_error_raise_is_exact_and_committed(tmp_path: Path, mocker: Mocker
 
 
 @_UNIX_FLOCK_ONLY
-def test_close_not_reached_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_close_not_reached_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     lock = FileLock(str(tmp_path / "a"), close_error_policy="raise")
     lock.acquire()
     fd = lock._context.lock_file_fd
@@ -1895,7 +1895,7 @@ def test_close_not_reached_when_unlock_fails(tmp_path: Path, mocker: MockerFixtu
     real_close = os.close
     closed: list[int] = []
     mocker.patch("filelock._api.os.close", side_effect=lambda target: closed.append(target) or real_close(target))
-    with pytest.raises(OSError, match="unlock failed"):
+    with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 no cover
         lock.release()
     assert lock.is_locked  # the kernel unlock failed, so the lock is still held
     assert fd not in closed  # close is not reached while the lock is still held
@@ -1943,26 +1943,26 @@ def test_singleton_shares_across_equivalent_spellings(tmp_path: Path) -> None:
 
 
 @_UNIX_FLOCK_ONLY
-def test_singleton_shares_through_symlinked_parent(tmp_path: Path) -> None:
+def test_singleton_shares_through_symlinked_parent(tmp_path: Path) -> None:  # pragma: win32 no cover
     real = tmp_path / "real"
     real.mkdir()
     (tmp_path / "link").symlink_to(real)
     via_real = FileLock(str(real / "a"), is_singleton=True)
     via_link = FileLock(str(tmp_path / "link" / "a"), is_singleton=True)
-    try:
+    try:  # pragma: win32 no cover
         assert via_real is via_link  # a symlinked parent directory resolves to the same key
     finally:
         via_real.release(force=True)
 
 
 @_UNIX_FLOCK_ONLY
-def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
+def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:  # pragma: win32 no cover
     target = tmp_path / "target"
     target.write_text("")
     (tmp_path / "link").symlink_to(target)
     on_link = FileLock(str(tmp_path / "link"), is_singleton=True)
     on_target = FileLock(str(target), is_singleton=True)
-    try:
+    try:  # pragma: win32 no cover
         assert on_link is not on_target  # the final component is not resolved, so the symlink is its own key
     finally:
         on_link.release(force=True)
@@ -1970,11 +1970,11 @@ def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
 
 
 @_UNIX_FLOCK_ONLY
-def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:
+def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:  # pragma: win32 no cover
     (tmp_path / "target").write_text("")
     (tmp_path / "link").symlink_to(tmp_path / "target")
     # Keeping the final symlink a distinct key is safe because the backend still refuses to lock through it.
-    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link"):
+    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link"):  # pragma: win32 no cover
         FileLock(str(tmp_path / "link")).acquire()
 
 
@@ -1989,11 +1989,11 @@ def test_separate_lock_classes_keep_separate_registries(tmp_path: Path) -> None:
         soft.release(force=True)
 
 
-@_UNIX_FLOCK_ONLY
+@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
 def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), fallback_to_soft=False)
-    with pytest.raises(OSError, match="no flock") as info:
+    with pytest.raises(OSError, match="no flock") as info:  # pragma: win32 no cover
         lock.acquire()
     assert info.value.errno == ENOSYS  # the original error, not a soft-lock timeout
     assert not lock.is_locked
@@ -2001,13 +2001,13 @@ def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerF
     assert lock.lock_counter == 0  # the failed acquire left no holder count
 
 
-@_UNIX_FLOCK_ONLY
+@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
 def test_fallback_to_soft_default_switches_to_soft(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"))  # default fallback_to_soft=True
-    with pytest.warns(UserWarning, match="falling back to SoftFileLock"):
+    with pytest.warns(UserWarning, match="falling back to SoftFileLock"):  # pragma: win32 no cover
         lock.acquire()
-    try:
+    try:  # pragma: win32 no cover
         assert lock.is_locked
         assert isinstance(lock, SoftFileLock)  # switched to existence-lock semantics
     finally:
@@ -2015,21 +2015,21 @@ def test_fallback_to_soft_default_switches_to_soft(tmp_path: Path, mocker: Mocke
 
 
 @_UNIX_FLOCK_ONLY
-def test_fallback_disabled_recursive_reraises(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_fallback_disabled_recursive_reraises(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), fallback_to_soft=False)
-    for _ in range(2):  # a repeat acquire keeps failing the same way, never a soft downgrade
-        with pytest.raises(OSError, match="no flock"):
+    for _ in range(2):  # a repeat acquire keeps failing the same way, never a soft downgrade  # pragma: win32 no cover
+        with pytest.raises(OSError, match="no flock"):  # pragma: win32 no cover
             lock.acquire()
         assert not lock.is_locked
 
 
 @_UNIX_FLOCK_ONLY
-def test_singleton_rejects_different_fallback_to_soft(tmp_path: Path) -> None:
+def test_singleton_rejects_different_fallback_to_soft(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = str(tmp_path / "a")
     first = FileLock(path, is_singleton=True, fallback_to_soft=True)
-    try:
-        with pytest.raises(ValueError, match="fallback_to_soft"):
+    try:  # pragma: win32 no cover
+        with pytest.raises(ValueError, match="fallback_to_soft"):  # pragma: win32 no cover
             FileLock(path, is_singleton=True, fallback_to_soft=False)
     finally:
         first.release(force=True)
@@ -2115,10 +2115,10 @@ def test_filelock_and_descriptor_contend(tmp_path: Path, direction: str) -> None
 
 
 @_UNIX_FLOCK_ONLY
-def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:
+def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = tmp_path / "a"
     fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
-    try:
+    try:  # pragma: win32 no cover
         os.write(fd, b"payload")
         before = os.fstat(fd)
         assert lock_descriptor(fd, blocking=False) is True
@@ -2138,13 +2138,13 @@ def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:
         os.close(fd)
 
 
-@_UNIX_FLOCK_ONLY
+@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
 def test_unlock_descriptor_failure_allows_retry(tmp_path: Path, mocker: MockerFixture) -> None:
     fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
-    try:
+    try:  # pragma: win32 no cover
         assert lock_descriptor(fd, blocking=False) is True
         mocker.patch("filelock._unix.fcntl.flock", side_effect=[OSError(EIO, "unlock failed"), None])
-        with pytest.raises(OSError, match="unlock failed"):
+        with pytest.raises(OSError, match="unlock failed"):  # pragma: win32 no cover
             unlock_descriptor(fd)
         unlock_descriptor(fd)  # the same descriptor can retry
     finally:
@@ -2220,7 +2220,7 @@ def test_singleton_rejects_different_preserve_lock_file(tmp_path: Path) -> None:
 
 
 @_UNIX_FLOCK_ONLY
-def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:
+def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
     lock.acquire()
@@ -2229,18 +2229,18 @@ def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:
     assert type(lock).__name__ == "UnixFileLock"
 
 
-@_UNIX_FLOCK_ONLY
+@_UNIX_FLOCK_ONLY  # pragma: win32 no cover
 def test_preserve_lock_file_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), preserve_lock_file=True)  # fallback_to_soft still defaults to True
-    with pytest.raises(OSError, match="no flock"):
+    with pytest.raises(OSError, match="no flock"):  # pragma: win32 no cover
         lock.acquire()
     assert not lock.is_locked
     assert type(lock).__name__ == "UnixFileLock"  # preserve overrides the soft fallback that would unlink to release
 
 
 @_WINDOWS_ONLY
-def test_preserve_lock_file_windows_default_removes_file(tmp_path: Path) -> None:
+def test_preserve_lock_file_windows_default_removes_file(tmp_path: Path) -> None:  # pragma: win32 cover
     path = tmp_path / "a"
     lock = FileLock(str(path))
     lock.acquire()
@@ -2249,7 +2249,7 @@ def test_preserve_lock_file_windows_default_removes_file(tmp_path: Path) -> None
 
 
 @_WINDOWS_ONLY
-def test_preserve_lock_file_windows_keeps_file(tmp_path: Path) -> None:
+def test_preserve_lock_file_windows_keeps_file(tmp_path: Path) -> None:  # pragma: win32 cover
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
     lock.acquire()
@@ -2258,14 +2258,14 @@ def test_preserve_lock_file_windows_keeps_file(tmp_path: Path) -> None:
 
 
 @_WINDOWS_ONLY
-def test_preserve_lock_file_windows_reacquires_same_identity(tmp_path: Path) -> None:
+def test_preserve_lock_file_windows_reacquires_same_identity(tmp_path: Path) -> None:  # pragma: win32 cover
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
     lock.acquire()
     lock.release()
     kept = path.stat()
     lock.acquire()
-    try:
+    try:  # pragma: win32 cover
         current = path.stat()
         assert (current.st_dev, current.st_ino) == (kept.st_dev, kept.st_ino)  # same file across acquisitions
     finally:
@@ -2273,7 +2273,7 @@ def test_preserve_lock_file_windows_reacquires_same_identity(tmp_path: Path) -> 
 
 
 @_WINDOWS_ONLY
-def test_preserve_lock_file_windows_kept_after_forced_release(tmp_path: Path) -> None:
+def test_preserve_lock_file_windows_kept_after_forced_release(tmp_path: Path) -> None:  # pragma: win32 cover
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
     lock.acquire()
@@ -2343,36 +2343,36 @@ def test_on_acquired_not_called_for_contender(tmp_path: Path) -> None:
 
 
 @_UNIX_FLOCK_ONLY
-def test_on_acquired_runs_after_truncation_and_mode(tmp_path: Path) -> None:
+def test_on_acquired_runs_after_truncation_and_mode(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = tmp_path / "a"
     path.write_bytes(b"stale content")
     seen: dict[str, int] = {}
 
-    def hook(fd: int) -> None:
+    def hook(fd: int) -> None:  # pragma: win32 no cover
         stat_result = os.fstat(fd)
         seen["size"] = stat_result.st_size
         seen["mode"] = S_IMODE(stat_result.st_mode)
 
     lock = FileLock(str(path), mode=0o600, on_acquired=hook)
     lock.acquire()
-    try:
+    try:  # pragma: win32 no cover
         assert seen == {"size": 0, "mode": 0o600}  # backend truncation and mode setup finished before the hook
     finally:
         lock.release()
 
 
 @_UNIX_FLOCK_ONLY
-def test_on_acquired_writes_survive_contention(tmp_path: Path) -> None:
+def test_on_acquired_writes_survive_contention(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = str(tmp_path / "a")
 
-    def write_metadata(fd: int) -> None:
+    def write_metadata(fd: int) -> None:  # pragma: win32 no cover
         os.write(fd, b"holder-metadata")
 
     writer = FileLock(path, on_acquired=write_metadata)
     writer.acquire()
-    try:
+    try:  # pragma: win32 no cover
         contender = FileLock(path)
-        with pytest.raises(Timeout):
+        with pytest.raises(Timeout):  # pragma: win32 no cover
             contender.acquire(timeout=0.1)  # a losing contender must not truncate the holder's file
         assert Path(path).read_bytes() == b"holder-metadata"
     finally:
@@ -2392,11 +2392,11 @@ def test_on_acquired_failure_releases_lock(tmp_path: Path) -> None:
 
 
 @_UNIX_FLOCK_ONLY
-def test_on_acquired_and_release_failure_group(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_on_acquired_and_release_failure_group(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     path = str(tmp_path / "a")
     lock = FileLock(path, on_acquired=_failing_on_acquired)
     mocker.patch("filelock._unix._unlock_fd", side_effect=[OSError(EIO, "unlock failed"), None])
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         lock.acquire()
     assert {type(error) for error in info.value.exceptions} == {RuntimeError, OSError}
     assert lock.is_locked  # the OS unlock failed, so the lock stays held for a retry
@@ -2430,11 +2430,11 @@ def test_on_acquired_rollback_group_detaches_release_context(
 
 
 @_UNIX_FLOCK_ONLY
-def test_on_acquired_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_on_acquired_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     calls: list[int] = []
     lock = FileLock(str(tmp_path / "a"), on_acquired=calls.append)
-    with pytest.raises(OSError, match="no flock"):
+    with pytest.raises(OSError, match="no flock"):  # pragma: win32 no cover
         lock.acquire()
     assert not lock.is_locked
     assert type(lock).__name__ == "UnixFileLock"  # a soft lock cannot run the hook, so no fallback

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -39,7 +39,7 @@ from filelock import (
 from filelock._api import _append_exception_context, _raise_grouped_errors, _registry
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
-    from builtins import BaseExceptionGroup, ExceptionGroup
+    from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -34,6 +34,7 @@ from filelock import (
     lock_descriptor,
     unlock_descriptor,
 )
+from filelock._api import _raise_grouped_errors
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup, ExceptionGroup
@@ -2429,6 +2430,57 @@ def test_on_acquired_rollback_group_detaches_release_context(
     ) == ((callback_error, release_error), None, None, callback_cause, release_cause, True, True)
 
 
+def test_grouped_errors_keep_a_context_that_is_a_distinct_group() -> None:
+    # _same_exception_tree rejects two same-typed groups whose message or arity differ, so a member's group-valued
+    # __context__ that is genuinely distinct survives the detach rather than being treated as a duplicate to strip.
+    context = ExceptionGroup("context group", [ValueError("a")])
+    member = ExceptionGroup("member group", [KeyError("b"), KeyError("c")])
+    member.__context__ = context
+
+    with pytest.raises(BaseExceptionGroup) as info:
+        _raise_grouped_errors("grouped", member, RuntimeError("other"))
+
+    assert member.__context__ is context
+    assert member in info.value.exceptions
+
+
+def test_grouped_errors_detach_a_context_already_nested_in_a_sibling() -> None:
+    # _contains_exception walks a sibling group's tree; finding the exact context object there drops that member's
+    # __context__ so the raised group never carries the same leaf twice.
+    shared = ValueError("shared leaf")
+    sibling = ExceptionGroup("sibling", [shared])
+    member = RuntimeError("boom")
+    member.__context__ = shared
+
+    with pytest.raises(BaseExceptionGroup) as info:
+        _raise_grouped_errors("grouped", sibling, member)
+
+    assert member.__context__ is None
+    assert set(info.value.exceptions) == {sibling, member}
+
+
+def test_rollback_failed_acquire_groups_registration_and_release_failures(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    # An acquire that raised while still holding the lock re-registers the descriptor and releases; when both that
+    # re-registration and the release then fail, every failure survives as a sibling of the group raised.
+    lock = SoftFileLock(str(tmp_path / "a"))
+    lock.acquire()
+    registration_error = OSError("registration failed")
+    release_error = OSError("release failed")
+    mocker.patch.object(lock, "_register_context_descriptor", side_effect=registration_error)
+    mocker.patch.object(lock, "_release_with_fork_tracking", side_effect=release_error)
+    acquisition_error = RuntimeError("acquire failed")
+
+    try:
+        with pytest.raises(BaseExceptionGroup) as info:
+            lock._rollback_failed_acquire(acquisition_error)
+        assert set(info.value.exceptions) == {acquisition_error, registration_error, release_error}
+    finally:
+        mocker.stopall()
+        lock.release(force=True)
+
+
 @_UNIX_FLOCK_ONLY
 def test_on_acquired_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
@@ -2489,3 +2541,29 @@ def test_strict_lock_reports_unsupported_without_os_link(tmp_path: Path, mocker:
     with pytest.raises(SoftFileLockProtocolError, match="hard-link publication"):
         lock.acquire()
     assert (lock.claims, lock.is_locked) == ((), False)
+
+
+def test_soft_release_groups_close_and_cleanup_failures(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock = SoftFileLock(str(tmp_path / "grouped.lock"))
+    lock.acquire()
+    mocker.patch.object(lock, "_close_released_fd", side_effect=OSError("close boom"))
+    mocker.patch.object(lock, "_unlink_held_marker", side_effect=OSError("cleanup boom"))
+
+    with pytest.raises(BaseExceptionGroup, match="both failed") as excinfo:
+        lock._release()
+
+    messages = {str(exc) for exc in excinfo.value.exceptions}
+    assert any("close boom" in message for message in messages)
+    assert any("cleanup boom" in message for message in messages)
+
+
+def test_soft_windows_unlink_stops_on_non_permission_error(tmp_path: Path, mocker: MockerFixture) -> None:
+    path = tmp_path / "windows.lock"
+    path.write_bytes(b"x")
+    lock = SoftFileLock(str(path))
+    st = os.lstat(path)
+    mocker.patch.object(Path, "unlink", side_effect=OSError(ENOSYS, "boom"))
+
+    lock._windows_unlink_if_ours((st.st_dev, st.st_ino))
+
+    assert path.exists()

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1021,6 +1021,9 @@ def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
 
 @_NEEDS_FCNTL  # pragma: needs fcntl
 def test_waiter_fd_cannot_split_lock_after_release(tmp_path: Path) -> None:
+    # typeshed guards fcntl's members behind a non-Windows platform, so state the invariant the fcntl capability
+    # gate already enforces; without it ty cannot see flock when it checks on Windows.
+    assert sys.platform != "win32"
     import fcntl
 
     lock_path = tmp_path / "test.lock"
@@ -1341,8 +1344,15 @@ _NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
 )
 
+# filelock resolves a lock's parent with abspath on Windows so junctions and reparse points are never followed, which
+# also keeps a symlinked parent a distinct key there. These cases assert the collapsing the realpath platforms do.
+_NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"] or sys.platform == "win32",
+    reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",
+)
 
-@_NEEDS_SYMLINK  # pragma: needs symlink
+
+@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     # A symlinked parent directory resolves to the same canonical key (the final component is kept literal, so a final
@@ -1358,7 +1368,7 @@ def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLoc
             lock2.acquire()
 
 
-@_NEEDS_SYMLINK  # pragma: needs symlink
+@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 @pytest.mark.parametrize(
     ("depth", "force"),
     [
@@ -1384,7 +1394,7 @@ def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Path, dep
         assert successor.is_locked
 
 
-@_NEEDS_SYMLINK  # pragma: needs symlink
+@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:
     lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     original = FileLock(lock_path)
@@ -1956,7 +1966,7 @@ def test_singleton_shares_across_equivalent_spellings(tmp_path: Path) -> None:
         absolute.release(force=True)
 
 
-@_NEEDS_SYMLINK  # pragma: needs symlink
+@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 def test_singleton_shares_through_symlinked_parent(tmp_path: Path) -> None:
     real = tmp_path / "real"
     real.mkdir()

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -13,7 +13,7 @@ from fork_helpers import exit_child, fork_process
 from filelock import BaseAsyncFileLock, BaseFileLock
 
 if sys.version_info >= (3, 11):
-    from builtins import BaseExceptionGroup
+    from builtins import BaseExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup
 
@@ -214,7 +214,7 @@ import os
 import sys
 
 if sys.version_info >= (3, 11):
-    from builtins import BaseExceptionGroup
+    from builtins import BaseExceptionGroup  # pragma: >=3.11 cover
 else:
     from exceptiongroup import BaseExceptionGroup
 

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -31,13 +31,13 @@ class _DescriptorLock(BaseFileLock):
     descriptor: int | None = None
     fail_release: bool = False
 
-    def _acquire(self) -> None:
+    def _acquire(self) -> None:  # pragma: win32 no cover
         self.descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
-        if self.acquire_error is not None:
+        if self.acquire_error is not None:  # pragma: win32 no cover
             raise self.acquire_error
 
-    def _release(self) -> None:
-        if self.fail_release:
+    def _release(self) -> None:  # pragma: win32 no cover
+        if self.fail_release:  # pragma: win32 no cover
             msg = "unlock failed"
             raise RuntimeError(msg)
         os.close(cast("int", self._context.lock_file_fd))
@@ -55,11 +55,11 @@ class _CoroutineDescriptorLock(BaseAsyncFileLock):
         if self.acquire_error_before_descriptor is not None:
             raise self.acquire_error_before_descriptor
         self.descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
-        if self.acquire_error is not None:
+        if self.acquire_error is not None:  # pragma: win32 no cover
             raise self.acquire_error
 
     async def _release(self) -> None:  # ty: ignore[invalid-method-override]  # coroutine backends are supported
-        if self.release_error_before_close is not None:
+        if self.release_error_before_close is not None:  # pragma: win32 no cover
             raise self.release_error_before_close
         os.close(cast("int", self._context.lock_file_fd))
         self._context.lock_file_fd = None
@@ -68,7 +68,7 @@ class _CoroutineDescriptorLock(BaseAsyncFileLock):
 
 
 @_REQUIRES_FORK
-def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:
+def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:  # pragma: win32 no cover
     descriptors: list[int] = []
     lock = _DescriptorLock(str(tmp_path / "third-party.lock"), is_singleton=False, on_acquired=descriptors.append)
     lock.acquire()
@@ -81,12 +81,12 @@ def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:
 
 
 @_REQUIRES_FORK
-def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:
+def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:  # pragma: win32 no cover
     descriptors: list[int] = []
     lock = _DescriptorLock(str(tmp_path / "retry.lock"), is_singleton=False, on_acquired=descriptors.append)
     lock.acquire()
     lock.fail_release = True
-    with pytest.raises(RuntimeError, match="unlock failed"):
+    with pytest.raises(RuntimeError, match="unlock failed"):  # pragma: win32 no cover
         lock.release()
 
     child_pid = _fork_descriptor_probe(descriptors[0], os.fstat)
@@ -97,12 +97,12 @@ def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: win32 no cover
 def test_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path: Path) -> None:
     lock = _DescriptorLock(str(tmp_path / "partial.lock"), is_singleton=False)
     lock.acquire_error = RuntimeError("acquire failed")
     lock.fail_release = True
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         lock.acquire(timeout=0)
     child_pid = _fork_descriptor_probe(cast("int", lock.descriptor), os.fstat)
     _, status = os.waitpid(child_pid, 0)
@@ -139,7 +139,7 @@ def test_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path
     ],
 )
 @_REQUIRES_FORK
-def test_acquisition_and_registration_errors_are_grouped(
+def test_acquisition_and_registration_errors_are_grouped(  # pragma: win32 no cover
     tmp_path: Path,
     mocker: MockerFixture,
     *,
@@ -151,13 +151,13 @@ def test_acquisition_and_registration_errors_are_grouped(
     lock.fail_release = fail_release
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:
+    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
         assert fd == lock.descriptor
         msg = "registration failed"
         raise OSError(msg)
 
     fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
@@ -168,24 +168,24 @@ def test_acquisition_and_registration_errors_are_grouped(
     lock.fail_release = False
     lock.release(force=True)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
         real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: win32 no cover
 def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = _DescriptorLock(str(tmp_path / "group.lock"), is_singleton=False)
     lock.fail_release = True
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:
+    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
         assert fd == lock.descriptor
         msg = "registration failed"
         raise OSError(msg)
 
     fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
@@ -195,7 +195,7 @@ def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Pa
     lock.fail_release = False
     lock.release()
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
         real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (
         [(OSError, "registration failed"), (RuntimeError, "unlock failed")],
@@ -204,7 +204,7 @@ def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Pa
 
 
 @_REQUIRES_FORK
-def test_unverified_descriptor_does_not_close_reused_child_fd(tmp_path: Path) -> None:
+def test_unverified_descriptor_does_not_close_reused_child_fd(tmp_path: Path) -> None:  # pragma: win32 no cover
     script = """
 from __future__ import annotations
 
@@ -287,48 +287,48 @@ raise SystemExit(os.waitstatus_to_exitcode(status))
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: win32 no cover
 def test_control_flow_registration_error_rolls_back_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     descriptors: list[int] = []
 
-    class StopAcquire(BaseException):
+    class StopAcquire(BaseException):  # pragma: win32 no cover
         pass
 
-    class CapturingLock(_DescriptorLock):
-        def _acquire(self) -> None:
+    class CapturingLock(_DescriptorLock):  # pragma: win32 no cover
+        def _acquire(self) -> None:  # pragma: win32 no cover
             super()._acquire()
             descriptors.append(cast("int", self._context.lock_file_fd))
 
     real_fstat = os.fstat
 
-    def interrupt_registration(fd: int) -> os.stat_result:
+    def interrupt_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
         assert fd == descriptors[0]
         raise StopAcquire
 
     mocker.patch("os.fstat", side_effect=interrupt_registration)
-    with pytest.raises(StopAcquire):
+    with pytest.raises(StopAcquire):  # pragma: win32 no cover
         CapturingLock(str(tmp_path / "interrupt.lock"), is_singleton=False).acquire(timeout=0)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
         real_fstat(descriptors[0])
 
 
 @pytest.mark.asyncio
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: win32 no cover
 async def test_coroutine_registration_error_rolls_back_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     descriptors: list[int] = []
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:
+    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
         descriptors.append(fd)
         msg = "registration failed"
         raise OSError(msg)
 
     mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(OSError, match="registration failed"):
+    with pytest.raises(OSError, match="registration failed"):  # pragma: win32 no cover
         await _CoroutineDescriptorLock(str(tmp_path / "coroutine.lock"), is_singleton=False).acquire(timeout=0)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
         real_fstat(descriptors[0])
 
 
@@ -345,14 +345,14 @@ async def test_coroutine_acquisition_failure_before_descriptor_propagates(tmp_pa
 
 
 @_REQUIRES_FORK
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # pragma: win32 no cover
 async def test_coroutine_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path: Path) -> None:
     lock = _CoroutineDescriptorLock(
         str(tmp_path / "coroutine-partial.lock"), is_singleton=False, context_error_policy="group"
     )
     lock.acquire_error = RuntimeError("acquire failed")
     lock.release_error = RuntimeError("release failed")
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         await lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
 
@@ -389,7 +389,7 @@ async def test_coroutine_acquisition_failure_keeps_descriptor_registered_until_r
 )
 @_REQUIRES_FORK
 @pytest.mark.asyncio
-async def test_coroutine_acquisition_and_registration_errors_are_grouped(
+async def test_coroutine_acquisition_and_registration_errors_are_grouped(  # pragma: win32 no cover
     tmp_path: Path,
     mocker: MockerFixture,
     release_error: BaseException | None,
@@ -400,13 +400,13 @@ async def test_coroutine_acquisition_and_registration_errors_are_grouped(
     lock.release_error = release_error
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:
+    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
         assert fd == lock.descriptor
         msg = "registration failed"
         raise OSError(msg)
 
     fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         await lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
@@ -417,27 +417,27 @@ async def test_coroutine_acquisition_and_registration_errors_are_grouped(
     lock.release_error = None
     await lock.release(force=True)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
         real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
 
 
 @_REQUIRES_FORK
 @pytest.mark.asyncio
-async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fails(
+async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fails(  # pragma: win32 no cover
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
     lock = _CoroutineDescriptorLock(str(tmp_path / "coroutine-group.lock"), is_singleton=False)
     lock.release_error_before_close = RuntimeError("rollback failed")
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:
+    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
         assert fd == lock.descriptor
         msg = "registration failed"
         raise OSError(msg)
 
     fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         await lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
@@ -447,7 +447,7 @@ async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fa
     lock.release_error_before_close = None
     await lock.release()
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
         real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (
         [(OSError, "registration failed"), (RuntimeError, "rollback failed")],

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -497,7 +497,9 @@ def _error_details(group: BaseExceptionGroup) -> list[tuple[type[BaseException],
     return [(type(error), str(error)) for error in group.exceptions]
 
 
-def _fork_descriptor_probe(descriptor: int, stat_descriptor: Callable[[int], os.stat_result]) -> int:
+def _fork_descriptor_probe(  # pragma: win32 no cover
+    descriptor: int, stat_descriptor: Callable[[int], os.stat_result]
+) -> int:
     def probe_child() -> NoReturn:
         with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
             stat_descriptor(descriptor)

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -14,7 +14,7 @@ from filelock import BaseAsyncFileLock, BaseFileLock
 
 if sys.version_info >= (3, 11):
     from builtins import BaseExceptionGroup
-else:  # pragma: no cover (<py311)
+else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup
 
 if TYPE_CHECKING:
@@ -23,7 +23,9 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
+_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not (hasattr(os, "fork") and hasattr(os, "register_at_fork")), reason="os.fork and os.register_at_fork required"
+)
 
 
 class _DescriptorLock(BaseFileLock):
@@ -31,13 +33,13 @@ class _DescriptorLock(BaseFileLock):
     descriptor: int | None = None
     fail_release: bool = False
 
-    def _acquire(self) -> None:  # pragma: win32 no cover
+    def _acquire(self) -> None:  # pragma: needs fork
         self.descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
-        if self.acquire_error is not None:  # pragma: win32 no cover
+        if self.acquire_error is not None:
             raise self.acquire_error
 
-    def _release(self) -> None:  # pragma: win32 no cover
-        if self.fail_release:  # pragma: win32 no cover
+    def _release(self) -> None:  # pragma: needs fork
+        if self.fail_release:
             msg = "unlock failed"
             raise RuntimeError(msg)
         os.close(cast("int", self._context.lock_file_fd))
@@ -55,11 +57,11 @@ class _CoroutineDescriptorLock(BaseAsyncFileLock):
         if self.acquire_error_before_descriptor is not None:
             raise self.acquire_error_before_descriptor
         self.descriptor = self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
-        if self.acquire_error is not None:  # pragma: win32 no cover
+        if self.acquire_error is not None:  # pragma: needs fork
             raise self.acquire_error
 
     async def _release(self) -> None:  # ty: ignore[invalid-method-override]  # coroutine backends are supported
-        if self.release_error_before_close is not None:  # pragma: win32 no cover
+        if self.release_error_before_close is not None:  # pragma: needs fork
             raise self.release_error_before_close
         os.close(cast("int", self._context.lock_file_fd))
         self._context.lock_file_fd = None
@@ -67,8 +69,8 @@ class _CoroutineDescriptorLock(BaseAsyncFileLock):
             raise self.release_error
 
 
-@_REQUIRES_FORK
-def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:
     descriptors: list[int] = []
     lock = _DescriptorLock(str(tmp_path / "third-party.lock"), is_singleton=False, on_acquired=descriptors.append)
     lock.acquire()
@@ -80,13 +82,13 @@ def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:  # p
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK
-def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:
     descriptors: list[int] = []
     lock = _DescriptorLock(str(tmp_path / "retry.lock"), is_singleton=False, on_acquired=descriptors.append)
     lock.acquire()
     lock.fail_release = True
-    with pytest.raises(RuntimeError, match="unlock failed"):  # pragma: win32 no cover
+    with pytest.raises(RuntimeError, match="unlock failed"):
         lock.release()
 
     child_pid = _fork_descriptor_probe(descriptors[0], os.fstat)
@@ -97,12 +99,12 @@ def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:  # 
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
 def test_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path: Path) -> None:
     lock = _DescriptorLock(str(tmp_path / "partial.lock"), is_singleton=False)
     lock.acquire_error = RuntimeError("acquire failed")
     lock.fail_release = True
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         lock.acquire(timeout=0)
     child_pid = _fork_descriptor_probe(cast("int", lock.descriptor), os.fstat)
     _, status = os.waitpid(child_pid, 0)
@@ -138,8 +140,8 @@ def test_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path
         ),
     ],
 )
-@_REQUIRES_FORK
-def test_acquisition_and_registration_errors_are_grouped(  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+def test_acquisition_and_registration_errors_are_grouped(
     tmp_path: Path,
     mocker: MockerFixture,
     *,
@@ -151,13 +153,13 @@ def test_acquisition_and_registration_errors_are_grouped(  # pragma: win32 no co
     lock.fail_release = fail_release
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def fail_registration(fd: int) -> os.stat_result:
         assert fd == lock.descriptor
         msg = "registration failed"
         raise OSError(msg)
 
     fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
@@ -168,24 +170,24 @@ def test_acquisition_and_registration_errors_are_grouped(  # pragma: win32 no co
     lock.fail_release = False
     lock.release(force=True)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
         real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
 
 
-@_REQUIRES_FORK  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
 def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = _DescriptorLock(str(tmp_path / "group.lock"), is_singleton=False)
     lock.fail_release = True
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def fail_registration(fd: int) -> os.stat_result:
         assert fd == lock.descriptor
         msg = "registration failed"
         raise OSError(msg)
 
     fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
@@ -195,7 +197,7 @@ def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Pa
     lock.fail_release = False
     lock.release()
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
         real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (
         [(OSError, "registration failed"), (RuntimeError, "unlock failed")],
@@ -203,8 +205,8 @@ def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Pa
     )
 
 
-@_REQUIRES_FORK
-def test_unverified_descriptor_does_not_close_reused_child_fd(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+def test_unverified_descriptor_does_not_close_reused_child_fd(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
 
@@ -287,48 +289,48 @@ raise SystemExit(os.waitstatus_to_exitcode(status))
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
 def test_control_flow_registration_error_rolls_back_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     descriptors: list[int] = []
 
-    class StopAcquire(BaseException):  # pragma: win32 no cover
+    class StopAcquire(BaseException):
         pass
 
-    class CapturingLock(_DescriptorLock):  # pragma: win32 no cover
-        def _acquire(self) -> None:  # pragma: win32 no cover
+    class CapturingLock(_DescriptorLock):
+        def _acquire(self) -> None:
             super()._acquire()
             descriptors.append(cast("int", self._context.lock_file_fd))
 
     real_fstat = os.fstat
 
-    def interrupt_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def interrupt_registration(fd: int) -> os.stat_result:
         assert fd == descriptors[0]
         raise StopAcquire
 
     mocker.patch("os.fstat", side_effect=interrupt_registration)
-    with pytest.raises(StopAcquire):  # pragma: win32 no cover
+    with pytest.raises(StopAcquire):
         CapturingLock(str(tmp_path / "interrupt.lock"), is_singleton=False).acquire(timeout=0)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
         real_fstat(descriptors[0])
 
 
 @pytest.mark.asyncio
-@_REQUIRES_FORK  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
 async def test_coroutine_registration_error_rolls_back_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     descriptors: list[int] = []
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def fail_registration(fd: int) -> os.stat_result:
         descriptors.append(fd)
         msg = "registration failed"
         raise OSError(msg)
 
     mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(OSError, match="registration failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="registration failed"):
         await _CoroutineDescriptorLock(str(tmp_path / "coroutine.lock"), is_singleton=False).acquire(timeout=0)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
         real_fstat(descriptors[0])
 
 
@@ -344,15 +346,15 @@ async def test_coroutine_acquisition_failure_before_descriptor_propagates(tmp_pa
     assert (info.value is acquisition_error, lock.is_locked) == (True, False)
 
 
-@_REQUIRES_FORK
-@pytest.mark.asyncio  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@pytest.mark.asyncio
 async def test_coroutine_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path: Path) -> None:
     lock = _CoroutineDescriptorLock(
         str(tmp_path / "coroutine-partial.lock"), is_singleton=False, context_error_policy="group"
     )
     lock.acquire_error = RuntimeError("acquire failed")
     lock.release_error = RuntimeError("release failed")
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         await lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
 
@@ -387,9 +389,9 @@ async def test_coroutine_acquisition_failure_keeps_descriptor_registered_until_r
         ),
     ],
 )
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @pytest.mark.asyncio
-async def test_coroutine_acquisition_and_registration_errors_are_grouped(  # pragma: win32 no cover
+async def test_coroutine_acquisition_and_registration_errors_are_grouped(
     tmp_path: Path,
     mocker: MockerFixture,
     release_error: BaseException | None,
@@ -400,13 +402,13 @@ async def test_coroutine_acquisition_and_registration_errors_are_grouped(  # pra
     lock.release_error = release_error
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def fail_registration(fd: int) -> os.stat_result:
         assert fd == lock.descriptor
         msg = "registration failed"
         raise OSError(msg)
 
     fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         await lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
@@ -417,27 +419,27 @@ async def test_coroutine_acquisition_and_registration_errors_are_grouped(  # pra
     lock.release_error = None
     await lock.release(force=True)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
         real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @pytest.mark.asyncio
-async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fails(  # pragma: win32 no cover
+async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fails(
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
     lock = _CoroutineDescriptorLock(str(tmp_path / "coroutine-group.lock"), is_singleton=False)
     lock.release_error_before_close = RuntimeError("rollback failed")
     real_fstat = os.fstat
 
-    def fail_registration(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def fail_registration(fd: int) -> os.stat_result:
         assert fd == lock.descriptor
         msg = "registration failed"
         raise OSError(msg)
 
     fstat_mock = mocker.patch("os.fstat", side_effect=fail_registration)
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         await lock.acquire(timeout=0)
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
@@ -447,7 +449,7 @@ async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fa
     lock.release_error_before_close = None
     await lock.release()
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
         real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (
         [(OSError, "registration failed"), (RuntimeError, "rollback failed")],
@@ -497,7 +499,7 @@ def _error_details(group: BaseExceptionGroup) -> list[tuple[type[BaseException],
     return [(type(error), str(error)) for error in group.exceptions]
 
 
-def _fork_descriptor_probe(  # pragma: win32 no cover
+def _fork_descriptor_probe(  # pragma: needs fork
     descriptor: int, stat_descriptor: Callable[[int], os.stat_result]
 ) -> int:
     def probe_child() -> NoReturn:

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -22,7 +22,7 @@ _FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-def test_callbacks_registered_before_filelock_can_use_locks(tmp_path: Path) -> None:
+def test_callbacks_registered_before_filelock_can_use_locks(tmp_path: Path) -> None:  # pragma: win32 no cover
     script = """
 from __future__ import annotations
 
@@ -90,7 +90,7 @@ if (
     "audit_mode",
     [pytest.param("installed", id="audit-installed"), pytest.param("rejected", id="audit-rejected")],
 )
-def test_concurrent_fork_after_first_snapshot_does_not_deadlock(
+def test_concurrent_fork_after_first_snapshot_does_not_deadlock(  # pragma: win32 no cover
     tmp_path: Path, audit_mode: Literal["installed", "rejected"]
 ) -> None:
     script = """
@@ -170,16 +170,16 @@ if second_status != 0 or owner.is_alive() or statuses.get(timeout=1) != 0:
         pytest.param("_posixsubprocess.fork_exec", id="fork-exec"),
     ],
 )
-def test_audit_rejects_process_creation_inside_descriptor_transition(
+def test_audit_rejects_process_creation_inside_descriptor_transition(  # pragma: win32 no cover
     tmp_path: Path,
     event: Literal["os.fork", "os.forkpty", "_posixsubprocess.fork_exec"],
 ) -> None:
-    class AuditedLock(BaseFileLock):
-        def _acquire(self) -> None:
+    class AuditedLock(BaseFileLock):  # pragma: win32 no cover
+        def _acquire(self) -> None:  # pragma: win32 no cover
             self._context.lock_file_fd = None
-            if event == "_posixsubprocess.fork_exec":
+            if event == "_posixsubprocess.fork_exec":  # pragma: win32 no cover
                 sys.audit(event, (), (), None)
-            else:
+            else:  # pragma: win32 no cover
                 sys.audit(event)
 
         _release = _acquire
@@ -201,7 +201,7 @@ def test_audit_rejects_process_creation_inside_descriptor_transition(
         ),
     ],
 )
-def test_fork_without_audit_guard_snapshots_current_transition(
+def test_fork_without_audit_guard_snapshots_current_transition(  # pragma: win32 no cover
     tmp_path: Path, fork_mode: Literal["rejected-audit", "fork1"]
 ) -> None:
     script = """
@@ -273,7 +273,7 @@ raise SystemExit(lock.child_status)
         ),
     ],
 )
-def test_native_descriptor_is_visible_during_flock_audit(
+def test_native_descriptor_is_visible_during_flock_audit(  # pragma: win32 no cover
     tmp_path: Path, fork_mode: Literal["rejected-audit", "fork1"]
 ) -> None:
     script = """
@@ -327,7 +327,7 @@ raise SystemExit(child_status)
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-def test_child_unwinds_pre_fork_transition_before_new_acquire(tmp_path: Path) -> None:
+def test_child_unwinds_pre_fork_transition_before_new_acquire(tmp_path: Path) -> None:  # pragma: win32 no cover
     script = """
 from __future__ import annotations
 
@@ -408,7 +408,7 @@ raise SystemExit(os.waitstatus_to_exitcode(status))
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 def test_overlapping_coroutine_transitions_close_every_pending_descriptor(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -482,7 +482,7 @@ asyncio.run(main())
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 def test_pending_descriptor_with_unknown_identity_is_preserved_in_child(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -547,7 +547,7 @@ raise SystemExit(lock.child_status)
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 def test_child_replaces_parameter_model_mutex_held_during_construction(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -634,7 +634,7 @@ if os.waitstatus_to_exitcode(status) != 0 or worker.is_alive() or os.getpid() !=
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 def test_registration_transition_completes_after_fork_closes_admission(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -722,7 +722,7 @@ lock.release()
 @_REQUIRES_FORK
 @_FORK_WARNING
 @pytest.mark.skipif(not has_fcntl, reason="fcntl.flock required")
-def test_cancelled_async_acquire_unregisters_reused_descriptor(tmp_path: Path) -> None:
+def test_cancelled_async_acquire_unregisters_reused_descriptor(tmp_path: Path) -> None:  # pragma: win32 no cover
     script = """
 from __future__ import annotations
 
@@ -809,7 +809,7 @@ raise SystemExit(asyncio.run(main()))
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-def test_parent_callback_rejects_reentrant_singleton_construction(tmp_path: Path) -> None:
+def test_parent_callback_rejects_reentrant_singleton_construction(tmp_path: Path) -> None:  # pragma: win32 no cover
     script = """
 from __future__ import annotations
 
@@ -913,7 +913,7 @@ if (
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 def test_singleton_construction_crossing_fork_does_not_poison_child_cache(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -970,7 +970,7 @@ if (
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 def test_soft_read_write_construction_crossing_fork_does_not_poison_child_cache(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -1069,21 +1069,21 @@ def test_fork_exec_from_another_thread_remains_available(tmp_path: Path) -> None
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) -> None:
+def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) -> None:  # pragma: win32 no cover
     entered, release = threading.Event(), threading.Event()
     parent_pid = os.getpid()
 
-    class BlockingLock(BaseFileLock):
-        def __init__(self, lock_file: str, *, is_singleton: bool = False) -> None:
-            if os.getpid() == parent_pid:
+    class BlockingLock(BaseFileLock):  # pragma: win32 no cover
+        def __init__(self, lock_file: str, *, is_singleton: bool = False) -> None:  # pragma: win32 no cover
+            if os.getpid() == parent_pid:  # pragma: win32 no cover
                 entered.set()
                 release.wait(timeout=5)
             super().__init__(lock_file, thread_local=False, is_singleton=is_singleton)
 
-        def _acquire(self) -> None:
+        def _acquire(self) -> None:  # pragma: win32 no cover
             self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
 
-        def _release(self) -> None:
+        def _release(self) -> None:  # pragma: win32 no cover
             os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
             self._context.lock_file_fd = None
 
@@ -1091,7 +1091,7 @@ def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) 
     worker.start()
     assert entered.wait(timeout=5)
 
-    if (child_pid := fork_process()) == 0:
+    if (child_pid := fork_process()) == 0:  # pragma: win32 no cover
         child_lock = BlockingLock(str(tmp_path / "mutex.lock"), is_singleton=True)
         child_lock.acquire(timeout=0)
         child_lock.release()

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -1092,10 +1092,12 @@ def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) 
     assert entered.wait(timeout=5)
 
     if (child_pid := fork_process()) == 0:  # pragma: win32 no cover
-        child_lock = BlockingLock(str(tmp_path / "mutex.lock"), is_singleton=True)
-        child_lock.acquire(timeout=0)
-        child_lock.release()
-        exit_child(0)
+        child_lock = BlockingLock(
+            str(tmp_path / "mutex.lock"), is_singleton=True
+        )  # pragma: no cover  # runs in the forked child, not measured
+        child_lock.acquire(timeout=0)  # pragma: no cover  # runs in the forked child, not measured
+        child_lock.release()  # pragma: no cover  # runs in the forked child, not measured
+        exit_child(0)  # pragma: no cover  # runs in the forked child, not measured
     _, status = os.waitpid(child_pid, 0)
     release.set()
     worker.join(timeout=5)

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -14,15 +14,17 @@ from filelock import BaseFileLock, Timeout, has_fcntl
 if TYPE_CHECKING:
     from pathlib import Path
 
-_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
+_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not (hasattr(os, "fork") and hasattr(os, "register_at_fork")), reason="os.fork and os.register_at_fork required"
+)
 _FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
     "ignore:.*multi-threaded, use of fork.*:DeprecationWarning"
 )
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-def test_callbacks_registered_before_filelock_can_use_locks(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_callbacks_registered_before_filelock_can_use_locks(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
 
@@ -84,13 +86,13 @@ if (
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     "audit_mode",
     [pytest.param("installed", id="audit-installed"), pytest.param("rejected", id="audit-rejected")],
 )
-def test_concurrent_fork_after_first_snapshot_does_not_deadlock(  # pragma: win32 no cover
+def test_concurrent_fork_after_first_snapshot_does_not_deadlock(
     tmp_path: Path, audit_mode: Literal["installed", "rejected"]
 ) -> None:
     script = """
@@ -161,7 +163,7 @@ if second_status != 0 or owner.is_alive() or statuses.get(timeout=1) != 0:
     assert result.returncode == 0, result.stderr
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @pytest.mark.parametrize(
     "event",
     [
@@ -170,16 +172,16 @@ if second_status != 0 or owner.is_alive() or statuses.get(timeout=1) != 0:
         pytest.param("_posixsubprocess.fork_exec", id="fork-exec"),
     ],
 )
-def test_audit_rejects_process_creation_inside_descriptor_transition(  # pragma: win32 no cover
+def test_audit_rejects_process_creation_inside_descriptor_transition(
     tmp_path: Path,
     event: Literal["os.fork", "os.forkpty", "_posixsubprocess.fork_exec"],
 ) -> None:
-    class AuditedLock(BaseFileLock):  # pragma: win32 no cover
-        def _acquire(self) -> None:  # pragma: win32 no cover
+    class AuditedLock(BaseFileLock):
+        def _acquire(self) -> None:
             self._context.lock_file_fd = None
-            if event == "_posixsubprocess.fork_exec":  # pragma: win32 no cover
+            if event == "_posixsubprocess.fork_exec":
                 sys.audit(event, (), (), None)
-            else:  # pragma: win32 no cover
+            else:
                 sys.audit(event)
 
         _release = _acquire
@@ -188,7 +190,7 @@ def test_audit_rejects_process_creation_inside_descriptor_transition(  # pragma:
         AuditedLock(str(tmp_path / "audit.lock"), is_singleton=False).acquire(timeout=0)
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     "fork_mode",
@@ -201,7 +203,7 @@ def test_audit_rejects_process_creation_inside_descriptor_transition(  # pragma:
         ),
     ],
 )
-def test_fork_without_audit_guard_snapshots_current_transition(  # pragma: win32 no cover
+def test_fork_without_audit_guard_snapshots_current_transition(
     tmp_path: Path, fork_mode: Literal["rejected-audit", "fork1"]
 ) -> None:
     script = """
@@ -258,7 +260,7 @@ raise SystemExit(lock.child_status)
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.skipif(not has_fcntl, reason="fcntl.flock required")
 @pytest.mark.skipif(sys.implementation.name != "cpython", reason="CPython fcntl audit event required")
@@ -273,7 +275,7 @@ raise SystemExit(lock.child_status)
         ),
     ],
 )
-def test_native_descriptor_is_visible_during_flock_audit(  # pragma: win32 no cover
+def test_native_descriptor_is_visible_during_flock_audit(
     tmp_path: Path, fork_mode: Literal["rejected-audit", "fork1"]
 ) -> None:
     script = """
@@ -325,9 +327,9 @@ raise SystemExit(child_status)
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-def test_child_unwinds_pre_fork_transition_before_new_acquire(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_child_unwinds_pre_fork_transition_before_new_acquire(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
 
@@ -407,8 +409,8 @@ raise SystemExit(os.waitstatus_to_exitcode(status))
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 def test_overlapping_coroutine_transitions_close_every_pending_descriptor(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -481,8 +483,8 @@ asyncio.run(main())
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 def test_pending_descriptor_with_unknown_identity_is_preserved_in_child(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -546,8 +548,8 @@ raise SystemExit(lock.child_status)
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 def test_child_replaces_parameter_model_mutex_held_during_construction(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -633,8 +635,8 @@ if os.waitstatus_to_exitcode(status) != 0 or worker.is_alive() or os.getpid() !=
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 def test_registration_transition_completes_after_fork_closes_admission(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -719,10 +721,10 @@ lock.release()
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.skipif(not has_fcntl, reason="fcntl.flock required")
-def test_cancelled_async_acquire_unregisters_reused_descriptor(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_cancelled_async_acquire_unregisters_reused_descriptor(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
 
@@ -807,9 +809,9 @@ raise SystemExit(asyncio.run(main()))
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-def test_parent_callback_rejects_reentrant_singleton_construction(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_parent_callback_rejects_reentrant_singleton_construction(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
 
@@ -912,8 +914,8 @@ if (
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 def test_singleton_construction_crossing_fork_does_not_poison_child_cache(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -969,8 +971,8 @@ if (
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 def test_soft_read_write_construction_crossing_fork_does_not_poison_child_cache(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -1067,23 +1069,23 @@ def test_fork_exec_from_another_thread_remains_available(tmp_path: Path) -> None
     assert (result.returncode, finished.is_set(), worker.is_alive()) == (0, True, False)
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) -> None:
     entered, release = threading.Event(), threading.Event()
     parent_pid = os.getpid()
 
-    class BlockingLock(BaseFileLock):  # pragma: win32 no cover
-        def __init__(self, lock_file: str, *, is_singleton: bool = False) -> None:  # pragma: win32 no cover
-            if os.getpid() == parent_pid:  # pragma: win32 no cover
+    class BlockingLock(BaseFileLock):
+        def __init__(self, lock_file: str, *, is_singleton: bool = False) -> None:
+            if os.getpid() == parent_pid:
                 entered.set()
                 release.wait(timeout=5)
             super().__init__(lock_file, thread_local=False, is_singleton=is_singleton)
 
-        def _acquire(self) -> None:  # pragma: win32 no cover
+        def _acquire(self) -> None:
             self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
 
-        def _release(self) -> None:  # pragma: win32 no cover
+        def _release(self) -> None:
             os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
             self._context.lock_file_fd = None
 
@@ -1091,13 +1093,11 @@ def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) 
     worker.start()
     assert entered.wait(timeout=5)
 
-    if (child_pid := fork_process()) == 0:  # pragma: win32 no cover
-        child_lock = BlockingLock(
-            str(tmp_path / "mutex.lock"), is_singleton=True
-        )  # pragma: no cover  # runs in the forked child, not measured
-        child_lock.acquire(timeout=0)  # pragma: no cover  # runs in the forked child, not measured
-        child_lock.release()  # pragma: no cover  # runs in the forked child, not measured
-        exit_child(0)  # pragma: no cover  # runs in the forked child, not measured
+    if (child_pid := fork_process()) == 0:  # pragma: forked child
+        child_lock = BlockingLock(str(tmp_path / "mutex.lock"), is_singleton=True)
+        child_lock.acquire(timeout=0)
+        child_lock.release()
+        exit_child(0)
     _, status = os.waitpid(child_pid, 0)
     release.set()
     worker.join(timeout=5)

--- a/tests/test_fork_ownership.py
+++ b/tests/test_fork_ownership.py
@@ -28,7 +28,7 @@ from filelock import (
 
 if sys.version_info >= (3, 11):
     from builtins import BaseExceptionGroup
-else:  # pragma: no cover (<py311)
+else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup
 
 if TYPE_CHECKING:
@@ -36,13 +36,15 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
+_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not (hasattr(os, "fork") and hasattr(os, "register_at_fork")), reason="os.fork and os.register_at_fork required"
+)
 _FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
     "ignore:.*multi-threaded, use of fork.*:DeprecationWarning"
 )
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     ("lock_type", "action"),
@@ -55,7 +57,7 @@ _FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
         pytest.param(SoftFileLock, "collect", id="soft-collect"),
     ],
 )
-def test_child_cleanup_preserves_parent_lock(  # pragma: win32 no cover
+def test_child_cleanup_preserves_parent_lock(
     tmp_path: Path,
     lock_type: type[BaseFileLock],
     action: Literal["release", "context", "collect"],
@@ -76,7 +78,7 @@ def test_child_cleanup_preserves_parent_lock(  # pragma: win32 no cover
     assert _probe_lock(lock_type, path)
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     ("async_lock_type", "sync_lock_type"),
@@ -85,7 +87,7 @@ def test_child_cleanup_preserves_parent_lock(  # pragma: win32 no cover
         pytest.param(AsyncSoftFileLock, SoftFileLock, id="soft"),
     ],
 )
-def test_async_child_release_preserves_parent_lock(  # pragma: win32 no cover
+def test_async_child_release_preserves_parent_lock(
     tmp_path: Path,
     async_lock_type: type[BaseAsyncFileLock],
     sync_lock_type: type[BaseFileLock],
@@ -108,9 +110,9 @@ def test_async_child_release_preserves_parent_lock(  # pragma: win32 no cover
     assert _probe_lock(sync_lock_type, path)
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None:
     path = str(tmp_path / "parent.lock")
     older = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
     newer = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
@@ -129,23 +131,23 @@ def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None
 
     assert os.waitstatus_to_exitcode(status) == 0
     contender = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
-    with pytest.raises(Timeout):  # pragma: win32 no cover
+    with pytest.raises(Timeout):
         contender.acquire_write(timeout=0)
     contender.close()
     older.release()
     older.close()
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None:
     path = str(tmp_path / "parent.lock")
     descriptor: Queue[int] = Queue()
     acquired, release = threading.Event(), threading.Event()
 
-    def hold_lock() -> None:  # pragma: win32 no cover
+    def hold_lock() -> None:
         lock = FileLock(path, thread_local=True, is_singleton=False, on_acquired=descriptor.put)
-        with lock:  # pragma: win32 no cover
+        with lock:
             acquired.set()
             release.wait()
 
@@ -165,8 +167,8 @@ def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None
     assert (os.waitstatus_to_exitcode(status), worker.is_alive()) == (0, False)
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFixture) -> None:
     path = str(tmp_path / "parent.lock")
     lock = FileLock(path, thread_local=False, is_singleton=False)
@@ -174,8 +176,8 @@ def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFi
     descriptors: list[int] = []
     real_fstat = os.fstat
 
-    def delayed_fstat(fd: int) -> os.stat_result:  # pragma: win32 no cover
-        if threading.current_thread() is worker and not entered.is_set():  # pragma: win32 no cover
+    def delayed_fstat(fd: int) -> os.stat_result:
+        if threading.current_thread() is worker and not entered.is_set():
             descriptors.append(fd)
             entered.set()
             proceed.wait()
@@ -183,7 +185,7 @@ def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFi
 
     mocker.patch("os.fstat", side_effect=delayed_fstat)
 
-    def acquire_lock() -> None:  # pragma: win32 no cover
+    def acquire_lock() -> None:
         lock.acquire()
         acquired.set()
 
@@ -206,21 +208,22 @@ def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFi
 
 
 @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="fork transition gate requires register_at_fork")
-def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(  # pragma: win32 no cover
+def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
     boundary = threading.Barrier(3, timeout=5)
     real_fstat = os.fstat
 
-    def wait_at_boundary(fd: int) -> os.stat_result:  # pragma: win32 no cover
-        if threading.current_thread().name.startswith("concurrent-acquire-"):  # pragma: win32 no cover
+    def wait_at_boundary(fd: int) -> os.stat_result:
+        # Only the two named workers stat while the patch is installed, so the guard never takes its false arc.
+        if threading.current_thread().name.startswith("concurrent-acquire-"):  # pragma: no branch
             boundary.wait()
         return real_fstat(fd)
 
     mocker.patch("os.fstat", side_effect=wait_at_boundary)
 
-    def acquire_lock(path: str) -> None:  # pragma: win32 no cover
-        with FileLock(path, is_singleton=False):  # pragma: win32 no cover
+    def acquire_lock(path: str) -> None:
+        with FileLock(path, is_singleton=False):
             pass
 
     workers = [
@@ -231,19 +234,19 @@ def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(  # pragm
         )
         for index in range(2)
     ]
-    for worker in workers:  # pragma: win32 no cover
+    for worker in workers:
         worker.start()
-    try:  # pragma: win32 no cover
+    try:
         boundary.wait()
     finally:
-        for worker in workers:  # pragma: win32 no cover
+        for worker in workers:
             worker.join(timeout=5)
 
     assert [worker.is_alive() for worker in workers] == [False, False]
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 @pytest.mark.parametrize("lock_type", [pytest.param(FileLock, id="native"), pytest.param(SoftFileLock, id="soft")])
 def test_child_singleton_registry_drops_parent_instance(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     path = str(tmp_path / "parent.lock")
@@ -259,8 +262,8 @@ def test_child_singleton_registry_drops_parent_instance(tmp_path: Path, lock_typ
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK
-@_FORK_WARNING  # pragma: win32 no cover
+@_REQUIRES_FORK  # pragma: needs fork
+@_FORK_WARNING
 @pytest.mark.parametrize("lock_type", [pytest.param(FileLock, id="native"), pytest.param(SoftFileLock, id="soft")])
 def test_inherited_idle_lock_rejects_acquire(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     lock = lock_type(str(tmp_path / "parent.lock"), is_singleton=False)
@@ -278,9 +281,9 @@ def test_inherited_idle_lock_rejects_acquire(tmp_path: Path, lock_type: type[Bas
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-@pytest.mark.parametrize(  # pragma: win32 no cover
+@pytest.mark.parametrize(
     "lock_type", [pytest.param(AsyncFileLock, id="native"), pytest.param(AsyncSoftFileLock, id="soft")]
 )
 def test_inherited_idle_async_lock_rejects_acquire(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
@@ -299,9 +302,9 @@ def test_inherited_idle_async_lock_rejects_acquire(tmp_path: Path, lock_type: ty
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None:
     path = str(tmp_path / "parent.lock")
     fork_result = -1
     lock: FileLock
@@ -313,7 +316,7 @@ def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None
             exit_child(0 if "inherited across fork" in str(exception) else 1)
         exit_child(1)
 
-    def fork_from_hook(_fd: int) -> None:  # pragma: win32 no cover
+    def fork_from_hook(_fd: int) -> None:
         nonlocal fork_result
         fork_result = fork_process(inherited_child)
 
@@ -325,7 +328,7 @@ def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None
 
 
 @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="descriptor registry requires register_at_fork")
-def test_reader_directory_registration_failure_closes_descriptor(  # pragma: win32 no cover
+def test_reader_directory_registration_failure_closes_descriptor(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
     lock = SoftReadWriteLock(
@@ -337,7 +340,7 @@ def test_reader_directory_registration_failure_closes_descriptor(  # pragma: win
     real_fstat = os.fstat
     directory_fds: list[int] = []
 
-    def fail_directory_fstat(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def fail_directory_fstat(fd: int) -> os.stat_result:
         stat_result = real_fstat(fd)
         assert S_ISDIR(stat_result.st_mode)
         directory_fds.append(fd)
@@ -345,16 +348,16 @@ def test_reader_directory_registration_failure_closes_descriptor(  # pragma: win
         raise OSError(msg)
 
     mocker.patch("os.fstat", side_effect=fail_directory_fstat)
-    with pytest.raises(OSError, match="directory identity unavailable"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="directory identity unavailable"):
         lock.acquire_read()
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
         real_fstat(directory_fds[0])
     lock.close()
 
 
 @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="descriptor registry requires register_at_fork")
-def test_reader_directory_registration_and_close_errors_are_grouped(  # pragma: win32 no cover
+def test_reader_directory_registration_and_close_errors_are_grouped(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
     lock = SoftReadWriteLock(
@@ -366,21 +369,21 @@ def test_reader_directory_registration_and_close_errors_are_grouped(  # pragma: 
     real_close, real_fstat = os.close, os.fstat
     directory_fds: list[int] = []
 
-    def fail_directory_fstat(fd: int) -> os.stat_result:  # pragma: win32 no cover
+    def fail_directory_fstat(fd: int) -> os.stat_result:
         stat_result = real_fstat(fd)
         assert S_ISDIR(stat_result.st_mode)
         directory_fds.append(fd)
         msg = "directory identity unavailable"
         raise OSError(msg)
 
-    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
+    def fail_directory_close(fd: int) -> None:
         assert fd == directory_fds[0]
         msg = "directory close failed"
         raise OSError(msg)
 
     mocker.patch("os.fstat", side_effect=fail_directory_fstat)
     mocker.patch("os.close", side_effect=fail_directory_close)
-    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as info:
         lock.acquire_read()
     real_close(directory_fds[0])
     lock.close()
@@ -391,9 +394,9 @@ def test_reader_directory_registration_and_close_errors_are_grouped(  # pragma: 
     ]
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
-def test_child_callback_registered_before_filelock_can_acquire(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_child_callback_registered_before_filelock_can_acquire(tmp_path: Path) -> None:
     script = """
 import os
 import sys
@@ -440,7 +443,7 @@ parent.release()
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK
+@_REQUIRES_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     "kind",
@@ -450,7 +453,7 @@ parent.release()
         pytest.param("soft-rw", id="soft-read-write"),
     ],
 )
-def test_child_interpreter_exit_preserves_parent_lock(  # pragma: win32 no cover
+def test_child_interpreter_exit_preserves_parent_lock(
     tmp_path: Path, kind: Literal["native", "soft", "soft-rw"]
 ) -> None:
     script = """
@@ -538,7 +541,7 @@ def _run_child_cleanup(
     exit_child(0)
 
 
-def _probe_lock(lock_type: type[BaseFileLock], path: str) -> bool:  # pragma: win32 no cover
+def _probe_lock(lock_type: type[BaseFileLock], path: str) -> bool:  # pragma: needs fork
     read_fd, write_fd = os.pipe()
 
     def probe_child() -> NoReturn:

--- a/tests/test_fork_ownership.py
+++ b/tests/test_fork_ownership.py
@@ -206,7 +206,9 @@ def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFi
 
 
 @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="fork transition gate requires register_at_fork")
-def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(  # pragma: win32 no cover
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
     boundary = threading.Barrier(3, timeout=5)
     real_fstat = os.fstat
 
@@ -323,7 +325,9 @@ def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None
 
 
 @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="descriptor registry requires register_at_fork")
-def test_reader_directory_registration_failure_closes_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_reader_directory_registration_failure_closes_descriptor(  # pragma: win32 no cover
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
     lock = SoftReadWriteLock(
         str(tmp_path / "parent.lock"),
         is_singleton=False,
@@ -350,7 +354,9 @@ def test_reader_directory_registration_failure_closes_descriptor(tmp_path: Path,
 
 
 @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="descriptor registry requires register_at_fork")
-def test_reader_directory_registration_and_close_errors_are_grouped(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_reader_directory_registration_and_close_errors_are_grouped(  # pragma: win32 no cover
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
     lock = SoftReadWriteLock(
         str(tmp_path / "parent.lock"),
         is_singleton=False,

--- a/tests/test_fork_ownership.py
+++ b/tests/test_fork_ownership.py
@@ -55,7 +55,7 @@ _FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
         pytest.param(SoftFileLock, "collect", id="soft-collect"),
     ],
 )
-def test_child_cleanup_preserves_parent_lock(
+def test_child_cleanup_preserves_parent_lock(  # pragma: win32 no cover
     tmp_path: Path,
     lock_type: type[BaseFileLock],
     action: Literal["release", "context", "collect"],
@@ -85,7 +85,7 @@ def test_child_cleanup_preserves_parent_lock(
         pytest.param(AsyncSoftFileLock, SoftFileLock, id="soft"),
     ],
 )
-def test_async_child_release_preserves_parent_lock(
+def test_async_child_release_preserves_parent_lock(  # pragma: win32 no cover
     tmp_path: Path,
     async_lock_type: type[BaseAsyncFileLock],
     sync_lock_type: type[BaseFileLock],
@@ -110,7 +110,7 @@ def test_async_child_release_preserves_parent_lock(
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None:
+def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = str(tmp_path / "parent.lock")
     older = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
     newer = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
@@ -129,7 +129,7 @@ def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None
 
     assert os.waitstatus_to_exitcode(status) == 0
     contender = SoftReadWriteLock(path, is_singleton=False, heartbeat_interval=0.1, stale_threshold=0.5)
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 no cover
         contender.acquire_write(timeout=0)
     contender.close()
     older.release()
@@ -138,14 +138,14 @@ def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None:
+def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = str(tmp_path / "parent.lock")
     descriptor: Queue[int] = Queue()
     acquired, release = threading.Event(), threading.Event()
 
-    def hold_lock() -> None:
+    def hold_lock() -> None:  # pragma: win32 no cover
         lock = FileLock(path, thread_local=True, is_singleton=False, on_acquired=descriptor.put)
-        with lock:
+        with lock:  # pragma: win32 no cover
             acquired.set()
             release.wait()
 
@@ -166,7 +166,7 @@ def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFixture) -> None:
     path = str(tmp_path / "parent.lock")
     lock = FileLock(path, thread_local=False, is_singleton=False)
@@ -174,8 +174,8 @@ def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFi
     descriptors: list[int] = []
     real_fstat = os.fstat
 
-    def delayed_fstat(fd: int) -> os.stat_result:
-        if threading.current_thread() is worker and not entered.is_set():
+    def delayed_fstat(fd: int) -> os.stat_result:  # pragma: win32 no cover
+        if threading.current_thread() is worker and not entered.is_set():  # pragma: win32 no cover
             descriptors.append(fd)
             entered.set()
             proceed.wait()
@@ -183,7 +183,7 @@ def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFi
 
     mocker.patch("os.fstat", side_effect=delayed_fstat)
 
-    def acquire_lock() -> None:
+    def acquire_lock() -> None:  # pragma: win32 no cover
         lock.acquire()
         acquired.set()
 
@@ -210,15 +210,15 @@ def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(tmp_path:
     boundary = threading.Barrier(3, timeout=5)
     real_fstat = os.fstat
 
-    def wait_at_boundary(fd: int) -> os.stat_result:
-        if threading.current_thread().name.startswith("concurrent-acquire-"):
+    def wait_at_boundary(fd: int) -> os.stat_result:  # pragma: win32 no cover
+        if threading.current_thread().name.startswith("concurrent-acquire-"):  # pragma: win32 no cover
             boundary.wait()
         return real_fstat(fd)
 
     mocker.patch("os.fstat", side_effect=wait_at_boundary)
 
-    def acquire_lock(path: str) -> None:
-        with FileLock(path, is_singleton=False):
+    def acquire_lock(path: str) -> None:  # pragma: win32 no cover
+        with FileLock(path, is_singleton=False):  # pragma: win32 no cover
             pass
 
     workers = [
@@ -229,19 +229,19 @@ def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(tmp_path:
         )
         for index in range(2)
     ]
-    for worker in workers:
+    for worker in workers:  # pragma: win32 no cover
         worker.start()
-    try:
+    try:  # pragma: win32 no cover
         boundary.wait()
     finally:
-        for worker in workers:
+        for worker in workers:  # pragma: win32 no cover
             worker.join(timeout=5)
 
     assert [worker.is_alive() for worker in workers] == [False, False]
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 @pytest.mark.parametrize("lock_type", [pytest.param(FileLock, id="native"), pytest.param(SoftFileLock, id="soft")])
 def test_child_singleton_registry_drops_parent_instance(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     path = str(tmp_path / "parent.lock")
@@ -258,7 +258,7 @@ def test_child_singleton_registry_drops_parent_instance(tmp_path: Path, lock_typ
 
 
 @_REQUIRES_FORK
-@_FORK_WARNING
+@_FORK_WARNING  # pragma: win32 no cover
 @pytest.mark.parametrize("lock_type", [pytest.param(FileLock, id="native"), pytest.param(SoftFileLock, id="soft")])
 def test_inherited_idle_lock_rejects_acquire(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     lock = lock_type(str(tmp_path / "parent.lock"), is_singleton=False)
@@ -278,7 +278,7 @@ def test_inherited_idle_lock_rejects_acquire(tmp_path: Path, lock_type: type[Bas
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # pragma: win32 no cover
     "lock_type", [pytest.param(AsyncFileLock, id="native"), pytest.param(AsyncSoftFileLock, id="soft")]
 )
 def test_inherited_idle_async_lock_rejects_acquire(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
@@ -299,7 +299,7 @@ def test_inherited_idle_async_lock_rejects_acquire(tmp_path: Path, lock_type: ty
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None:
+def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = str(tmp_path / "parent.lock")
     fork_result = -1
     lock: FileLock
@@ -311,7 +311,7 @@ def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None
             exit_child(0 if "inherited across fork" in str(exception) else 1)
         exit_child(1)
 
-    def fork_from_hook(_fd: int) -> None:
+    def fork_from_hook(_fd: int) -> None:  # pragma: win32 no cover
         nonlocal fork_result
         fork_result = fork_process(inherited_child)
 
@@ -333,7 +333,7 @@ def test_reader_directory_registration_failure_closes_descriptor(tmp_path: Path,
     real_fstat = os.fstat
     directory_fds: list[int] = []
 
-    def fail_directory_fstat(fd: int) -> os.stat_result:
+    def fail_directory_fstat(fd: int) -> os.stat_result:  # pragma: win32 no cover
         stat_result = real_fstat(fd)
         assert S_ISDIR(stat_result.st_mode)
         directory_fds.append(fd)
@@ -341,10 +341,10 @@ def test_reader_directory_registration_failure_closes_descriptor(tmp_path: Path,
         raise OSError(msg)
 
     mocker.patch("os.fstat", side_effect=fail_directory_fstat)
-    with pytest.raises(OSError, match="directory identity unavailable"):
+    with pytest.raises(OSError, match="directory identity unavailable"):  # pragma: win32 no cover
         lock.acquire_read()
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):  # pragma: win32 no cover
         real_fstat(directory_fds[0])
     lock.close()
 
@@ -360,21 +360,21 @@ def test_reader_directory_registration_and_close_errors_are_grouped(tmp_path: Pa
     real_close, real_fstat = os.close, os.fstat
     directory_fds: list[int] = []
 
-    def fail_directory_fstat(fd: int) -> os.stat_result:
+    def fail_directory_fstat(fd: int) -> os.stat_result:  # pragma: win32 no cover
         stat_result = real_fstat(fd)
         assert S_ISDIR(stat_result.st_mode)
         directory_fds.append(fd)
         msg = "directory identity unavailable"
         raise OSError(msg)
 
-    def fail_directory_close(fd: int) -> None:
+    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
         assert fd == directory_fds[0]
         msg = "directory close failed"
         raise OSError(msg)
 
     mocker.patch("os.fstat", side_effect=fail_directory_fstat)
     mocker.patch("os.close", side_effect=fail_directory_close)
-    with pytest.raises(BaseExceptionGroup) as info:
+    with pytest.raises(BaseExceptionGroup) as info:  # pragma: win32 no cover
         lock.acquire_read()
     real_close(directory_fds[0])
     lock.close()
@@ -387,7 +387,7 @@ def test_reader_directory_registration_and_close_errors_are_grouped(tmp_path: Pa
 
 @_REQUIRES_FORK
 @_FORK_WARNING
-def test_child_callback_registered_before_filelock_can_acquire(tmp_path: Path) -> None:
+def test_child_callback_registered_before_filelock_can_acquire(tmp_path: Path) -> None:  # pragma: win32 no cover
     script = """
 import os
 import sys
@@ -444,7 +444,7 @@ parent.release()
         pytest.param("soft-rw", id="soft-read-write"),
     ],
 )
-def test_child_interpreter_exit_preserves_parent_lock(
+def test_child_interpreter_exit_preserves_parent_lock(  # pragma: win32 no cover
     tmp_path: Path, kind: Literal["native", "soft", "soft-rw"]
 ) -> None:
     script = """
@@ -532,7 +532,7 @@ def _run_child_cleanup(
     exit_child(0)
 
 
-def _probe_lock(lock_type: type[BaseFileLock], path: str) -> bool:
+def _probe_lock(lock_type: type[BaseFileLock], path: str) -> bool:  # pragma: win32 no cover
     read_fd, write_fd = os.pipe()
 
     def probe_child() -> NoReturn:

--- a/tests/test_fork_ownership.py
+++ b/tests/test_fork_ownership.py
@@ -27,7 +27,7 @@ from filelock import (
 )
 
 if sys.version_info >= (3, 11):
-    from builtins import BaseExceptionGroup
+    from builtins import BaseExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup
 

--- a/tests/test_fork_registries.py
+++ b/tests/test_fork_registries.py
@@ -20,13 +20,13 @@ _REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os,
 
 
 @_REQUIRES_FORK
-def test_equal_unhashable_locks_reset_independently(tmp_path: Path) -> None:
-    @dataclass(eq=True, init=False)
-    class EqualLock(BaseFileLock):
-        def _acquire(self) -> None:
+def test_equal_unhashable_locks_reset_independently(tmp_path: Path) -> None:  # pragma: win32 no cover
+    @dataclass(eq=True, init=False)  # pragma: win32 no cover
+    class EqualLock(BaseFileLock):  # pragma: win32 no cover
+        def _acquire(self) -> None:  # pragma: win32 no cover
             self._context.lock_file_fd = os.open(self.lock_file, os.O_CREAT | os.O_RDWR, 0o600)
 
-        def _release(self) -> None:
+        def _release(self) -> None:  # pragma: win32 no cover
             os.close(self._context.lock_file_fd if self._context.lock_file_fd is not None else -1)
             self._context.lock_file_fd = None
 

--- a/tests/test_lock_expiry.py
+++ b/tests/test_lock_expiry.py
@@ -182,5 +182,5 @@ def test_lock_mtime_updated_on_acquire(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     before = time.time()
     with SoftFileLock(lock_path, lifetime=60):
-        if lock_path.exists():
-            assert lock_path.stat().st_mtime >= before - 1
+        assert lock_path.exists()  # the soft marker exists while held
+        assert lock_path.stat().st_mtime >= before - 1

--- a/tests/test_marker_records.py
+++ b/tests/test_marker_records.py
@@ -131,3 +131,20 @@ def test_lease_ages_out_a_malformed_record(tmp_path: Path) -> None:
 
     with SoftFileLease(str(marker), lease_duration=5, timeout=1) as lease:
         assert lease.is_lock_held_by_us
+
+
+def test_marker_pid_and_owner_are_none_without_marker(tmp_path: Path) -> None:
+    lease = SoftFileLease(tmp_path / "a")
+    assert (lease.pid, lease.owner, lease.is_lock_held_by_us) == (None, None, False)
+
+
+def test_marker_force_break_removes_the_marker(tmp_path: Path) -> None:
+    # force_break clears a marker whose holder is gone, so the file is on disk but not held open — the one case where
+    # an unlink also succeeds on Windows, which refuses to remove a descriptor another handle still holds.
+    marker = tmp_path / "a"
+    marker.write_text("filelock/2\npid=1\nhost=h\nmode=lease\n", encoding="utf-8")
+    assert marker.exists()
+
+    SoftFileLease(marker).force_break()
+
+    assert not marker.exists()

--- a/tests/test_marker_records.py
+++ b/tests/test_marker_records.py
@@ -8,6 +8,7 @@ import pytest
 
 from filelock import SoftFileLease, Timeout
 from filelock._identity import process_start_token
+from filelock._marker import OwnerRecord, encode_marker
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -43,6 +44,15 @@ def test_unreadable_record_names_no_owner(tmp_path: Path, record: str) -> None:
     marker.write_text(record, encoding="utf-8")
 
     assert SoftFileLease(str(marker), lease_duration=1).owner is None
+
+
+def test_encode_marker_omits_absent_lease_fields() -> None:
+    # A non-lease owner carries no token or duration, so those lines never appear in the rendered marker.
+    rendered = encode_marker(OwnerRecord(pid=7, hostname="h", mode="unknown"))
+
+    assert rendered == b"filelock/2\npid=7\nhost=h\nmode=unknown\n"
+    assert b"token=" not in rendered
+    assert b"duration=" not in rendered
 
 
 def test_record_start_token_reads_back(tmp_path: Path) -> None:

--- a/tests/test_process_identity.py
+++ b/tests/test_process_identity.py
@@ -30,15 +30,15 @@ def test_process_alive_false_for_dead() -> None:
 
 
 @_POSIX_ONLY
-def test_process_alive_reads_permission_denied_as_alive(mocker: MockerFixture) -> None:
+def test_process_alive_reads_permission_denied_as_alive(mocker: MockerFixture) -> None:  # pragma: win32 no cover
     mocker.patch("filelock._identity.os.kill", side_effect=OSError(EPERM, "operation not permitted"))
     assert process_alive(_DEAD_PID) is True
 
 
 @_POSIX_ONLY
-def test_process_alive_reraises_unexpected_errno(mocker: MockerFixture) -> None:
+def test_process_alive_reraises_unexpected_errno(mocker: MockerFixture) -> None:  # pragma: win32 no cover
     mocker.patch("filelock._identity.os.kill", side_effect=OSError(ENODEV, "no such device"))
-    with pytest.raises(OSError, match="no such device"):
+    with pytest.raises(OSError, match="no such device"):  # pragma: win32 no cover
         process_alive(_DEAD_PID)
 
 
@@ -51,7 +51,7 @@ def test_process_start_token_none_for_dead() -> None:
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS sysctl probe")
-def test_darwin_sysctl_probe_failure_reads_no_token(mocker: MockerFixture) -> None:
+def test_darwin_sysctl_probe_failure_reads_no_token(mocker: MockerFixture) -> None:  # pragma: darwin cover
     mocker.patch("filelock._identity._LIBC.sysctl", return_value=-1)
     assert process_start_token(os.getpid()) is None
 

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -460,6 +460,19 @@ def lock_file(tmp_path: Path) -> str:
     return str(tmp_path / "test_lock.db")
 
 
+@pytest.mark.parametrize("mode", [pytest.param("read", id="read"), pytest.param("write", id="write")])
+def test_acquire_proxy_releases_the_read_write_lock_on_exit(lock_file: str, mode: Literal["read", "write"]) -> None:
+    # acquire_read/acquire_write hand back the shared AcquireReturnProxy; a read/write lock is not a BaseFileLock, so
+    # exiting the proxy must route through the lock's own release() rather than a context-error policy.
+    lock = ReadWriteLock(lock_file, is_singleton=False)
+    acquire = lock.acquire_read if mode == "read" else lock.acquire_write
+
+    with acquire():
+        assert_read_write_lock_state(lock_file, "write", available=False)
+
+    assert_read_write_lock_state(lock_file, "write", available=True)
+
+
 def acquire_lock(
     lock_file: str,
     mode: Literal["read", "write"],

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -563,7 +563,7 @@ def recursive_lock(lock_file: str, mode: Literal["read", "write"], success_flag:
 
 def acquire_lock_and_crash(lock_file: str, mode: Literal["read", "write"], acquired_event: EventType) -> None:
     lock = ReadWriteLock(lock_file)
-    with lock.read_lock() if mode == "read" else lock.write_lock():
+    with lock.read_lock() if mode == "read" else lock.write_lock():  # pragma: win32 no cover
         acquired_event.set()
-        while True:
+        while True:  # pragma: win32 no cover
             time.sleep(0.1)

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -17,7 +17,9 @@ from read_write_helpers import assert_read_write_lock_state
 from filelock import ReadWriteLock, Timeout
 
 if sys.implementation.name == "pypy":
-    set_start_method("spawn", force=True)
+    set_start_method(
+        "spawn", force=True
+    )  # pragma: no cover  # exercised only under the pypy fork backend, which runs without coverage
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -575,7 +577,7 @@ def recursive_lock(lock_file: str, mode: Literal["read", "write"], success_flag:
 
 
 def acquire_lock_and_crash(lock_file: str, mode: Literal["read", "write"], acquired_event: EventType) -> None:
-    lock = ReadWriteLock(lock_file)
+    lock = ReadWriteLock(lock_file)  # pragma: win32 no cover
     with lock.read_lock() if mode == "read" else lock.write_lock():  # pragma: win32 no cover
         acquired_event.set()
         while True:  # pragma: win32 no cover

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -241,7 +241,9 @@ def test_read_write_lock_idle_fork_handles_fresh_child_lock(tmp_path: Path) -> N
 
 
 @pytest.mark.skipif(sys.implementation.name != "pypy" or not hasattr(os, "fork"), reason="requires fork on PyPy")
-def test_read_write_lock_pypy_child_allows_without_known_sqlite_use(tmp_path: Path) -> None:
+def test_read_write_lock_pypy_child_allows_without_known_sqlite_use(
+    tmp_path: Path,
+) -> None:  # pragma: no cover  # exercised only under the pypy fork backend, which runs without coverage
     result = _run_fork_script(
         _pypy_fork_script(),
         [str(tmp_path / "child.db")],
@@ -252,7 +254,9 @@ def test_read_write_lock_pypy_child_allows_without_known_sqlite_use(tmp_path: Pa
 
 
 @pytest.mark.skipif(sys.implementation.name != "pypy" or not hasattr(os, "fork"), reason="requires fork on PyPy")
-def test_read_write_lock_pypy_child_rejects_after_external_sqlite_use(tmp_path: Path) -> None:
+def test_read_write_lock_pypy_child_rejects_after_external_sqlite_use(
+    tmp_path: Path,
+) -> None:  # pragma: no cover  # exercised only under the pypy fork backend, which runs without coverage
     result = _run_fork_script(
         _pypy_external_sqlite_script(),
         [str(tmp_path / "external.db"), str(tmp_path / "child.db")],
@@ -815,8 +819,9 @@ def _idle_fork_script() -> str:
 
 
 def _pypy_fork_script() -> str:
-    return textwrap.dedent(
-        """
+    return (
+        textwrap.dedent(  # pragma: no cover  # exercised only under the pypy fork backend, which runs without coverage
+            """
         from __future__ import annotations
 
         import os
@@ -833,6 +838,7 @@ def _pypy_fork_script() -> str:
         _, status = os.waitpid(child_pid, 0)
         assert os.waitstatus_to_exitcode(status) == 0
         """
+        )
     )
 
 

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -45,14 +45,14 @@ def test_read_write_lock_closes_idle_connections(tmp_path: Path) -> None:
     not Path("/dev/fd").is_dir() and not Path("/proc/self/fd").is_dir(),
     reason="no descriptor view",
 )
-def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) -> None:  # pragma: needs fd-directory
     result = _run_fork_script(_dropped_instances_script(), [str(tmp_path)], timeout=10)
 
     assert result == (0, "", "")
 
 
-@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="requires fork transitions")
-def test_async_read_write_lock_allows_finalizer_reentry(tmp_path: Path) -> None:  # pragma: win32 no cover
+@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="requires fork transitions")  # pragma: needs fork
+def test_async_read_write_lock_allows_finalizer_reentry(tmp_path: Path) -> None:
     result = _run_fork_script(
         _reentrant_finalizer_script(),
         [str(tmp_path / "async.db"), str(tmp_path / "finalizer.db")],
@@ -103,7 +103,7 @@ def test_read_write_lock_rejects_recursive_singleton_construction(tmp_path: Path
     sys.implementation.name != "cpython" or sys.version_info >= (3, 12),
     reason="connection escrow uses CPython reference functions before 3.12",
 )
-def test_read_write_lock_escrow_ignores_shared_ctypes_signatures(tmp_path: Path) -> None:
+def test_read_write_lock_escrow_ignores_shared_ctypes_signatures(tmp_path: Path) -> None:  # pragma: <3.12 cover
     result = subprocess.run(  # executes this test's fixed interpreter and source
         [sys.executable, "-c", _ctypes_signature_script(), str(tmp_path / "ctypes.db")],
         capture_output=True,
@@ -158,7 +158,7 @@ def test_read_write_lock_serializes_other_thread_operation_during_acquisition(
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
 @pytest.mark.parametrize(
     ("mode", "fork_name", "reject_audit_hook"),
     [
@@ -181,7 +181,7 @@ def test_read_write_lock_serializes_other_thread_operation_during_acquisition(
         ),
     ],
 )
-def test_read_write_lock_survives_normal_fork_child_exit(  # pragma: win32 no cover
+def test_read_write_lock_survives_normal_fork_child_exit(
     tmp_path: Path,
     mode: Literal["read", "write"],
     fork_name: Literal["fork", "fork1"],
@@ -201,8 +201,8 @@ def test_read_write_lock_survives_normal_fork_child_exit(  # pragma: win32 no co
     assert result == (0, "", "")
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
-def test_read_write_lock_fork_waits_for_sqlite_operation(tmp_path: Path) -> None:  # pragma: win32 no cover
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
+def test_read_write_lock_fork_waits_for_sqlite_operation(tmp_path: Path) -> None:
     result = _run_fork_script(_fork_during_sqlite_script(), [str(tmp_path / "fork-gate.db")], timeout=15)
 
     assert result == (0, "", "")
@@ -221,7 +221,7 @@ def test_read_write_lock_fork_waits_for_sqlite_operation(tmp_path: Path) -> None
         pytest.param("connection-return", id="connection-return"),
     ],
 )
-def test_read_write_lock_fork_at_sqlite_boundary_exits_child(  # pragma: win32 no cover
+def test_read_write_lock_fork_at_sqlite_boundary_exits_child(  # pragma: needs fork
     tmp_path: Path, boundary: Literal["executescript", "rollback", "close", "connection-return"]
 ) -> None:
     result = _run_fork_script(
@@ -233,17 +233,15 @@ def test_read_write_lock_fork_at_sqlite_boundary_exits_child(  # pragma: win32 n
     assert result == (0, "", "")
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
-def test_read_write_lock_idle_fork_handles_fresh_child_lock(tmp_path: Path) -> None:  # pragma: win32 no cover
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
+def test_read_write_lock_idle_fork_handles_fresh_child_lock(tmp_path: Path) -> None:
     result = _run_fork_script(_idle_fork_script(), [str(tmp_path / "idle-fork.db")], timeout=10)
 
     assert result == (0, "", "")
 
 
 @pytest.mark.skipif(sys.implementation.name != "pypy" or not hasattr(os, "fork"), reason="requires fork on PyPy")
-def test_read_write_lock_pypy_child_allows_without_known_sqlite_use(
-    tmp_path: Path,
-) -> None:  # pragma: no cover  # exercised only under the pypy fork backend, which runs without coverage
+def test_read_write_lock_pypy_child_allows_without_known_sqlite_use(tmp_path: Path) -> None:  # pragma: pypy cover
     result = _run_fork_script(
         _pypy_fork_script(),
         [str(tmp_path / "child.db")],
@@ -254,9 +252,7 @@ def test_read_write_lock_pypy_child_allows_without_known_sqlite_use(
 
 
 @pytest.mark.skipif(sys.implementation.name != "pypy" or not hasattr(os, "fork"), reason="requires fork on PyPy")
-def test_read_write_lock_pypy_child_rejects_after_external_sqlite_use(
-    tmp_path: Path,
-) -> None:  # pragma: no cover  # exercised only under the pypy fork backend, which runs without coverage
+def test_read_write_lock_pypy_child_rejects_after_external_sqlite_use(tmp_path: Path) -> None:  # pragma: pypy cover
     result = _run_fork_script(
         _pypy_external_sqlite_script(),
         [str(tmp_path / "external.db"), str(tmp_path / "child.db")],
@@ -271,16 +267,16 @@ def test_fork_script_terminates_timed_out_process_group() -> None:
         _run_fork_script("import time; time.sleep(10)", [], timeout=0.01)
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
-def test_read_write_lock_subclass_cache_resets_after_fork(tmp_path: Path) -> None:  # pragma: win32 no cover
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
+def test_read_write_lock_subclass_cache_resets_after_fork(tmp_path: Path) -> None:
     result = _run_fork_script(_subclass_fork_script(), [str(tmp_path / "subclass-fork.db")], timeout=10)
 
     assert result == (0, "", "")
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
 @pytest.mark.parametrize("held", [pytest.param(False, id="idle"), pytest.param(True, id="held")])
-def test_async_read_write_lock_fork_behavior(tmp_path: Path, held: bool) -> None:  # pragma: win32 no cover
+def test_async_read_write_lock_fork_behavior(tmp_path: Path, held: bool) -> None:
     result = _run_fork_script(
         _async_fork_script(),
         [str(tmp_path / "async-fork.db"), "held" if held else "idle"],
@@ -309,11 +305,11 @@ def _run_fork_script(script: str, arguments: list[str], *, timeout: float) -> tu
         process_output, process_error = process.communicate()
         msg = f"fork script exceeded {timeout} seconds: stdout={process_output!r}, stderr={process_error!r}"
         raise AssertionError(msg) from error
-    assert process.returncode is not None  # pragma: win32 no cover
-    return process.returncode, process_output, process_error  # pragma: win32 no cover
+    assert process.returncode is not None  # pragma: needs fork
+    return process.returncode, process_output, process_error  # pragma: needs fork
 
 
-def _dropped_instances_script() -> str:  # pragma: win32 no cover
+def _dropped_instances_script() -> str:  # pragma: needs fd-directory
     return textwrap.dedent(
         """
         from __future__ import annotations
@@ -341,7 +337,7 @@ def _dropped_instances_script() -> str:  # pragma: win32 no cover
     )
 
 
-def _reentrant_finalizer_script() -> str:  # pragma: win32 no cover
+def _reentrant_finalizer_script() -> str:  # pragma: needs fork
     return textwrap.dedent(
         """
         from __future__ import annotations
@@ -459,7 +455,7 @@ def _recursive_acquisition_script() -> str:
     )
 
 
-def _ctypes_signature_script() -> str:
+def _ctypes_signature_script() -> str:  # pragma: <3.12 cover
     return textwrap.dedent(
         """
         from __future__ import annotations
@@ -644,7 +640,7 @@ def _fork_script() -> str:
     )
 
 
-def _fork_during_sqlite_script() -> str:  # pragma: win32 no cover
+def _fork_during_sqlite_script() -> str:  # pragma: needs fork
     return textwrap.dedent(
         r"""
         from __future__ import annotations
@@ -818,10 +814,9 @@ def _idle_fork_script() -> str:
     )
 
 
-def _pypy_fork_script() -> str:
-    return (
-        textwrap.dedent(  # pragma: no cover  # exercised only under the pypy fork backend, which runs without coverage
-            """
+def _pypy_fork_script() -> str:  # pragma: pypy cover
+    return textwrap.dedent(
+        """
         from __future__ import annotations
 
         import os
@@ -838,11 +833,10 @@ def _pypy_fork_script() -> str:
         _, status = os.waitpid(child_pid, 0)
         assert os.waitstatus_to_exitcode(status) == 0
         """
-        )
     )
 
 
-def _pypy_external_sqlite_script() -> str:
+def _pypy_external_sqlite_script() -> str:  # pragma: pypy cover
     return textwrap.dedent(
         """
         from __future__ import annotations

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -45,14 +45,14 @@ def test_read_write_lock_closes_idle_connections(tmp_path: Path) -> None:
     not Path("/dev/fd").is_dir() and not Path("/proc/self/fd").is_dir(),
     reason="no descriptor view",
 )
-def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) -> None:
+def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) -> None:  # pragma: win32 no cover
     result = _run_fork_script(_dropped_instances_script(), [str(tmp_path)], timeout=10)
 
     assert result == (0, "", "")
 
 
 @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="requires fork transitions")
-def test_async_read_write_lock_allows_finalizer_reentry(tmp_path: Path) -> None:
+def test_async_read_write_lock_allows_finalizer_reentry(tmp_path: Path) -> None:  # pragma: win32 no cover
     result = _run_fork_script(
         _reentrant_finalizer_script(),
         [str(tmp_path / "async.db"), str(tmp_path / "finalizer.db")],
@@ -181,7 +181,7 @@ def test_read_write_lock_serializes_other_thread_operation_during_acquisition(
         ),
     ],
 )
-def test_read_write_lock_survives_normal_fork_child_exit(
+def test_read_write_lock_survives_normal_fork_child_exit(  # pragma: win32 no cover
     tmp_path: Path,
     mode: Literal["read", "write"],
     fork_name: Literal["fork", "fork1"],
@@ -202,7 +202,7 @@ def test_read_write_lock_survives_normal_fork_child_exit(
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
-def test_read_write_lock_fork_waits_for_sqlite_operation(tmp_path: Path) -> None:
+def test_read_write_lock_fork_waits_for_sqlite_operation(tmp_path: Path) -> None:  # pragma: win32 no cover
     result = _run_fork_script(_fork_during_sqlite_script(), [str(tmp_path / "fork-gate.db")], timeout=15)
 
     assert result == (0, "", "")
@@ -221,7 +221,7 @@ def test_read_write_lock_fork_waits_for_sqlite_operation(tmp_path: Path) -> None
         pytest.param("connection-return", id="connection-return"),
     ],
 )
-def test_read_write_lock_fork_at_sqlite_boundary_exits_child(
+def test_read_write_lock_fork_at_sqlite_boundary_exits_child(  # pragma: win32 no cover
     tmp_path: Path, boundary: Literal["executescript", "rollback", "close", "connection-return"]
 ) -> None:
     result = _run_fork_script(
@@ -234,7 +234,7 @@ def test_read_write_lock_fork_at_sqlite_boundary_exits_child(
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
-def test_read_write_lock_idle_fork_handles_fresh_child_lock(tmp_path: Path) -> None:
+def test_read_write_lock_idle_fork_handles_fresh_child_lock(tmp_path: Path) -> None:  # pragma: win32 no cover
     result = _run_fork_script(_idle_fork_script(), [str(tmp_path / "idle-fork.db")], timeout=10)
 
     assert result == (0, "", "")
@@ -268,7 +268,7 @@ def test_fork_script_terminates_timed_out_process_group() -> None:
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
-def test_read_write_lock_subclass_cache_resets_after_fork(tmp_path: Path) -> None:
+def test_read_write_lock_subclass_cache_resets_after_fork(tmp_path: Path) -> None:  # pragma: win32 no cover
     result = _run_fork_script(_subclass_fork_script(), [str(tmp_path / "subclass-fork.db")], timeout=10)
 
     assert result == (0, "", "")
@@ -276,7 +276,7 @@ def test_read_write_lock_subclass_cache_resets_after_fork(tmp_path: Path) -> Non
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
 @pytest.mark.parametrize("held", [pytest.param(False, id="idle"), pytest.param(True, id="held")])
-def test_async_read_write_lock_fork_behavior(tmp_path: Path, held: bool) -> None:
+def test_async_read_write_lock_fork_behavior(tmp_path: Path, held: bool) -> None:  # pragma: win32 no cover
     result = _run_fork_script(
         _async_fork_script(),
         [str(tmp_path / "async-fork.db"), "held" if held else "idle"],
@@ -298,18 +298,18 @@ def _run_fork_script(script: str, arguments: list[str], *, timeout: float) -> tu
         process_output, process_error = process.communicate(timeout=timeout)
     except subprocess.TimeoutExpired as error:
         with contextlib.suppress(ProcessLookupError):
-            if sys.platform == "win32":
+            if sys.platform == "win32":  # pragma: win32 cover
                 process.kill()
-            else:
+            else:  # pragma: win32 no cover
                 os.killpg(process.pid, signal.SIGKILL)
         process_output, process_error = process.communicate()
         msg = f"fork script exceeded {timeout} seconds: stdout={process_output!r}, stderr={process_error!r}"
         raise AssertionError(msg) from error
-    assert process.returncode is not None
-    return process.returncode, process_output, process_error
+    assert process.returncode is not None  # pragma: win32 no cover
+    return process.returncode, process_output, process_error  # pragma: win32 no cover
 
 
-def _dropped_instances_script() -> str:
+def _dropped_instances_script() -> str:  # pragma: win32 no cover
     return textwrap.dedent(
         """
         from __future__ import annotations
@@ -337,7 +337,7 @@ def _dropped_instances_script() -> str:
     )
 
 
-def _reentrant_finalizer_script() -> str:
+def _reentrant_finalizer_script() -> str:  # pragma: win32 no cover
     return textwrap.dedent(
         """
         from __future__ import annotations
@@ -640,7 +640,7 @@ def _fork_script() -> str:
     )
 
 
-def _fork_during_sqlite_script() -> str:
+def _fork_during_sqlite_script() -> str:  # pragma: win32 no cover
     return textwrap.dedent(
         r"""
         from __future__ import annotations

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import os
 import threading
 from typing import TYPE_CHECKING, Literal
@@ -648,3 +649,32 @@ def test_finish_connection_skips_rollback_when_already_released(lock_file: str) 
     assert lock._con is None
     with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
         con.execute("SELECT 1")
+
+
+def test_dropping_a_lock_closes_its_connection(lock_file: str) -> None:
+    # Nothing else closes a lock dropped while still holding one, so the connection would outlive it.
+    lock = ReadWriteLock(lock_file, is_singleton=False)
+    lock.acquire_read()
+    connection = lock._con
+    assert connection is not None
+
+    del lock
+    gc.collect()
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        connection.execute("select 1")
+
+
+def test_connection_close_from_another_process_leaves_it_open(lock_file: str, mocker: MockerFixture) -> None:
+    # A child inherits the parent's connection, and closing it there would take the parent's down with it.
+    lock = ReadWriteLock(lock_file, is_singleton=False)
+    lock.acquire_read()
+    connection = lock._con
+    assert connection is not None
+    mocker.patch("filelock._read_write._GETPID", return_value=-1)
+
+    connection.close()
+
+    mocker.stopall()
+    assert connection.execute("select 1").fetchone() == (1,)
+    lock.release()

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import threading
 from typing import TYPE_CHECKING, Literal
 
@@ -11,7 +12,14 @@ import sqlite3
 from pathlib import Path
 
 from filelock import Timeout
-from filelock._read_write import _MAX_SQLITE_TIMEOUT_MS, ReadWriteLock, timeout_for_sqlite
+from filelock._read_write import (
+    _FORKED_DATABASES,
+    _MAX_SQLITE_TIMEOUT_MS,
+    ReadWriteLock,
+    _ForkedDatabaseRegistry,
+    _track_sqlite_use,
+    timeout_for_sqlite,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -521,3 +529,93 @@ def test_acquire_converts_connect_lock_error_to_timeout(lock_file: str, mocker: 
 
     with pytest.raises(Timeout):
         lock.acquire_read(timeout=0.1)
+
+
+def test_get_lock_returns_the_singleton(lock_file: str) -> None:
+    lock = ReadWriteLock.get_lock(lock_file)
+    assert isinstance(lock, ReadWriteLock)
+    assert lock is ReadWriteLock(lock_file)
+
+
+def test_note_sqlite_use_records_use_on_pypy(mocker: MockerFixture) -> None:
+    mocker.patch("filelock._read_write._IS_PYPY", True)
+    registry = _ForkedDatabaseRegistry()
+    registry.note_sqlite_use()
+    assert registry._sqlite_used is True
+
+
+@pytest.mark.parametrize("identity", [None, (1, 2)], ids=["no-identity", "with-identity"])
+def test_poison_after_fork_records_path_and_identity(identity: tuple[int, int] | None) -> None:
+    registry = _ForkedDatabaseRegistry()
+    path = Path("poisoned.db")
+    registry.poison_after_fork(path, identity)
+    assert path in registry._paths
+    assert (identity in registry._identities) is (identity is not None)
+
+
+def test_track_sqlite_use_forwards_connect_event(mocker: MockerFixture) -> None:
+    note = mocker.patch.object(_FORKED_DATABASES, "note_sqlite_use")
+    _track_sqlite_use("sqlite3.connect", ())
+    note.assert_called_once_with()
+
+
+def test_track_sqlite_use_ignores_other_events(mocker: MockerFixture) -> None:
+    note = mocker.patch.object(_FORKED_DATABASES, "note_sqlite_use")
+    _track_sqlite_use("open", ())
+    note.assert_not_called()
+
+
+def test_meta_resets_class_state_after_pid_change(lock_file: str) -> None:
+    class _Sub(ReadWriteLock):
+        pass
+
+    _Sub._instances_pid = -1
+    lock = _Sub(lock_file)
+    try:
+        assert isinstance(lock, _Sub)
+        assert _Sub._instances_pid == os.getpid()
+    finally:
+        lock.close()
+
+
+def test_meta_raises_when_pid_changes_during_singleton_construction(lock_file: str, mocker: MockerFixture) -> None:
+    class _Sub(ReadWriteLock):
+        pass
+
+    pid_box = [os.getpid()]
+    mocker.patch("filelock._read_write._GETPID", side_effect=lambda: pid_box[0])
+    original_init = _Sub.__init__
+
+    def _init_then_fork(
+        self: _Sub,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1,
+        *,
+        blocking: bool = True,
+        is_singleton: bool = True,
+    ) -> None:
+        original_init(self, lock_file, timeout, blocking=blocking, is_singleton=is_singleton)
+        pid_box[0] += 1
+
+    mocker.patch.object(_Sub, "__init__", _init_then_fork)
+
+    with pytest.raises(RuntimeError, match="construction cannot continue after fork"):
+        _Sub(lock_file)
+
+
+def test_finish_connection_chains_rollback_then_close_error(lock_file: str, mocker: MockerFixture) -> None:
+    lock = ReadWriteLock(lock_file, is_singleton=False)
+    con = mocker.MagicMock()
+    type(con).in_transaction = mocker.PropertyMock(side_effect=[True, False])
+    con.rollback.side_effect = sqlite3.OperationalError("rollback boom")
+    con.close.side_effect = sqlite3.OperationalError("close boom")
+    lock._con = con
+    lock._connection_transaction_released = False
+
+    with pytest.raises(sqlite3.OperationalError, match="close boom") as excinfo:
+        lock._finish_connection()
+
+    assert isinstance(excinfo.value.__context__, sqlite3.OperationalError)
+    assert "rollback boom" in str(excinfo.value.__context__)
+    con.rollback.assert_called_once_with()
+    con.close.assert_called_once_with()

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -32,7 +32,7 @@ def _clear_singleton_cache() -> Generator[None]:
     ReadWriteLock._instances.clear()
     yield
     for instance in list(ReadWriteLock._instances.valuerefs()):
-        if (lock := instance()) is not None:
+        if (lock := instance()) is not None:  # pragma: no cover  # cache is normally emptied before teardown
             lock.close()
     ReadWriteLock._instances.clear()
 
@@ -194,6 +194,15 @@ def test_release_force_resets_level(lock_file: str) -> None:
     assert lock._current_mode is None
 
 
+def test_release_force_closes_lingering_connection_at_zero_level(lock_file: str) -> None:
+    lock = ReadWriteLock(lock_file, is_singleton=False)
+    lock.acquire_write()
+    lock._lock_level = 0
+    lock.release(force=True)
+    assert lock._con is None
+    assert lock._lock_level == 0
+
+
 @pytest.mark.parametrize(
     "mode",
     [
@@ -233,6 +242,12 @@ def test_write_lock_custom_blocking(lock_file: str) -> None:
     lock = ReadWriteLock(lock_file, is_singleton=False)
     with lock.write_lock(blocking=True):
         assert lock._current_mode == "write"
+
+
+def test_read_lock_context_manager_overrides_defaults(lock_file: str) -> None:
+    lock = ReadWriteLock(lock_file, timeout=10.0, blocking=False, is_singleton=False)
+    with lock.read_lock(timeout=5.0, blocking=True):
+        assert lock._current_mode == "read"
 
 
 def test_close_releases_lock_and_closes_connection(lock_file: str) -> None:
@@ -619,3 +634,17 @@ def test_finish_connection_chains_rollback_then_close_error(lock_file: str, mock
     assert "rollback boom" in str(excinfo.value.__context__)
     con.rollback.assert_called_once_with()
     con.close.assert_called_once_with()
+
+
+def test_finish_connection_skips_rollback_when_already_released(lock_file: str) -> None:
+    lock = ReadWriteLock(lock_file, is_singleton=False)
+    lock.acquire_write()
+    con = lock._con
+    assert con is not None
+    lock._connection_transaction_released = True
+
+    lock._finish_connection()
+
+    assert lock._con is None
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        con.execute("SELECT 1")

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import gc
 import os
 import threading
 from typing import TYPE_CHECKING, Literal
@@ -658,8 +657,7 @@ def test_dropping_a_lock_closes_its_connection(lock_file: str) -> None:
     connection = lock._con
     assert connection is not None
 
-    del lock
-    gc.collect()
+    lock.__del__()  # ruff:ignore[unnecessary-dunder-call]  # a finalizer test cannot ride on collection timing
 
     with pytest.raises(sqlite3.ProgrammingError):
         connection.execute("select 1")

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -327,7 +327,7 @@ def test_lease_rejects_a_peer_configured_with_another_duration(marker: Path) -> 
 
 
 @pytest.mark.requires_hard_links
-def test_lease_does_not_expire_a_strict_holder(marker: Path) -> None:
+def test_lease_does_not_expire_a_strict_holder(marker: Path) -> None:  # pragma: needs hard-link
     # A strict holder never agreed to be superseded by age, so a lease contender waits it out instead.
     with StrictSoftFileLock(str(marker)):
         with pytest.raises(Timeout):

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import itertools
 import os
 import socket
-import sys
 import time
 from errno import EIO, ENOENT
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Final, cast
 
 import pytest
+from coverage_pragmas import CAPABILITIES
 
 from filelock import (
     FileLock,
@@ -30,11 +30,11 @@ if TYPE_CHECKING:
 _DURATION: float = 0.9
 _HEARTBEAT: float = 0.1
 
-#: Windows refuses to rename or delete a file another process holds open, so a live holder's marker cannot be taken
-#: from it. A lease only reclaims there once the holder exits and its handle closes.
-_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Windows keeps an open marker undeletable, so no peer can take it from a live holder",
+#: Taking a claim from a live holder means removing its marker while the holder still has it open. Where that is
+#: refused, a lease only reclaims once the holder exits and its handle closes.
+_NEEDS_UNLINK_OPEN_FILE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["unlink-open-file"],
+    reason="this runtime keeps an open marker undeletable, so no peer can take it from a live holder",
 )
 
 
@@ -93,16 +93,16 @@ def test_lease_heartbeat_keeps_a_live_claim_past_its_duration(marker: Path) -> N
             _lease(marker).acquire()
 
 
-@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_peer_takes_an_expired_claim(marker: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
+def test_lease_peer_takes_an_expired_claim(marker: Path, mocker: MockerFixture) -> None:
     # A wedged holder: its marker stays on disk, but no refresh ever lands on it again, so the claim ages out.
     mocker.patch("filelock._lease.touch")
     holder = _lease(marker)
     holder.acquire()
 
-    try:  # pragma: win32 no cover
+    try:
         peer = _lease(marker, timeout=_DURATION * 5)
-        with peer:  # pragma: win32 no cover
+        with peer:
             assert peer.is_lock_held_by_us
             assert peer.token != holder.token
     finally:
@@ -129,12 +129,12 @@ def test_lease_reclaims_a_dead_same_host_holder(marker: Path) -> None:
         assert lease.is_lock_held_by_us
 
 
-@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE
+def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:  # pragma: needs unlink-open-file
     seen: list[LeaseCompromise] = []
     lease = _lease(marker, on_compromise=seen.append)
 
-    with lease:  # pragma: win32 no cover
+    with lease:
         token = lease.token
         marker.unlink()
         time.sleep(_HEARTBEAT * 5)
@@ -142,14 +142,14 @@ def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None
     assert [(c.reason, c.token, c.lock_file) for c in seen] == [("marker-missing", token, str(marker))]
 
 
-@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_reports_compromise_when_a_peer_takes_over(marker: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE
+def test_lease_reports_compromise_when_a_peer_takes_over(marker: Path) -> None:  # pragma: needs unlink-open-file
     seen: list[LeaseCompromise] = []
     holder = _lease(marker, on_compromise=seen.append)
     peer = _lease(marker)
 
-    try:  # pragma: win32 no cover
-        with holder:  # pragma: win32 no cover
+    try:
+        with holder:
             marker.unlink()
             peer.acquire()  # a peer publishes a fresh marker at the same path
             time.sleep(_HEARTBEAT * 5)
@@ -197,23 +197,23 @@ def test_lease_tolerates_a_transient_refresh_error(marker: Path, mocker: MockerF
         assert lease.compromise is None
 
 
-@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE
+def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:  # pragma: needs unlink-open-file
     seen: list[LeaseCompromise] = []
     lease = _lease(marker, on_compromise=seen.append)
 
-    with lease:  # pragma: win32 no cover
+    with lease:
         marker.unlink()
         time.sleep(_HEARTBEAT * 6)  # several refreshes fail, but the holder is told once
 
     assert len(seen) == 1
 
 
-@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_records_the_compromise_without_a_callback(marker: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE
+def test_lease_records_the_compromise_without_a_callback(marker: Path) -> None:  # pragma: needs unlink-open-file
     lease = _lease(marker)
 
-    with lease:  # pragma: win32 no cover
+    with lease:
         marker.unlink()
         time.sleep(_HEARTBEAT * 5)
         compromise = lease.compromise
@@ -230,13 +230,13 @@ def test_lease_holds_an_uncompromised_claim(marker: Path) -> None:
         assert lease.compromise is None
 
 
-@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE
+def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> None:  # pragma: needs unlink-open-file
     # The callback runs on the heartbeat thread, so releasing from it needs a context that thread can see, and it must
     # not deadlock joining itself.
     holder: list[SoftFileLease] = []
 
-    def release_the_claim(_: LeaseCompromise) -> None:  # pragma: win32 no cover
+    def release_the_claim(_: LeaseCompromise) -> None:
         holder[0].release()
 
     lease = SoftFileLease(
@@ -256,20 +256,20 @@ def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> Non
     assert not lease.is_locked
 
 
-@_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_release_from_the_callback_needs_a_shared_context(marker: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
+def test_lease_release_from_the_callback_needs_a_shared_context(marker: Path) -> None:
     # With the default thread-local context the heartbeat thread sees no claim of its own, so its release() does
     # nothing. Pin the trap the docstring warns about.
     holder: list[SoftFileLease] = []
 
-    def release_the_claim(_: LeaseCompromise) -> None:  # pragma: win32 no cover
+    def release_the_claim(_: LeaseCompromise) -> None:
         holder[0].release()
 
     lease = _lease(marker, on_compromise=release_the_claim)
     holder.append(lease)
     lease.acquire()
 
-    try:  # pragma: win32 no cover
+    try:
         marker.unlink()
         time.sleep(_HEARTBEAT * 5)
         assert lease.is_locked, "a thread-local release() from the heartbeat thread silently did nothing"

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -93,15 +93,15 @@ def test_lease_heartbeat_keeps_a_live_claim_past_its_duration(marker: Path) -> N
 
 
 @_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_peer_takes_an_expired_claim(marker: Path, mocker: MockerFixture) -> None:
+def test_lease_peer_takes_an_expired_claim(marker: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     # A wedged holder: its marker stays on disk, but no refresh ever lands on it again, so the claim ages out.
     mocker.patch("filelock._lease.touch")
     holder = _lease(marker)
     holder.acquire()
 
-    try:
+    try:  # pragma: win32 no cover
         peer = _lease(marker, timeout=_DURATION * 5)
-        with peer:
+        with peer:  # pragma: win32 no cover
             assert peer.is_lock_held_by_us
             assert peer.token != holder.token
     finally:
@@ -129,11 +129,11 @@ def test_lease_reclaims_a_dead_same_host_holder(marker: Path) -> None:
 
 
 @_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:
+def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:  # pragma: win32 no cover
     seen: list[LeaseCompromise] = []
     lease = _lease(marker, on_compromise=seen.append)
 
-    with lease:
+    with lease:  # pragma: win32 no cover
         token = lease.token
         marker.unlink()
         time.sleep(_HEARTBEAT * 5)
@@ -142,13 +142,13 @@ def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None
 
 
 @_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_reports_compromise_when_a_peer_takes_over(marker: Path) -> None:
+def test_lease_reports_compromise_when_a_peer_takes_over(marker: Path) -> None:  # pragma: win32 no cover
     seen: list[LeaseCompromise] = []
     holder = _lease(marker, on_compromise=seen.append)
     peer = _lease(marker)
 
-    try:
-        with holder:
+    try:  # pragma: win32 no cover
+        with holder:  # pragma: win32 no cover
             marker.unlink()
             peer.acquire()  # a peer publishes a fresh marker at the same path
             time.sleep(_HEARTBEAT * 5)
@@ -193,11 +193,11 @@ def test_lease_tolerates_a_transient_refresh_error(marker: Path, mocker: MockerF
 
 
 @_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:
+def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:  # pragma: win32 no cover
     seen: list[LeaseCompromise] = []
     lease = _lease(marker, on_compromise=seen.append)
 
-    with lease:
+    with lease:  # pragma: win32 no cover
         marker.unlink()
         time.sleep(_HEARTBEAT * 6)  # several refreshes fail, but the holder is told once
 
@@ -205,10 +205,10 @@ def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:
 
 
 @_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_records_the_compromise_without_a_callback(marker: Path) -> None:
+def test_lease_records_the_compromise_without_a_callback(marker: Path) -> None:  # pragma: win32 no cover
     lease = _lease(marker)
 
-    with lease:
+    with lease:  # pragma: win32 no cover
         marker.unlink()
         time.sleep(_HEARTBEAT * 5)
         compromise = lease.compromise
@@ -226,12 +226,12 @@ def test_lease_holds_an_uncompromised_claim(marker: Path) -> None:
 
 
 @_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> None:
+def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> None:  # pragma: win32 no cover
     # The callback runs on the heartbeat thread, so releasing from it needs a context that thread can see, and it must
     # not deadlock joining itself.
     holder: list[SoftFileLease] = []
 
-    def release_the_claim(_: LeaseCompromise) -> None:
+    def release_the_claim(_: LeaseCompromise) -> None:  # pragma: win32 no cover
         holder[0].release()
 
     lease = SoftFileLease(
@@ -252,19 +252,19 @@ def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> Non
 
 
 @_REQUIRES_TAKING_A_LIVE_HOLDERS_MARKER
-def test_lease_release_from_the_callback_needs_a_shared_context(marker: Path) -> None:
+def test_lease_release_from_the_callback_needs_a_shared_context(marker: Path) -> None:  # pragma: win32 no cover
     # With the default thread-local context the heartbeat thread sees no claim of its own, so its release() does
     # nothing. Pin the trap the docstring warns about.
     holder: list[SoftFileLease] = []
 
-    def release_the_claim(_: LeaseCompromise) -> None:
+    def release_the_claim(_: LeaseCompromise) -> None:  # pragma: win32 no cover
         holder[0].release()
 
     lease = _lease(marker, on_compromise=release_the_claim)
     holder.append(lease)
     lease.acquire()
 
-    try:
+    try:  # pragma: win32 no cover
         marker.unlink()
         time.sleep(_HEARTBEAT * 5)
         assert lease.is_locked, "a thread-local release() from the heartbeat thread silently did nothing"

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -277,6 +277,48 @@ def test_lease_release_from_the_callback_needs_a_shared_context(marker: Path) ->
         lease.release()
 
 
+def test_lease_records_a_compromise_without_a_callback_deterministically(marker: Path, mocker: MockerFixture) -> None:
+    # With no callback the heartbeat still records the loss on the lease so a holder can poll .compromise. A refresh
+    # that keeps failing drives the loss on every platform without depending on a peer taking the marker.
+    mocker.patch("filelock._lease.touch", side_effect=OSError("cannot touch the marker"))
+    lease = _lease(marker)
+
+    with lease:
+        deadline = time.monotonic() + _DURATION * 20
+        while lease.compromise is None and time.monotonic() < deadline:
+            time.sleep(_HEARTBEAT)
+
+    assert lease.compromise is not None
+    assert lease.compromise.reason == "refresh-failed"
+
+
+def test_lease_release_from_the_callback_does_not_join_itself(marker: Path, mocker: MockerFixture) -> None:
+    # The callback runs on the heartbeat thread, so releasing there must skip joining that thread onto itself. A shared
+    # context lets the thread see the claim, and a failing refresh drives the loss deterministically on every platform.
+    mocker.patch("filelock._lease.touch", side_effect=OSError("cannot touch the marker"))
+    holder: list[SoftFileLease] = []
+
+    def release_the_claim(_: LeaseCompromise) -> None:
+        holder[0].release()
+
+    lease = SoftFileLease(
+        str(marker),
+        thread_local=False,
+        lease_duration=_DURATION,
+        heartbeat_interval=_HEARTBEAT,
+        on_compromise=release_the_claim,
+    )
+    holder.append(lease)
+    lease.acquire()
+
+    deadline = time.monotonic() + _DURATION * 20
+    while lease.is_locked and time.monotonic() < deadline:
+        time.sleep(_HEARTBEAT)
+
+    assert lease.compromise is not None
+    assert not lease.is_locked
+
+
 def test_lease_rejects_a_peer_configured_with_another_duration(marker: Path) -> None:
     holder = _lease(marker)
 

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -165,8 +165,7 @@ def test_lease_reports_compromise_when_a_refresh_fails(marker: Path, mocker: Moc
     lease = _lease(marker, on_compromise=seen.append)
 
     with lease:
-        # Poll rather than sleep a fixed window: a starved heartbeat thread (e.g. under free-threaded builds) can miss
-        # a single refresh margin. A persistent failure is deduplicated, so it is still reported exactly once.
+        # A starved heartbeat can miss one refresh margin; the failure is deduplicated, so it still reports once.
         deadline = time.monotonic() + _DURATION * 20
         while not seen and time.monotonic() < deadline:
             time.sleep(_HEARTBEAT)

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -5,7 +5,8 @@ import os
 import socket
 import sys
 import time
-from errno import EIO
+from errno import EIO, ENOENT
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Final, cast
 
 import pytest
@@ -164,7 +165,11 @@ def test_lease_reports_compromise_when_a_refresh_fails(marker: Path, mocker: Moc
     lease = _lease(marker, on_compromise=seen.append)
 
     with lease:
-        time.sleep(_DURATION + _HEARTBEAT)  # past the refresh margin, so a persistent failure is reported once
+        # Poll rather than sleep a fixed window: a starved heartbeat thread (e.g. under free-threaded builds) can miss
+        # a single refresh margin. A persistent failure is deduplicated, so it is still reported exactly once.
+        deadline = time.monotonic() + _DURATION * 20
+        while not seen and time.monotonic() < deadline:
+            time.sleep(_HEARTBEAT)
 
     assert [(c.reason, c.error) for c in seen] == [("refresh-failed", failure)]
 
@@ -316,6 +321,76 @@ def test_lease_drops_lifetime_with_a_warning(marker: Path) -> None:
         lease = SoftFileLease(str(marker), lease_duration=_DURATION, lifetime=5)
 
     assert lease.lifetime is None
+
+
+def test_lease_supersedes_a_live_holder_once_its_claim_ages_out(marker: Path, mocker: MockerFixture) -> None:
+    # A live holder whose refresh stalled keeps its marker, yet a contender takes it once the marker ages past
+    # lease_duration. Windows cannot delete a live holder's open marker, so drive the age branch with a non-stale
+    # owner and an aged marker rather than a real second process.
+    mocker.patch("filelock._lease.owner_is_stale", return_value=False)
+    marker.write_text(
+        f"filelock/2\npid={os.getpid()}\nhost={socket.gethostname()}\nmode=lease\ntoken=stalled\nduration={_DURATION!r}\n",
+        encoding="utf-8",
+    )
+    aged = time.time() - (_DURATION + 5)
+    os.utime(marker, (aged, aged))
+
+    with _lease(marker) as contender:
+        assert contender.is_lock_held_by_us
+        assert contender.token not in {None, "stalled"}
+
+
+def test_lease_reports_marker_missing_when_a_refresh_cannot_stat_it(marker: Path, mocker: MockerFixture) -> None:
+    # A vanished marker surfaces as FileNotFoundError from the refresh stat. Windows keeps an open marker undeletable,
+    # so inject the missing stat at the agnostic os.lstat call rather than unlinking a held file.
+    seen: list[LeaseCompromise] = []
+    lease = _lease(marker, on_compromise=seen.append)
+    lease.acquire()
+    token = lease.token
+    real_lstat = cast("Callable[..., os.stat_result]", os.lstat)
+    missing = False
+
+    def lstat(path: object, *args: object, **kwargs: object) -> object:
+        if missing and str(path).endswith(marker.name):
+            raise FileNotFoundError(ENOENT, "No such file or directory", marker.name)
+        return real_lstat(path, *args, **kwargs)
+
+    mocker.patch("filelock._lease.os.lstat", side_effect=lstat)
+    try:
+        missing = True
+        time.sleep(_HEARTBEAT * 4)
+    finally:
+        missing = False
+        lease.release()
+
+    assert [(c.reason, c.token, c.lock_file) for c in seen] == [("marker-missing", token, str(marker))]
+
+
+def test_lease_reports_owner_changed_when_the_marker_identity_shifts(marker: Path, mocker: MockerFixture) -> None:
+    # A peer that took the expired claim replaces the marker, so the refresh stat names a different inode. Drive that
+    # agnostically by returning a stat whose identity differs from the one the holder verified at acquire.
+    seen: list[LeaseCompromise] = []
+    lease = _lease(marker, on_compromise=seen.append)
+    lease.acquire()
+    token = lease.token
+    real_lstat = cast("Callable[..., os.stat_result]", os.lstat)
+    shifted = False
+
+    def lstat(path: object, *args: object, **kwargs: object) -> object:
+        st = real_lstat(path, *args, **kwargs)
+        if shifted and str(path).endswith(marker.name):
+            return SimpleNamespace(st_dev=st.st_dev, st_ino=st.st_ino + 1)
+        return st
+
+    mocker.patch("filelock._lease.os.lstat", side_effect=lstat)
+    try:
+        shifted = True
+        time.sleep(_HEARTBEAT * 4)
+    finally:
+        shifted = False
+        lease.release()
+
+    assert [(c.reason, c.token) for c in seen] == [("owner-changed", token)]
 
 
 def test_native_lock_rejects_a_lease_duration(marker: Path) -> None:

--- a/tests/test_soft_lifetime_warning.py
+++ b/tests/test_soft_lifetime_warning.py
@@ -209,7 +209,9 @@ async def test_async_soft_lifetime_polling_does_not_repeat_warning(tmp_path: Pat
     async with holder:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            with pytest.raises(Timeout):
+            # The holder never releases inside this block, so the acquire always times out and the body never
+            # completes normally.
+            with pytest.raises(Timeout):  # pragma: no branch
                 await contender.acquire()
 
     assert caught == []

--- a/tests/test_soft_lifetime_warning.py
+++ b/tests/test_soft_lifetime_warning.py
@@ -209,8 +209,7 @@ async def test_async_soft_lifetime_polling_does_not_repeat_warning(tmp_path: Pat
     async with holder:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            # The holder never releases inside this block, so the acquire always times out and the body never
-            # completes normally.
+            # The holder never releases here, so the acquire always times out.
             with pytest.raises(Timeout):  # pragma: no branch
                 await contender.acquire()
 

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -111,7 +111,7 @@ def test_live_process_without_start_token_falls_back_to_pid(lock_path: Path) -> 
 
 
 @_UNIX_ONLY
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # pragma: win32 no cover
     "errno",
     [pytest.param(EPERM, id="eperm"), pytest.param(ENODEV, id="unexpected_device")],
 )
@@ -184,7 +184,7 @@ def test_stale_lock_rename_race(lock_path: Path, mocker: MockerFixture) -> None:
 
 
 @_UNIX_ONLY
-def test_symlinked_lock_file_is_not_followed(tmp_path: Path, lock_path: Path) -> None:
+def test_symlinked_lock_file_is_not_followed(tmp_path: Path, lock_path: Path) -> None:  # pragma: win32 no cover
     target = tmp_path / "target"
     target.write_text(_holder(99999), encoding="utf-8")
     lock_path.symlink_to(target)
@@ -195,45 +195,45 @@ def test_symlinked_lock_file_is_not_followed(tmp_path: Path, lock_path: Path) ->
 
 
 def test_fifo_lock_file_does_not_block(lock_path: Path) -> None:
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: win32 cover
         pytest.skip("os.mkfifo is unix-only")
     # An attacker-placed FIFO must not stall the open; O_NONBLOCK makes the read bail instead of hang.
-    os.mkfifo(lock_path)
-    assert SoftFileLock(lock_path).pid is None
+    os.mkfifo(lock_path)  # pragma: win32 no cover
+    assert SoftFileLock(lock_path).pid is None  # pragma: win32 no cover
 
 
 def test_fifo_lock_file_with_attached_writer_self_heals(lock_path: Path) -> None:
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: win32 cover
         pytest.skip("os.mkfifo is unix-only")
     # A same-UID peer can plant a FIFO with a writer attached so a non-blocking read would raise EAGAIN. The lstat
     # guard classifies it as a malformed lock before any open, so an aged FIFO self-heals like any other node.
-    os.mkfifo(lock_path)
-    reader = os.open(lock_path, os.O_RDONLY | os.O_NONBLOCK)
+    os.mkfifo(lock_path)  # pragma: win32 no cover
+    reader = os.open(lock_path, os.O_RDONLY | os.O_NONBLOCK)  # pragma: win32 no cover
     writer = os.open(lock_path, os.O_WRONLY | os.O_NONBLOCK)  # attached but never written, so reads get EAGAIN
-    try:
+    try:  # pragma: win32 no cover
         os.utime(lock_path, (0, 0))
         _assert_self_heals(lock_path)
     finally:
-        os.close(reader)
-        os.close(writer)
+        os.close(reader)  # pragma: win32 no cover
+        os.close(writer)  # pragma: win32 no cover
 
 
 def test_socket_lock_file_self_heals(lock_path: Path) -> None:
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: win32 cover
         pytest.skip("AF_UNIX sockets are unix-only")
-    sock = socket.socket(socket.AF_UNIX)
-    try:
+    sock = socket.socket(socket.AF_UNIX)  # pragma: win32 no cover
+    try:  # pragma: win32 no cover
         sock.bind(str(lock_path))
-    except OSError:
-        sock.close()
-        pytest.skip("AF_UNIX path too long for this temp dir")
+    except OSError:  # pragma: darwin cover
+        sock.close()  # pragma: darwin cover
+        pytest.skip("AF_UNIX path too long for this temp dir")  # pragma: darwin cover
     # A Unix-domain socket cannot be os.open()ed as a file. Before the lstat guard the failed open was swallowed by
     # stale detection so acquisition wedged; an aged socket now self-heals like any other non-regular node.
-    try:
+    try:  # pragma: linux cover
         os.utime(lock_path, (0, 0))
         _assert_self_heals(lock_path)
     finally:
-        sock.close()
+        sock.close()  # pragma: linux cover
 
 
 def test_stale_detection_errors_suppressed(lock_path: Path, mocker: MockerFixture) -> None:
@@ -251,7 +251,7 @@ def test_stale_detection_errors_suppressed(lock_path: Path, mocker: MockerFixtur
         pytest.param(_WIN_ERROR_ACCESS_DENIED, _WIN_ERROR_INVALID_PARAMETER, False, id="access-denied"),
     ],
 )
-def test_windows_stale_lock_uses_captured_process_error(
+def test_windows_stale_lock_uses_captured_process_error(  # pragma: win32 cover
     lock_path: Path,
     mocker: MockerFixture,
     captured_error: int,
@@ -259,55 +259,55 @@ def test_windows_stale_lock_uses_captured_process_error(
     *,
     acquires: bool,
 ) -> None:
-    if sys.platform != "win32":
+    if sys.platform != "win32":  # pragma: win32 cover
         pytest.skip("windows-only")
     import ctypes
 
-    def fail_open_process(_access: int, _inherit_handle: bool, _pid: int) -> None:
+    def fail_open_process(_access: int, _inherit_handle: bool, _pid: int) -> None:  # pragma: win32 cover
         ctypes.set_last_error(captured_error)
         ctypes.windll.kernel32.SetLastError(ambient_error)
 
     # ctypes function pointers do not expose a Python signature for autospec.
     mocker.patch("filelock._identity._KERNEL32.OpenProcess", side_effect=fail_open_process)
     lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
-    if acquires:
+    if acquires:  # pragma: win32 cover
         _assert_self_heals(lock_path)
-    else:
+    else:  # pragma: win32 cover
         _assert_times_out(lock_path)
 
 
 @_WINDOWS_ONLY
-def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path) -> None:
+def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path) -> None:  # pragma: win32 cover
     process_marker = lock_path.with_suffix(".process")
-    with SoftFileLock(process_marker):
+    with SoftFileLock(process_marker):  # pragma: win32 cover
         start = int(process_marker.read_text(encoding="utf-8").splitlines()[2])
     lock_path.write_text(_holder(os.getpid(), start=start + 1), encoding="utf-8")
     _assert_self_heals(lock_path)
 
 
 @_WINDOWS_ONLY
-def test_windows_live_process_marker_retained(lock_path: Path) -> None:
+def test_windows_live_process_marker_retained(lock_path: Path) -> None:  # pragma: win32 cover
     lock = SoftFileLock(lock_path)
     lock.acquire()
-    try:
+    try:  # pragma: win32 cover
         _assert_times_out(lock_path)
     finally:
         lock.release()
 
 
 @_WINDOWS_ONLY
-def test_windows_live_process_marker_without_start_token_retained(lock_path: Path) -> None:
+def test_windows_live_process_marker_without_start_token_retained(lock_path: Path) -> None:  # pragma: win32 cover
     lock_path.write_text(_holder(os.getpid()), encoding="utf-8")
     _assert_times_out(lock_path)
 
 
 @_WINDOWS_ONLY
-def test_windows_process_probe_closes_handles(lock_path: Path) -> None:
+def test_windows_process_probe_closes_handles(lock_path: Path) -> None:  # pragma: win32 cover
     lock = SoftFileLock(lock_path)
     lock.acquire()
-    try:
+    try:  # pragma: win32 cover
         handle_count = _current_process_handle_count()
-        for _attempt in range(50):
+        for _attempt in range(50):  # pragma: win32 cover
             _assert_times_out(lock_path, timeout=0)
         # A per-probe handle leak would add one handle per iteration, so ~50 over the loop. Assert no growth beyond a
         # small margin rather than exact equality, which another thread opening or closing a handle would break.
@@ -387,8 +387,8 @@ def _assert_times_out(lock_path: Path, *, timeout: float = 0.1) -> None:
         SoftFileLock(lock_path, timeout=timeout).acquire()
 
 
-def _current_process_handle_count() -> int:
-    if sys.platform != "win32":
+def _current_process_handle_count() -> int:  # pragma: win32 cover
+    if sys.platform != "win32":  # pragma: win32 cover
         pytest.skip("windows-only")
     import ctypes
     from ctypes import wintypes
@@ -470,7 +470,7 @@ def test_del_suppresses_a_release_error(lock_path: Path, mocker: MockerFixture) 
 
 
 @_UNIX_ONLY
-def test_stale_release_spares_a_successor(lock_path: Path) -> None:
+def test_stale_release_spares_a_successor(lock_path: Path) -> None:  # pragma: win32 no cover
     holder = SoftFileLock(lock_path)
     holder.acquire()
     # A peer breaks the stale marker and installs its own at the same path; unlink first so it gets a fresh inode.
@@ -482,7 +482,7 @@ def test_stale_release_spares_a_successor(lock_path: Path) -> None:
 
 
 @_WINDOWS_ONLY
-def test_windows_release_spares_a_replacement(lock_path: Path, mocker: MockerFixture) -> None:
+def test_windows_release_spares_a_replacement(lock_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 cover
     lock = SoftFileLock(lock_path)
     lock.acquire()
     _hold_reports_foreign_identity(mocker)
@@ -581,7 +581,7 @@ def test_second_release_does_not_close_reused_descriptor(
 
 
 @_UNIX_ONLY
-def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixture) -> None:
+def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     holder = SoftFileLock(lock_path)
     holder.acquire()
     lock_path.unlink()
@@ -591,7 +591,7 @@ def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixt
     assert lock_path.read_text(encoding="utf-8") == _holder(_DEAD_PID)
 
 
-@_UNIX_ONLY
+@_UNIX_ONLY  # pragma: win32 no cover
 def test_close_and_marker_cleanup_failures_are_grouped(lock_path: Path, mocker: MockerFixture) -> None:
     lock = SoftFileLock(lock_path)
     lock.acquire()

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gc
 import os
+import signal
 import socket
 import sys
 import threading
@@ -11,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 import pytest
+from coverage_pragmas import CAPABILITIES
 
 from filelock import CloseErrorPolicy, SoftFileLock
 from filelock._identity import process_start_token
@@ -27,8 +29,14 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_UNIX_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    sys.platform == "win32", reason="unix-only stale lock detection"
+_NEEDS_POSIX_SIGNALS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not hasattr(signal, "SIGKILL"), reason="liveness is probed with os.kill only where POSIX signals exist"
+)
+_NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"], reason="creating a symlink needs a privilege this runtime does not grant"
+)
+_NEEDS_UNLINK_OPEN_FILE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["unlink-open-file"], reason="a successor cannot replace a marker this runtime keeps undeletable"
 )
 _WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != "win32", reason="windows-only")
 
@@ -110,8 +118,8 @@ def test_live_process_without_start_token_falls_back_to_pid(lock_path: Path) -> 
     _assert_times_out(lock_path)
 
 
-@_UNIX_ONLY
-@pytest.mark.parametrize(  # pragma: win32 no cover
+@_NEEDS_POSIX_SIGNALS  # pragma: needs posix-signals
+@pytest.mark.parametrize(
     "errno",
     [pytest.param(EPERM, id="eperm"), pytest.param(ENODEV, id="unexpected_device")],
 )
@@ -183,8 +191,8 @@ def test_stale_lock_rename_race(lock_path: Path, mocker: MockerFixture) -> None:
     _assert_times_out(lock_path)
 
 
-@_UNIX_ONLY
-def test_symlinked_lock_file_is_not_followed(tmp_path: Path, lock_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_SYMLINK
+def test_symlinked_lock_file_is_not_followed(tmp_path: Path, lock_path: Path) -> None:  # pragma: needs symlink
     target = tmp_path / "target"
     target.write_text(_holder(99999), encoding="utf-8")
     lock_path.symlink_to(target)
@@ -263,23 +271,23 @@ def test_windows_stale_lock_uses_captured_process_error(  # pragma: win32 cover
         pytest.skip("windows-only")  # pragma: no cover  # win32-only test; this guard never runs
     import ctypes
 
-    def fail_open_process(_access: int, _inherit_handle: bool, _pid: int) -> None:  # pragma: win32 cover
+    def fail_open_process(_access: int, _inherit_handle: bool, _pid: int) -> None:
         ctypes.set_last_error(captured_error)
         ctypes.windll.kernel32.SetLastError(ambient_error)
 
     # ctypes function pointers do not expose a Python signature for autospec.
     mocker.patch("filelock._identity._KERNEL32.OpenProcess", side_effect=fail_open_process)
     lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
-    if acquires:  # pragma: win32 cover
+    if acquires:
         _assert_self_heals(lock_path)
-    else:  # pragma: win32 cover
+    else:
         _assert_times_out(lock_path)
 
 
 @_WINDOWS_ONLY
 def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path) -> None:  # pragma: win32 cover
     process_marker = lock_path.with_suffix(".process")
-    with SoftFileLock(process_marker):  # pragma: win32 cover
+    with SoftFileLock(process_marker):
         start = int(process_marker.read_text(encoding="utf-8").splitlines()[2])
     lock_path.write_text(_holder(os.getpid(), start=start + 1), encoding="utf-8")
     _assert_self_heals(lock_path)
@@ -289,7 +297,7 @@ def test_windows_stale_lock_broken_when_pid_recycled(lock_path: Path) -> None:  
 def test_windows_live_process_marker_retained(lock_path: Path) -> None:  # pragma: win32 cover
     lock = SoftFileLock(lock_path)
     lock.acquire()
-    try:  # pragma: win32 cover
+    try:
         _assert_times_out(lock_path)
     finally:
         lock.release()
@@ -305,9 +313,9 @@ def test_windows_live_process_marker_without_start_token_retained(lock_path: Pat
 def test_windows_process_probe_closes_handles(lock_path: Path) -> None:  # pragma: win32 cover
     lock = SoftFileLock(lock_path)
     lock.acquire()
-    try:  # pragma: win32 cover
+    try:
         handle_count = _current_process_handle_count()
-        for _attempt in range(50):  # pragma: win32 cover
+        for _attempt in range(50):
             _assert_times_out(lock_path, timeout=0)
         # A per-probe handle leak would add one handle per iteration, so ~50 over the loop. Assert no growth beyond a
         # small margin rather than exact equality, which another thread opening or closing a handle would break.
@@ -469,8 +477,8 @@ def test_del_suppresses_a_release_error(lock_path: Path, mocker: MockerFixture) 
     gc.collect()
 
 
-@_UNIX_ONLY
-def test_stale_release_spares_a_successor(lock_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE
+def test_stale_release_spares_a_successor(lock_path: Path) -> None:  # pragma: needs unlink-open-file
     holder = SoftFileLock(lock_path)
     holder.acquire()
     # A peer breaks the stale marker and installs its own at the same path; unlink first so it gets a fresh inode.
@@ -580,8 +588,8 @@ def test_second_release_does_not_close_reused_descriptor(
         os.close(reused_fd)
 
 
-@_UNIX_ONLY
-def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
+def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixture) -> None:
     holder = SoftFileLock(lock_path)
     holder.acquire()
     lock_path.unlink()
@@ -591,7 +599,6 @@ def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixt
     assert lock_path.read_text(encoding="utf-8") == _holder(_DEAD_PID)
 
 
-@_UNIX_ONLY  # pragma: win32 no cover
 def test_close_and_marker_cleanup_failures_are_grouped(lock_path: Path, mocker: MockerFixture) -> None:
     lock = SoftFileLock(lock_path)
     lock.acquire()

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -19,7 +19,7 @@ from filelock._identity import process_start_token
 from filelock._soft import _MAX_LOCK_FILE_SIZE
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
-    from builtins import ExceptionGroup
+    from builtins import ExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: no cover (<py311)
     from exceptiongroup import ExceptionGroup
 

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -209,7 +209,7 @@ def test_fifo_lock_file_with_attached_writer_self_heals(lock_path: Path) -> None
     # guard classifies it as a malformed lock before any open, so an aged FIFO self-heals like any other node.
     os.mkfifo(lock_path)  # pragma: win32 no cover
     reader = os.open(lock_path, os.O_RDONLY | os.O_NONBLOCK)  # pragma: win32 no cover
-    writer = os.open(lock_path, os.O_WRONLY | os.O_NONBLOCK)  # attached but never written, so reads get EAGAIN
+    writer = os.open(lock_path, os.O_WRONLY | os.O_NONBLOCK)  # pragma: win32 no cover
     try:  # pragma: win32 no cover
         os.utime(lock_path, (0, 0))
         _assert_self_heals(lock_path)
@@ -260,7 +260,7 @@ def test_windows_stale_lock_uses_captured_process_error(  # pragma: win32 cover
     acquires: bool,
 ) -> None:
     if sys.platform != "win32":  # pragma: win32 cover
-        pytest.skip("windows-only")
+        pytest.skip("windows-only")  # pragma: no cover  # win32-only test; this guard never runs
     import ctypes
 
     def fail_open_process(_access: int, _inherit_handle: bool, _pid: int) -> None:  # pragma: win32 cover
@@ -389,7 +389,7 @@ def _assert_times_out(lock_path: Path, *, timeout: float = 0.1) -> None:
 
 def _current_process_handle_count() -> int:  # pragma: win32 cover
     if sys.platform != "win32":  # pragma: win32 cover
-        pytest.skip("windows-only")
+        pytest.skip("windows-only")  # pragma: no cover  # only ever called on win32, so this guard never runs
     import ctypes
     from ctypes import wintypes
 
@@ -613,6 +613,26 @@ def test_close_and_marker_cleanup_failures_are_grouped(lock_path: Path, mocker: 
         None,
         False,
     )
+
+
+def test_close_after_commit_ignores_closes_from_other_threads(mocker: MockerFixture) -> None:
+    # The patch binds os.close process-wide, so a descriptor closed on another thread must pass through cleanly and
+    # stay out of the caller's recorded attempts rather than absorb the injected failure.
+    closed: list[int] = []
+
+    def close_a_pipe() -> None:
+        read_fd, write_fd = os.pipe()
+        os.close(read_fd)
+        os.close(write_fd)  # a non-caller thread: passes through untouched rather than raising the injected error
+        closed.extend((read_fd, write_fd))
+
+    with _close_after_commit(mocker) as (_close_error, attempts):
+        worker = threading.Thread(target=close_a_pipe)
+        worker.start()
+        worker.join()
+
+    assert len(closed) == 2
+    assert attempts == []
 
 
 @contextmanager

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -7,7 +7,7 @@ import socket
 import sys
 import threading
 from contextlib import contextmanager
-from errno import EINTR, ENODEV, ENOSPC, EPERM
+from errno import EACCES, EINTR, ENODEV, ENOSPC, EPERM
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
@@ -664,3 +664,19 @@ def _close_after_commit(mocker: MockerFixture) -> Iterator[tuple[OSError, list[i
         yield close_error, attempts
     finally:
         mocker.stop(close_mock)
+
+
+def test_soft_windows_unlink_gives_up_after_every_attempt_is_denied(tmp_path: Path, mocker: MockerFixture) -> None:
+    # Windows can still hold a handle just after close, so the marker unlink retries on EACCES. Deny every attempt to
+    # prove the retry runs and then stops, and that the denial never escapes to the caller.
+    from filelock._soft import _file_identity
+
+    marker = tmp_path / "a"
+    marker.write_text("x", encoding="utf-8")
+    lock = SoftFileLock(marker)
+    mocker.patch("filelock._soft.time.sleep")
+    mocker.patch("filelock._soft.Path.unlink", side_effect=PermissionError(EACCES, "handle still open"))
+
+    lock._windows_unlink_if_ours(_file_identity(os.lstat(marker)))
+
+    assert marker.exists()

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -11,8 +11,10 @@ import pytest
 
 if sys.version_info >= (3, 11):
     from builtins import ExceptionGroup
-else:  # pragma: no cover (<py311)
+else:  # pragma: <3.11 cover
     from exceptiongroup import ExceptionGroup
+
+from coverage_pragmas import CAPABILITIES
 
 from filelock import (
     AsyncStrictSoftFileLock,
@@ -29,6 +31,10 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 _SENTINEL: Final[bytes] = b"1\nfilelock-strict-v1\x00\n0\n"
+
+_NEEDS_FILE_MODE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["file-mode"], reason="an unreadable claim needs POSIX permission bits"
+)
 
 
 pytestmark = pytest.mark.requires_hard_links
@@ -277,22 +283,23 @@ def test_strict_soft_rejects_non_directory_coordination_path(tmp_path: Path) -> 
         StrictSoftFileLock(lock_path).acquire()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix permission bits control claim readability")
-def test_strict_soft_unreadable_claim_fails_closed(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_FILE_MODE  # pragma: needs file-mode
+def test_strict_soft_unreadable_claim_fails_closed(tmp_path: Path) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
     lock.acquire()
     claim = Path(f"{lock_path}.filelock") / "claims" / lock.claims[0].name
     claim.chmod(0)
-    try:  # pragma: win32 no cover
-        with pytest.raises(SoftFileLockProtocolError, match="cannot read claim"):  # pragma: win32 no cover
+    try:
+        with pytest.raises(SoftFileLockProtocolError, match="cannot read claim"):
             _ = StrictSoftFileLock(lock_path).claims
     finally:
         claim.chmod(0o600)
         lock.release()
 
 
-def test_strict_soft_symlink_claim_fails_closed(tmp_path: Path) -> None:
+@pytest.mark.skipif(not CAPABILITIES["symlink"], reason="stages a claim as a symlink")
+def test_strict_soft_symlink_claim_fails_closed(tmp_path: Path) -> None:  # pragma: needs symlink
     lock_path = tmp_path / "resource.lock"
     claims = Path(f"{lock_path}.filelock") / "claims"
     claims.mkdir(parents=True)
@@ -402,11 +409,15 @@ async def test_async_strict_soft_matches_claim_protocol(tmp_path: Path) -> None:
         assert contender.is_locked
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="exercises Windows pathname sharing")
-def test_strict_soft_windows_release_allows_reacquire(tmp_path: Path) -> None:  # pragma: win32 cover
+# The reacquire only needs proving where the holder's own open handle blocks the unlink; elsewhere release
+# removes the name outright and there is no sharing rule to exercise.
+@pytest.mark.skipif(
+    CAPABILITIES["unlink-open-file"], reason="exercises pathname sharing where an open file resists unlink"
+)
+def test_strict_soft_release_allows_reacquire(tmp_path: Path) -> None:  # pragma: lacks unlink-open-file
     lock_path = tmp_path / "resource.lock"
 
-    with StrictSoftFileLock(lock_path) as first:  # pragma: win32 cover
+    with StrictSoftFileLock(lock_path) as first:
         assert first.claims[0].state == "held"
-    with StrictSoftFileLock(lock_path, timeout=0) as second:  # pragma: win32 cover
+    with StrictSoftFileLock(lock_path, timeout=0) as second:
         assert second.claims[0].state == "held"

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import socket
 import sys
+import time
 from errno import EBADF, ENOSYS, EXDEV
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
@@ -10,7 +11,7 @@ from typing import TYPE_CHECKING, Final
 import pytest
 
 if sys.version_info >= (3, 11):
-    from builtins import ExceptionGroup
+    from builtins import ExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from exceptiongroup import ExceptionGroup
 
@@ -26,6 +27,7 @@ from filelock import (
     Timeout,
 )
 from filelock._identity import process_start_token
+from filelock._strict import _PRIVATE_RECORD_MARKER
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -421,3 +423,16 @@ def test_strict_soft_release_allows_reacquire(tmp_path: Path) -> None:  # pragma
         assert first.claims[0].state == "held"
     with StrictSoftFileLock(lock_path, timeout=0) as second:
         assert second.claims[0].state == "held"
+
+
+def test_strict_soft_reclaims_an_aged_sentinel_private_record(tmp_path: Path) -> None:
+    # A crash between creating a private record and linking it leaves the record behind. The next acquire reclaims it
+    # once it ages past the grace window, which the dir_fd reaper cases only ever proved where dir_fd exists.
+    lock_path = tmp_path / "resource.lock"
+    stale = tmp_path / f".{lock_path.name}{_PRIVATE_RECORD_MARKER}{'0' * 32}.tmp"
+    stale.write_bytes(b"")
+    aged = time.time() - 3600
+    os.utime(stale, (aged, aged))
+
+    with StrictSoftFileLock(lock_path):
+        assert not stale.exists()

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -427,8 +427,8 @@ def test_strict_soft_release_allows_reacquire(tmp_path: Path) -> None:  # pragma
 
 
 def test_strict_soft_reclaims_an_aged_sentinel_private_record(tmp_path: Path) -> None:
-    # A crash between creating a private record and linking it leaves the record behind. The next acquire reclaims it
-    # once it ages past the grace window, which the dir_fd reaper cases only ever proved where dir_fd exists.
+    # A crash between creating a private record and linking it leaves it behind; the next acquire reclaims it once
+    # it ages out. The dir_fd reaper cases only proved this where dir_fd exists.
     lock_path = tmp_path / "resource.lock"
     stale = tmp_path / f".{lock_path.name}{_PRIVATE_RECORD_MARKER}{'0' * 32}.tmp"
     stale.write_bytes(b"")

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -278,14 +278,14 @@ def test_strict_soft_rejects_non_directory_coordination_path(tmp_path: Path) -> 
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix permission bits control claim readability")
-def test_strict_soft_unreadable_claim_fails_closed(tmp_path: Path) -> None:
+def test_strict_soft_unreadable_claim_fails_closed(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
     lock.acquire()
     claim = Path(f"{lock_path}.filelock") / "claims" / lock.claims[0].name
     claim.chmod(0)
-    try:
-        with pytest.raises(SoftFileLockProtocolError, match="cannot read claim"):
+    try:  # pragma: win32 no cover
+        with pytest.raises(SoftFileLockProtocolError, match="cannot read claim"):  # pragma: win32 no cover
             _ = StrictSoftFileLock(lock_path).claims
     finally:
         claim.chmod(0o600)
@@ -403,10 +403,10 @@ async def test_async_strict_soft_matches_claim_protocol(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="exercises Windows pathname sharing")
-def test_strict_soft_windows_release_allows_reacquire(tmp_path: Path) -> None:
+def test_strict_soft_windows_release_allows_reacquire(tmp_path: Path) -> None:  # pragma: win32 cover
     lock_path = tmp_path / "resource.lock"
 
-    with StrictSoftFileLock(lock_path) as first:
+    with StrictSoftFileLock(lock_path) as first:  # pragma: win32 cover
         assert first.claims[0].state == "held"
-    with StrictSoftFileLock(lock_path, timeout=0) as second:
+    with StrictSoftFileLock(lock_path, timeout=0) as second:  # pragma: win32 cover
         assert second.claims[0].state == "held"

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -383,7 +383,8 @@ def test_strict_soft_publication_and_close_failures_preserve_both_errors(tmp_pat
     def fail_first_close(fd: int) -> None:
         nonlocal close_failed
         real_close(fd)
-        if not close_failed:
+        # Only a dir_fd release closes a second descriptor, so elsewhere the first close is the only one.
+        if not close_failed:  # pragma: no branch
             close_failed = True
             msg = "private close failed"
             raise OSError(msg)

--- a/tests/test_strict_soft_compat.py
+++ b/tests/test_strict_soft_compat.py
@@ -56,8 +56,7 @@ pytestmark = [
 def old_client_env() -> dict[str, str]:  # pragma: needs old-client
     old_client_path = os.environ[_OLD_CLIENT_PATH_VARIABLE]
     env = os.environ.copy()
-    # Prepend rather than replace: the inherited PYTHONPATH carries the coverage plugin, and coverage restarts
-    # itself in this child.
+    # Prepend: the inherited PYTHONPATH carries the coverage plugin this child restarts under.
     env["PYTHONPATH"] = os.pathsep.join(part for part in (old_client_path, env.get("PYTHONPATH")) if part)
     installed = subprocess.run(
         [sys.executable, "-c", "import filelock; print(filelock.__version__)"],

--- a/tests/test_strict_soft_compat.py
+++ b/tests/test_strict_soft_compat.py
@@ -50,7 +50,9 @@ def old_client_env() -> dict[str, str]:
     if not (old_client_path := os.environ.get(_OLD_CLIENT_PATH_VARIABLE, "")):
         pytest.skip(f"{_OLD_CLIENT_PATH_VARIABLE} must name an installed filelock {_OLDEST_LEGACY_VERSION}")
     env = os.environ.copy()
-    env["PYTHONPATH"] = old_client_path
+    # Prepend rather than replace: the inherited PYTHONPATH carries the coverage plugin, and coverage restarts
+    # itself in this child.
+    env["PYTHONPATH"] = os.pathsep.join(part for part in (old_client_path, env.get("PYTHONPATH")) if part)
     installed = subprocess.run(
         [sys.executable, "-c", "import filelock; print(filelock.__version__)"],
         check=True,

--- a/tests/test_strict_soft_compat.py
+++ b/tests/test_strict_soft_compat.py
@@ -6,6 +6,7 @@ import sys
 from typing import TYPE_CHECKING, Final, TextIO, cast
 
 import pytest
+from coverage_pragmas import CAPABILITIES
 
 from filelock import StrictSoftFileLock, Timeout
 
@@ -42,13 +43,18 @@ else:
 """
 
 
-pytestmark = pytest.mark.requires_hard_links
+pytestmark = [
+    pytest.mark.requires_hard_links,
+    pytest.mark.skipif(
+        not CAPABILITIES["old-client"],
+        reason=f"{_OLD_CLIENT_PATH_VARIABLE} must name an installed filelock {_OLDEST_LEGACY_VERSION}",
+    ),
+]
 
 
 @pytest.fixture(scope="module")
-def old_client_env() -> dict[str, str]:
-    if not (old_client_path := os.environ.get(_OLD_CLIENT_PATH_VARIABLE, "")):
-        pytest.skip(f"{_OLD_CLIENT_PATH_VARIABLE} must name an installed filelock {_OLDEST_LEGACY_VERSION}")
+def old_client_env() -> dict[str, str]:  # pragma: needs old-client
+    old_client_path = os.environ[_OLD_CLIENT_PATH_VARIABLE]
     env = os.environ.copy()
     # Prepend rather than replace: the inherited PYTHONPATH carries the coverage plugin, and coverage restarts
     # itself in this child.
@@ -65,7 +71,9 @@ def old_client_env() -> dict[str, str]:
     return env
 
 
-def test_old_soft_holder_blocks_strict_client(tmp_path: Path, old_client_env: dict[str, str]) -> None:
+def test_old_soft_holder_blocks_strict_client(
+    tmp_path: Path, old_client_env: dict[str, str]
+) -> None:  # pragma: needs old-client
     lock_path = tmp_path / "resource.lock"
     with subprocess.Popen(
         [sys.executable, "-c", _OLD_HOLDER, os.fspath(lock_path)],
@@ -86,7 +94,9 @@ def test_old_soft_holder_blocks_strict_client(tmp_path: Path, old_client_env: di
         assert strict.is_locked
 
 
-def test_strict_activation_rejects_old_soft_client(tmp_path: Path, old_client_env: dict[str, str]) -> None:
+def test_strict_activation_rejects_old_soft_client(
+    tmp_path: Path, old_client_env: dict[str, str]
+) -> None:  # pragma: needs old-client
     lock_path = tmp_path / "resource.lock"
     with StrictSoftFileLock(lock_path):
         blocked = subprocess.run(

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Final
 import pytest
 
 if sys.version_info >= (3, 11):
-    from builtins import BaseExceptionGroup
+    from builtins import BaseExceptionGroup  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup
 

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -185,7 +185,7 @@ def test_strict_soft_force_break_held_during_doorway_backs_off(tmp_path: Path, m
     assert (lock.claims, lock.is_locked) == ((), False)
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_reaper_removes_private_before_publication(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -193,7 +193,7 @@ def test_strict_soft_reaper_removes_private_before_publication(tmp_path: Path, m
     private_path = _private_claim_path(lock_path, token)
     real_link = os.link
 
-    def reap_before_link(
+    def reap_before_link(  # pragma: win32 no cover
         source: _PathValue,
         destination: _PathValue,
         *,
@@ -201,7 +201,7 @@ def test_strict_soft_reaper_removes_private_before_publication(tmp_path: Path, m
         dst_dir_fd: int | None = None,
         follow_symlinks: bool = True,
     ) -> None:
-        if Path(os.fsdecode(destination)).name.startswith("intent-"):
+        if Path(os.fsdecode(destination)).name.startswith("intent-"):  # pragma: win32 no cover
             os.utime(private_path, (0, 0))
             assert StrictSoftFileLock(lock_path).claims == ()
         real_link(
@@ -216,7 +216,7 @@ def test_strict_soft_reaper_removes_private_before_publication(tmp_path: Path, m
     mocker.patch("filelock._strict.os.link", side_effect=reap_before_link)
     lock = StrictSoftFileLock(lock_path, timeout=0)
 
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 no cover
         lock.acquire()
     assert (lock.claims, lock.is_locked, private_path.exists()) == ((), False, False)
 
@@ -253,7 +253,7 @@ def test_strict_soft_reaper_removes_private_after_publication(tmp_path: Path, mo
         assert (lock.claims[0].state, private_path.exists()) == ("held", False)
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_reaper_replacement_only_aborts_publisher(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -264,16 +264,16 @@ def test_strict_soft_reaper_replacement_only_aborts_publisher(tmp_path: Path, mo
     real_unlink = Path.unlink
     replaced = False
 
-    def replace_before_unlink(path: Path, *, missing_ok: bool = False) -> None:
+    def replace_before_unlink(path: Path, *, missing_ok: bool = False) -> None:  # pragma: win32 no cover
         nonlocal replaced
-        if path == private_path and not replaced:
+        if path == private_path and not replaced:  # pragma: win32 no cover
             replaced = True
             path.replace(displaced_path)
             path.write_bytes(b"replacement publisher")
             return
         real_unlink(path, missing_ok=missing_ok)
 
-    def reap_before_link(
+    def reap_before_link(  # pragma: win32 no cover
         source: _PathValue,
         destination: _PathValue,
         *,
@@ -281,7 +281,7 @@ def test_strict_soft_reaper_replacement_only_aborts_publisher(tmp_path: Path, mo
         dst_dir_fd: int | None = None,
         follow_symlinks: bool = True,
     ) -> None:
-        if Path(os.fsdecode(destination)).name.startswith("intent-"):
+        if Path(os.fsdecode(destination)).name.startswith("intent-"):  # pragma: win32 no cover
             os.utime(private_path, (0, 0))
             assert StrictSoftFileLock(lock_path).claims == ()
         real_link(
@@ -297,9 +297,9 @@ def test_strict_soft_reaper_replacement_only_aborts_publisher(tmp_path: Path, mo
     mocker.patch.object(Path, "unlink", autospec=True, side_effect=replace_before_unlink)
     lock = StrictSoftFileLock(lock_path, timeout=0)
 
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 no cover
         lock.acquire()
-    with pytest.raises(SoftFileLockProtocolError, match="malformed claim record"):
+    with pytest.raises(SoftFileLockProtocolError, match="malformed claim record"):  # pragma: win32 no cover
         _ = lock.claims
     public_path = private_path.parent / f"intent-v1-{token}.claim"
     assert (
@@ -338,7 +338,7 @@ def test_strict_soft_private_close_failure_leaves_public_claim(tmp_path: Path, m
     assert ([claim.state for claim in lock.claims], lock.is_locked) == (["intent"], False)
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -346,11 +346,11 @@ def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: P
     real_fstat = os.fstat
     directory_close_failed = False
 
-    def fail_directory_close(fd: int) -> None:
+    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
         nonlocal directory_close_failed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and not directory_close_failed:
+        if is_directory and not directory_close_failed:  # pragma: win32 no cover
             directory_close_failed = True
             raise OSError(EIO, "directory close failed")
 
@@ -358,7 +358,7 @@ def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: P
     mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close)
     lock = StrictSoftFileLock(lock_path)
 
-    with pytest.raises(BaseExceptionGroup) as raised:
+    with pytest.raises(BaseExceptionGroup) as raised:  # pragma: win32 no cover
         lock.acquire()
     assert ([str(error) for error in raised.value.exceptions], lock.claims, lock.is_locked) == (
         ["[Errno 5] link failed", "[Errno 5] directory close failed"],
@@ -367,7 +367,7 @@ def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: P
     )
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_held_directory_close_failure_leaves_both_claims(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -375,19 +375,19 @@ def test_strict_soft_held_directory_close_failure_leaves_both_claims(tmp_path: P
     real_fstat = os.fstat
     directory_closes = 0
 
-    def fail_second_directory_close(fd: int) -> None:
+    def fail_second_directory_close(fd: int) -> None:  # pragma: win32 no cover
         nonlocal directory_closes
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory:
+        if is_directory:  # pragma: win32 no cover
             directory_closes += 1
-            if directory_closes == 2:
+            if directory_closes == 2:  # pragma: win32 no cover
                 raise OSError(EIO, "held directory close failed")
 
     mocker.patch("filelock._strict.os.close", side_effect=fail_second_directory_close)
     lock = StrictSoftFileLock(lock_path)
 
-    with pytest.raises(OSError, match="held directory close failed"):
+    with pytest.raises(OSError, match="held directory close failed"):  # pragma: win32 no cover
         lock.acquire()
     assert ([claim.state for claim in lock.claims], lock.is_locked) == (["held", "intent"], False)
 
@@ -426,7 +426,7 @@ def test_strict_soft_reaper_does_not_retry_sharing_error(tmp_path: Path, mocker:
     assert (unlink.call_count, elapsed < 0.1, private_path.exists()) == (1, True, True)
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_release_error_keeps_remaining_claim(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
@@ -435,9 +435,9 @@ def test_strict_soft_release_error_keeps_remaining_claim(tmp_path: Path, mocker:
     real_unlink = Path.unlink
     failed = False
 
-    def fail_once(path: Path, *, missing_ok: bool = False) -> None:
+    def fail_once(path: Path, *, missing_ok: bool = False) -> None:  # pragma: win32 no cover
         nonlocal failed
-        if not failed:
+        if not failed:  # pragma: win32 no cover
             failed = True
             assert path.name == claim_name
             raise PermissionError(EACCES, "claim is not writable")
@@ -445,7 +445,7 @@ def test_strict_soft_release_error_keeps_remaining_claim(tmp_path: Path, mocker:
 
     mocker.patch("filelock._strict._UNLINK_SUPPORTS_DIR_FD", new=False)
     mocker.patch.object(Path, "unlink", autospec=True, side_effect=fail_once)
-    with pytest.raises(PermissionError, match="claim is not writable"):
+    with pytest.raises(PermissionError, match="claim is not writable"):  # pragma: win32 no cover
         lock.release()
     assert (lock.is_locked, [claim.name for claim in lock.claims]) == (True, [claim_name])
 
@@ -453,7 +453,7 @@ def test_strict_soft_release_error_keeps_remaining_claim(tmp_path: Path, mocker:
     assert (lock.is_locked, lock.claims) == (False, ())
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_release_commits_before_directory_close_error(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
@@ -462,25 +462,25 @@ def test_strict_soft_release_commits_before_directory_close_error(tmp_path: Path
     real_fstat = os.fstat
     directory_close_failed = False
 
-    def fail_directory_close(fd: int) -> None:
+    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
         nonlocal directory_close_failed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and not directory_close_failed:
+        if is_directory and not directory_close_failed:  # pragma: win32 no cover
             directory_close_failed = True
             raise OSError(EIO, "directory close failed")
 
     close_mock = mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close)
 
-    with pytest.raises(OSError, match="directory close failed"):
+    with pytest.raises(OSError, match="directory close failed"):  # pragma: win32 no cover
         lock.release()
     mocker.stop(close_mock)
     assert (lock.is_locked, lock.lock_counter, lock.claims) == (False, 0, ())
-    with StrictSoftFileLock(lock_path, timeout=0) as contender:
+    with StrictSoftFileLock(lock_path, timeout=0) as contender:  # pragma: win32 no cover
         assert contender.is_locked
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_release_preserves_unlink_and_directory_close_errors(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
@@ -490,16 +490,16 @@ def test_strict_soft_release_preserves_unlink_and_directory_close_errors(tmp_pat
     real_unlink = os.unlink
     directory_close_failed = False
 
-    def fail_claim_unlink(path: _PathValue, *, dir_fd: int | None = None) -> None:
-        if Path(os.fsdecode(path)).name.startswith("held-"):
+    def fail_claim_unlink(path: _PathValue, *, dir_fd: int | None = None) -> None:  # pragma: win32 no cover
+        if Path(os.fsdecode(path)).name.startswith("held-"):  # pragma: win32 no cover
             raise PermissionError(EACCES, "claim unlink failed")
         real_unlink(path, dir_fd=dir_fd)
 
-    def fail_directory_close(fd: int) -> None:
+    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
         nonlocal directory_close_failed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and not directory_close_failed:
+        if is_directory and not directory_close_failed:  # pragma: win32 no cover
             directory_close_failed = True
             raise OSError(EIO, "directory close failed")
 
@@ -507,7 +507,7 @@ def test_strict_soft_release_preserves_unlink_and_directory_close_errors(tmp_pat
     supports_dir_fd_mock = mocker.patch.object(os, "supports_dir_fd", os.supports_dir_fd | {unlink_mock})
     close_mock = mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close)
 
-    with pytest.raises(BaseExceptionGroup) as raised:
+    with pytest.raises(BaseExceptionGroup) as raised:  # pragma: win32 no cover
         lock.release()
     mocker.stop(unlink_mock)
     mocker.stop(supports_dir_fd_mock)
@@ -526,7 +526,7 @@ def test_strict_soft_release_preserves_unlink_and_directory_close_errors(tmp_pat
     lock.release()
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -543,7 +543,7 @@ def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path,
     def add_competitor_before_final_scan(path: str | os.PathLike[str]) -> Iterator[os.DirEntry[str]]:
         nonlocal scans
         scans += 1
-        if scans == 3:
+        if scans == 3:  # pragma: win32 no cover
             Path(path, competitor_name).write_text(
                 f"filelock-strict-v1\n{competitor_token}\n{os.getpid()}\n{socket.gethostname().encode().hex()}\n4242\n",
                 encoding="ascii",
@@ -551,19 +551,19 @@ def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path,
             )
         return real_scandir(path)
 
-    def fail_held_unlink(path: _PathValue, *, dir_fd: int | None = None) -> None:
+    def fail_held_unlink(path: _PathValue, *, dir_fd: int | None = None) -> None:  # pragma: win32 no cover
         nonlocal cleanup_name
         cleanup_name = Path(os.fsdecode(path)).name
-        if cleanup_name == f"held-v1-{owner_token}.claim":
+        if cleanup_name == f"held-v1-{owner_token}.claim":  # pragma: win32 no cover
             raise PermissionError(EACCES, "held unlink failed")
         real_unlink(path, dir_fd=dir_fd)
 
-    def fail_cleanup_directory_close(fd: int) -> None:
+    def fail_cleanup_directory_close(fd: int) -> None:  # pragma: win32 no cover
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and cleanup_name == f"intent-v1-{owner_token}.claim":
+        if is_directory and cleanup_name == f"intent-v1-{owner_token}.claim":  # pragma: win32 no cover
             raise OSError(EIO, "intent directory close failed")
-        if is_directory and cleanup_name == f"held-v1-{owner_token}.claim":
+        if is_directory and cleanup_name == f"held-v1-{owner_token}.claim":  # pragma: win32 no cover
             raise OSError(EIO, "held directory close failed")
 
     mocker.patch("filelock._strict.secrets.token_hex", return_value=owner_token)
@@ -573,7 +573,7 @@ def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path,
     close_mock = mocker.patch("filelock._strict.os.close", side_effect=fail_cleanup_directory_close)
     lock = StrictSoftFileLock(lock_path)
 
-    with pytest.raises(BaseExceptionGroup) as raised:
+    with pytest.raises(BaseExceptionGroup) as raised:  # pragma: win32 no cover
         lock.acquire()
     mocker.stop(unlink_mock)
     mocker.stop(supports_dir_fd_mock)
@@ -688,26 +688,26 @@ def test_strict_soft_sentinel_race_with_non_regular_winner_blocks(tmp_path: Path
     assert lock_path.is_dir()
 
 
-@_REQUIRES_DIR_FD_CLEANUP
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
 def test_strict_soft_sentinel_remains_after_private_cleanup_failure(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     real_unlink = os.unlink
     failed = False
 
-    def fail_first_private_cleanup(path: _PathValue, *, dir_fd: int | None = None) -> None:
+    def fail_first_private_cleanup(path: _PathValue, *, dir_fd: int | None = None) -> None:  # pragma: win32 no cover
         nonlocal failed
-        if not failed and Path(os.fsdecode(path)).name.startswith(".resource.lock.private-"):
+        if not failed and Path(os.fsdecode(path)).name.startswith(".resource.lock.private-"):  # pragma: win32 no cover
             failed = True
             raise OSError(EIO, "private cleanup failed")
         real_unlink(path, dir_fd=dir_fd)
 
     mocker.patch("filelock._strict.os.unlink", side_effect=fail_first_private_cleanup)
 
-    with pytest.raises(OSError, match="private cleanup failed"):
+    with pytest.raises(OSError, match="private cleanup failed"):  # pragma: win32 no cover
         StrictSoftFileLock(lock_path).acquire()
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 no cover
         SoftFileLock(lock_path, timeout=0).acquire()
-    with StrictSoftFileLock(lock_path, timeout=0) as strict:
+    with StrictSoftFileLock(lock_path, timeout=0) as strict:  # pragma: win32 no cover
         assert (lock_path.read_bytes(), strict.is_locked) == (b"1\nfilelock-strict-v1\x00\n0\n", True)
 
 
@@ -925,7 +925,7 @@ def _private_claim_path(lock_path: Path, token: str) -> Path:
     return Path(f"{lock_path}.filelock") / "claims" / f".intent-v1-{token}.claim.private-v1-{token}.tmp"
 
 
-def _leaf_error_messages(error: BaseException) -> list[str]:
-    if isinstance(error, BaseExceptionGroup):
+def _leaf_error_messages(error: BaseException) -> list[str]:  # pragma: win32 no cover
+    if isinstance(error, BaseExceptionGroup):  # pragma: win32 no cover
         return [message for child in error.exceptions for message in _leaf_error_messages(child)]
     return [str(error)]

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -8,25 +8,27 @@ import sys
 import time
 from errno import EACCES, EEXIST, EIO, ENOENT, ESTALE, EXDEV
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
 if sys.version_info >= (3, 11):
     from builtins import BaseExceptionGroup
-else:  # pragma: no cover (<py311)
+else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup
+
+from coverage_pragmas import CAPABILITIES
 
 import filelock._strict
 from filelock import SoftFileLock, SoftFileLockProtocolError, StrictSoftFileLock, Timeout
 from filelock._strict import _probe_link_follow_symlinks, _relative_identity
 
 # These cases inject a failure into a directory-fd cleanup step or the reaper race, both of which only run where the
-# protocol uses dir_fd descriptors. Windows has no dir_fd, so those branches never execute and the injected fault never
-# fires; the win32 cleanup path is covered instead by the passing stress, contention and release tests.
-_REQUIRES_DIR_FD_CLEANUP = pytest.mark.skipif(
+# protocol uses dir_fd descriptors. Without dir_fd those branches never execute and the injected fault never fires; the
+# cleanup path is covered there instead by the passing stress, contention and release tests.
+_NEEDS_DIR_FD: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     os.open not in os.supports_dir_fd,
-    reason="injects a fault into the dir_fd cleanup path, which Windows does not execute",
+    reason="injects a fault into the dir_fd cleanup path, which a runtime without dir_fd never executes",
 )
 
 if TYPE_CHECKING:
@@ -188,7 +190,7 @@ def test_strict_soft_force_break_held_during_doorway_backs_off(tmp_path: Path, m
     assert (lock.claims, lock.is_locked) == ((), False)
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_reaper_removes_private_before_publication(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -196,7 +198,7 @@ def test_strict_soft_reaper_removes_private_before_publication(tmp_path: Path, m
     private_path = _private_claim_path(lock_path, token)
     real_link = os.link
 
-    def reap_before_link(  # pragma: win32 no cover
+    def reap_before_link(
         source: _PathValue,
         destination: _PathValue,
         *,
@@ -204,7 +206,8 @@ def test_strict_soft_reaper_removes_private_before_publication(tmp_path: Path, m
         dst_dir_fd: int | None = None,
         follow_symlinks: bool = True,
     ) -> None:
-        if Path(os.fsdecode(destination)).name.startswith("intent-"):  # pragma: win32 no cover
+        # The reaped private record aborts the acquisition at the intent link, so no held link ever reaches here.
+        if Path(os.fsdecode(destination)).name.startswith("intent-"):  # pragma: no branch
             os.utime(private_path, (0, 0))
             assert StrictSoftFileLock(lock_path).claims == ()
         real_link(
@@ -219,7 +222,7 @@ def test_strict_soft_reaper_removes_private_before_publication(tmp_path: Path, m
     mocker.patch("filelock._strict.os.link", side_effect=reap_before_link)
     lock = StrictSoftFileLock(lock_path, timeout=0)
 
-    with pytest.raises(Timeout):  # pragma: win32 no cover
+    with pytest.raises(Timeout):
         lock.acquire()
     assert (lock.claims, lock.is_locked, private_path.exists()) == ((), False, False)
 
@@ -256,7 +259,7 @@ def test_strict_soft_reaper_removes_private_after_publication(tmp_path: Path, mo
         assert (lock.claims[0].state, private_path.exists()) == ("held", False)
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_reaper_replacement_only_aborts_publisher(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -267,16 +270,16 @@ def test_strict_soft_reaper_replacement_only_aborts_publisher(tmp_path: Path, mo
     real_unlink = Path.unlink
     replaced = False
 
-    def replace_before_unlink(path: Path, *, missing_ok: bool = False) -> None:  # pragma: win32 no cover
+    def replace_before_unlink(path: Path, *, missing_ok: bool = False) -> None:
         nonlocal replaced
-        if path == private_path and not replaced:  # pragma: win32 no cover
+        if path == private_path and not replaced:
             replaced = True
             path.replace(displaced_path)
             path.write_bytes(b"replacement publisher")
             return
         real_unlink(path, missing_ok=missing_ok)
 
-    def reap_before_link(  # pragma: win32 no cover
+    def reap_before_link(
         source: _PathValue,
         destination: _PathValue,
         *,
@@ -284,7 +287,8 @@ def test_strict_soft_reaper_replacement_only_aborts_publisher(tmp_path: Path, mo
         dst_dir_fd: int | None = None,
         follow_symlinks: bool = True,
     ) -> None:
-        if Path(os.fsdecode(destination)).name.startswith("intent-"):  # pragma: win32 no cover
+        # The reaped private record aborts the acquisition at the intent link, so no held link ever reaches here.
+        if Path(os.fsdecode(destination)).name.startswith("intent-"):  # pragma: no branch
             os.utime(private_path, (0, 0))
             assert StrictSoftFileLock(lock_path).claims == ()
         real_link(
@@ -300,9 +304,9 @@ def test_strict_soft_reaper_replacement_only_aborts_publisher(tmp_path: Path, mo
     mocker.patch.object(Path, "unlink", autospec=True, side_effect=replace_before_unlink)
     lock = StrictSoftFileLock(lock_path, timeout=0)
 
-    with pytest.raises(Timeout):  # pragma: win32 no cover
+    with pytest.raises(Timeout):
         lock.acquire()
-    with pytest.raises(SoftFileLockProtocolError, match="malformed claim record"):  # pragma: win32 no cover
+    with pytest.raises(SoftFileLockProtocolError, match="malformed claim record"):
         _ = lock.claims
     public_path = private_path.parent / f"intent-v1-{token}.claim"
     assert (
@@ -341,7 +345,7 @@ def test_strict_soft_private_close_failure_leaves_public_claim(tmp_path: Path, m
     assert ([claim.state for claim in lock.claims], lock.is_locked) == (["intent"], False)
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -349,11 +353,11 @@ def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: P
     real_fstat = os.fstat
     directory_close_failed = False
 
-    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
+    def fail_directory_close(fd: int) -> None:
         nonlocal directory_close_failed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and not directory_close_failed:  # pragma: win32 no cover
+        if is_directory and not directory_close_failed:
             directory_close_failed = True
             raise OSError(EIO, "directory close failed")
 
@@ -361,7 +365,7 @@ def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: P
     mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close)
     lock = StrictSoftFileLock(lock_path)
 
-    with pytest.raises(BaseExceptionGroup) as raised:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as raised:
         lock.acquire()
     assert ([str(error) for error in raised.value.exceptions], lock.claims, lock.is_locked) == (
         ["[Errno 5] link failed", "[Errno 5] directory close failed"],
@@ -370,7 +374,7 @@ def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: P
     )
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_held_directory_close_failure_leaves_both_claims(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -378,24 +382,34 @@ def test_strict_soft_held_directory_close_failure_leaves_both_claims(tmp_path: P
     real_fstat = os.fstat
     directory_closes = 0
 
-    def fail_second_directory_close(fd: int) -> None:  # pragma: win32 no cover
+    def fail_second_directory_close(fd: int) -> None:
         nonlocal directory_closes
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory:  # pragma: win32 no cover
+        if is_directory:
             directory_closes += 1
-            if directory_closes == 2:  # pragma: win32 no cover
+            if directory_closes == 2:
                 raise OSError(EIO, "held directory close failed")
 
     mocker.patch("filelock._strict.os.close", side_effect=fail_second_directory_close)
     lock = StrictSoftFileLock(lock_path)
 
-    with pytest.raises(OSError, match="held directory close failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="held directory close failed"):
         lock.acquire()
     assert ([claim.state for claim in lock.claims], lock.is_locked) == (["held", "intent"], False)
 
 
-@pytest.mark.parametrize("node", [pytest.param("directory", id="directory"), pytest.param("symlink", id="symlink")])
+@pytest.mark.parametrize(
+    "node",
+    [
+        pytest.param("directory", id="directory"),
+        pytest.param(
+            "symlink",
+            id="symlink",
+            marks=pytest.mark.skipif(not CAPABILITIES["symlink"], reason="stages the private record as a symlink"),
+        ),
+    ],
+)
 def test_strict_soft_reaper_leaves_non_regular_private_node(tmp_path: Path, node: str) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -403,7 +417,7 @@ def test_strict_soft_reaper_leaves_non_regular_private_node(tmp_path: Path, node
     if node == "directory":
         private_path.mkdir()
     else:
-        private_path.symlink_to(tmp_path / "missing")
+        private_path.symlink_to(tmp_path / "missing")  # pragma: needs symlink
 
     with pytest.raises(SoftFileLockProtocolError, match="cannot list claim directory"):
         _ = StrictSoftFileLock(lock_path).claims
@@ -429,7 +443,7 @@ def test_strict_soft_reaper_does_not_retry_sharing_error(tmp_path: Path, mocker:
     assert (unlink.call_count, elapsed < 0.1, private_path.exists()) == (1, True, True)
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_release_error_keeps_remaining_claim(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
@@ -438,9 +452,9 @@ def test_strict_soft_release_error_keeps_remaining_claim(tmp_path: Path, mocker:
     real_unlink = Path.unlink
     failed = False
 
-    def fail_once(path: Path, *, missing_ok: bool = False) -> None:  # pragma: win32 no cover
+    def fail_once(path: Path, *, missing_ok: bool = False) -> None:
         nonlocal failed
-        if not failed:  # pragma: win32 no cover
+        if not failed:
             failed = True
             assert path.name == claim_name
             raise PermissionError(EACCES, "claim is not writable")
@@ -448,7 +462,7 @@ def test_strict_soft_release_error_keeps_remaining_claim(tmp_path: Path, mocker:
 
     mocker.patch("filelock._strict._UNLINK_SUPPORTS_DIR_FD", new=False)
     mocker.patch.object(Path, "unlink", autospec=True, side_effect=fail_once)
-    with pytest.raises(PermissionError, match="claim is not writable"):  # pragma: win32 no cover
+    with pytest.raises(PermissionError, match="claim is not writable"):
         lock.release()
     assert (lock.is_locked, [claim.name for claim in lock.claims]) == (True, [claim_name])
 
@@ -456,7 +470,7 @@ def test_strict_soft_release_error_keeps_remaining_claim(tmp_path: Path, mocker:
     assert (lock.is_locked, lock.claims) == (False, ())
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_release_commits_before_directory_close_error(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
@@ -465,25 +479,25 @@ def test_strict_soft_release_commits_before_directory_close_error(tmp_path: Path
     real_fstat = os.fstat
     directory_close_failed = False
 
-    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
+    def fail_directory_close(fd: int) -> None:
         nonlocal directory_close_failed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and not directory_close_failed:  # pragma: win32 no cover
+        if is_directory and not directory_close_failed:
             directory_close_failed = True
             raise OSError(EIO, "directory close failed")
 
     close_mock = mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close)
 
-    with pytest.raises(OSError, match="directory close failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="directory close failed"):
         lock.release()
     mocker.stop(close_mock)
     assert (lock.is_locked, lock.lock_counter, lock.claims) == (False, 0, ())
-    with StrictSoftFileLock(lock_path, timeout=0) as contender:  # pragma: win32 no cover
+    with StrictSoftFileLock(lock_path, timeout=0) as contender:
         assert contender.is_locked
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_release_preserves_unlink_and_directory_close_errors(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
@@ -493,16 +507,16 @@ def test_strict_soft_release_preserves_unlink_and_directory_close_errors(tmp_pat
     real_unlink = os.unlink
     directory_close_failed = False
 
-    def fail_claim_unlink(path: _PathValue, *, dir_fd: int | None = None) -> None:  # pragma: win32 no cover
-        if Path(os.fsdecode(path)).name.startswith("held-"):  # pragma: win32 no cover
+    def fail_claim_unlink(path: _PathValue, *, dir_fd: int | None = None) -> None:
+        if Path(os.fsdecode(path)).name.startswith("held-"):
             raise PermissionError(EACCES, "claim unlink failed")
         real_unlink(path, dir_fd=dir_fd)
 
-    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
+    def fail_directory_close(fd: int) -> None:
         nonlocal directory_close_failed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and not directory_close_failed:  # pragma: win32 no cover
+        if is_directory and not directory_close_failed:
             directory_close_failed = True
             raise OSError(EIO, "directory close failed")
 
@@ -510,7 +524,7 @@ def test_strict_soft_release_preserves_unlink_and_directory_close_errors(tmp_pat
     supports_dir_fd_mock = mocker.patch.object(os, "supports_dir_fd", os.supports_dir_fd | {unlink_mock})
     close_mock = mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close)
 
-    with pytest.raises(BaseExceptionGroup) as raised:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as raised:
         lock.release()
     mocker.stop(unlink_mock)
     mocker.stop(supports_dir_fd_mock)
@@ -529,7 +543,7 @@ def test_strict_soft_release_preserves_unlink_and_directory_close_errors(tmp_pat
     lock.release()
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -546,7 +560,7 @@ def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path,
     def add_competitor_before_final_scan(path: str | os.PathLike[str]) -> Iterator[os.DirEntry[str]]:
         nonlocal scans
         scans += 1
-        if scans == 3:  # pragma: win32 no cover
+        if scans == 3:
             Path(path, competitor_name).write_text(
                 f"filelock-strict-v1\n{competitor_token}\n{os.getpid()}\n{socket.gethostname().encode().hex()}\n4242\n",
                 encoding="ascii",
@@ -554,19 +568,19 @@ def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path,
             )
         return real_scandir(path)
 
-    def fail_held_unlink(path: _PathValue, *, dir_fd: int | None = None) -> None:  # pragma: win32 no cover
+    def fail_held_unlink(path: _PathValue, *, dir_fd: int | None = None) -> None:
         nonlocal cleanup_name
         cleanup_name = Path(os.fsdecode(path)).name
-        if cleanup_name == f"held-v1-{owner_token}.claim":  # pragma: win32 no cover
+        if cleanup_name == f"held-v1-{owner_token}.claim":
             raise PermissionError(EACCES, "held unlink failed")
         real_unlink(path, dir_fd=dir_fd)
 
-    def fail_cleanup_directory_close(fd: int) -> None:  # pragma: win32 no cover
+    def fail_cleanup_directory_close(fd: int) -> None:
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and cleanup_name == f"intent-v1-{owner_token}.claim":  # pragma: win32 no cover
+        if is_directory and cleanup_name == f"intent-v1-{owner_token}.claim":
             raise OSError(EIO, "intent directory close failed")
-        if is_directory and cleanup_name == f"held-v1-{owner_token}.claim":  # pragma: win32 no cover
+        if is_directory and cleanup_name == f"held-v1-{owner_token}.claim":
             raise OSError(EIO, "held directory close failed")
 
     mocker.patch("filelock._strict.secrets.token_hex", return_value=owner_token)
@@ -576,7 +590,7 @@ def test_strict_soft_doorway_preserves_every_claim_cleanup_error(tmp_path: Path,
     close_mock = mocker.patch("filelock._strict.os.close", side_effect=fail_cleanup_directory_close)
     lock = StrictSoftFileLock(lock_path)
 
-    with pytest.raises(BaseExceptionGroup) as raised:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as raised:
         lock.acquire()
     mocker.stop(unlink_mock)
     mocker.stop(supports_dir_fd_mock)
@@ -691,26 +705,26 @@ def test_strict_soft_sentinel_race_with_non_regular_winner_blocks(tmp_path: Path
     assert lock_path.is_dir()
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_sentinel_remains_after_private_cleanup_failure(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     real_unlink = os.unlink
     failed = False
 
-    def fail_first_private_cleanup(path: _PathValue, *, dir_fd: int | None = None) -> None:  # pragma: win32 no cover
+    def fail_first_private_cleanup(path: _PathValue, *, dir_fd: int | None = None) -> None:
         nonlocal failed
-        if not failed and Path(os.fsdecode(path)).name.startswith(".resource.lock.private-"):  # pragma: win32 no cover
+        if not failed and Path(os.fsdecode(path)).name.startswith(".resource.lock.private-"):
             failed = True
             raise OSError(EIO, "private cleanup failed")
         real_unlink(path, dir_fd=dir_fd)
 
     mocker.patch("filelock._strict.os.unlink", side_effect=fail_first_private_cleanup)
 
-    with pytest.raises(OSError, match="private cleanup failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="private cleanup failed"):
         StrictSoftFileLock(lock_path).acquire()
-    with pytest.raises(Timeout):  # pragma: win32 no cover
+    with pytest.raises(Timeout):
         SoftFileLock(lock_path, timeout=0).acquire()
-    with StrictSoftFileLock(lock_path, timeout=0) as strict:  # pragma: win32 no cover
+    with StrictSoftFileLock(lock_path, timeout=0) as strict:
         assert (lock_path.read_bytes(), strict.is_locked) == (b"1\nfilelock-strict-v1\x00\n0\n", True)
 
 
@@ -930,8 +944,8 @@ def _private_claim_path(lock_path: Path, token: str) -> Path:
     return Path(f"{lock_path}.filelock") / "claims" / f".intent-v1-{token}.claim.private-v1-{token}.tmp"
 
 
-def _leaf_error_messages(error: BaseException) -> list[str]:  # pragma: win32 no cover
-    if isinstance(error, BaseExceptionGroup):  # pragma: win32 no cover
+def _leaf_error_messages(error: BaseException) -> list[str]:  # pragma: needs dir-fd
+    if isinstance(error, BaseExceptionGroup):
         return [message for child in error.exceptions for message in _leaf_error_messages(child)]
     return [str(error)]
 
@@ -985,7 +999,7 @@ def test_strict_soft_sentinel_inspection_and_close_failure_group(tmp_path: Path,
     )
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 @pytest.mark.parametrize("initialized", [pytest.param(False, id="sentinel"), pytest.param(True, id="intent")])
 def test_strict_soft_publication_directory_close_failure(
     tmp_path: Path, mocker: MockerFixture, initialized: bool
@@ -997,23 +1011,23 @@ def test_strict_soft_publication_directory_close_failure(
     real_fstat = os.fstat
     closed = False
 
-    def fail_first_directory_close(fd: int) -> None:  # pragma: win32 no cover
+    def fail_first_directory_close(fd: int) -> None:
         nonlocal closed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and not closed:  # pragma: win32 no cover
+        if is_directory and not closed:
             closed = True
             raise OSError(EIO, "publication directory close failed")
 
     mocker.patch("filelock._strict.os.close", side_effect=fail_first_directory_close)
     lock = StrictSoftFileLock(lock_path, timeout=0)
 
-    with pytest.raises(OSError, match="publication directory close failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="publication directory close failed"):
         lock.acquire()
     assert lock.is_locked is False
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_force_break_directory_close_failure(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)
@@ -1023,17 +1037,17 @@ def test_strict_soft_force_break_directory_close_failure(tmp_path: Path, mocker:
     real_fstat = os.fstat
     closed = False
 
-    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
+    def fail_directory_close(fd: int) -> None:
         nonlocal closed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and not closed:  # pragma: win32 no cover
+        if is_directory and not closed:
             closed = True
             raise OSError(EIO, "force break directory close failed")
 
     mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close)
 
-    with pytest.raises(OSError, match="force break directory close failed"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="force break directory close failed"):
         lock.force_break(claim_name)
     lock.release()
     assert (lock.is_locked, lock.claims) == (False, ())
@@ -1050,7 +1064,7 @@ def test_strict_soft_release_sentinel_close_failure(tmp_path: Path, mocker: Mock
         if fd == sentinel_fd:
             raise OSError(EIO, "sentinel close failed")
         # Only posix release closes a second, non-sentinel descriptor (the dir_fd); win32 closes only the sentinel.
-        real_close(fd)  # pragma: win32 no cover
+        real_close(fd)  # pragma: needs dir-fd
 
     mocker.patch("filelock._strict.os.close", side_effect=fail_sentinel_close)
 
@@ -1223,7 +1237,7 @@ def test_strict_soft_doorway_claim_unlink_failure_commits_owned(tmp_path: Path, 
         # the fault before the doorway ever discards and masking the commit-owned path this test targets.
         if name == intent_name:
             raise PermissionError(EACCES, "intent unlink denied")
-        return real_unlink_in_directory(directory, name)  # pragma: win32 cover
+        return real_unlink_in_directory(directory, name)  # pragma: lacks dir-fd
 
     mocker.patch("filelock._strict.secrets.token_hex", return_value=owner_token)
     scandir_mock = mocker.patch("filelock._strict.os.scandir", side_effect=add_competitor_once_intent_is_published)
@@ -1300,7 +1314,7 @@ def test_strict_soft_acquires_without_dir_fd(tmp_path: Path, mocker: MockerFixtu
     assert StrictSoftFileLock(lock_path).claims == ()
 
 
-@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@_NEEDS_DIR_FD  # pragma: needs dir-fd
 def test_strict_soft_held_link_and_directory_close_failure(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -1310,7 +1324,7 @@ def test_strict_soft_held_link_and_directory_close_failure(tmp_path: Path, mocke
     held_failed = False
     directory_closed = False
 
-    def fail_held_link(  # pragma: win32 no cover
+    def fail_held_link(
         source: _PathValue,
         destination: _PathValue,
         *,
@@ -1319,16 +1333,16 @@ def test_strict_soft_held_link_and_directory_close_failure(tmp_path: Path, mocke
         follow_symlinks: bool = True,
     ) -> None:
         nonlocal held_failed
-        if Path(os.fsdecode(destination)).name.startswith("held-"):  # pragma: win32 no cover
+        if Path(os.fsdecode(destination)).name.startswith("held-"):
             held_failed = True
             raise OSError(EIO, "held link failed")
         real_link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd, follow_symlinks=follow_symlinks)
 
-    def fail_directory_close_after_held(fd: int) -> None:  # pragma: win32 no cover
+    def fail_directory_close_after_held(fd: int) -> None:
         nonlocal directory_closed
         is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
         real_close(fd)
-        if is_directory and held_failed and not directory_closed:  # pragma: win32 no cover
+        if is_directory and held_failed and not directory_closed:
             directory_closed = True
             raise OSError(EIO, "held link directory close failed")
 
@@ -1336,7 +1350,7 @@ def test_strict_soft_held_link_and_directory_close_failure(tmp_path: Path, mocke
     mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close_after_held)
     lock = StrictSoftFileLock(lock_path)
 
-    with pytest.raises(BaseExceptionGroup) as raised:  # pragma: win32 no cover
+    with pytest.raises(BaseExceptionGroup) as raised:
         lock.acquire()
     assert ([str(error) for error in raised.value.exceptions], lock.is_locked, lock.claims) == (
         ["[Errno 5] held link failed", "[Errno 5] held link directory close failed"],

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -64,11 +64,12 @@ def test_strict_soft_intent_token_collision_does_not_claim_lock(tmp_path: Path, 
 
     def collide_intent(
         _source: _PathValue,
-        destination: _PathValue,
+        _destination: _PathValue,
         **_options: int | bool | None,
     ) -> None:
-        if Path(os.fsdecode(destination)).name.startswith("intent-"):
-            raise FileExistsError(EEXIST, "claim exists")
+        # The intent link is the only link this flow attempts before it fails closed, so colliding it unconditionally
+        # is equivalent to matching on the intent- prefix.
+        raise FileExistsError(EEXIST, "claim exists")
 
     mocker.patch("filelock._strict.os.link", side_effect=collide_intent)
     lock = StrictSoftFileLock(lock_path, timeout=0)
@@ -858,7 +859,8 @@ def _open_raising_for(claim: Path, error: OSError, mocker: MockerFixture) -> Non
     def failing_open(path: _PathValue, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
         if os.fsdecode(path) == str(claim):
             raise error
-        return real_open(path, flags, mode, dir_fd=dir_fd)
+        # The flows using this helper open only the single target claim, so the passthrough never runs.
+        return real_open(path, flags, mode, dir_fd=dir_fd)  # pragma: no cover
 
     mocker.patch("filelock._strict.os.open", side_effect=failing_open)
 
@@ -886,7 +888,8 @@ def test_strict_soft_stale_claim_read_revalidates_to_gone(tmp_path: Path, mocker
             stale_raised = True
             claim.unlink()
             raise OSError(ESTALE, "Stale file handle")
-        return real_open(path, flags, mode, dir_fd=dir_fd)
+        # The retry re-lstats the vanished claim and fails there before reopening, so this passthrough never runs.
+        return real_open(path, flags, mode, dir_fd=dir_fd)  # pragma: no cover
 
     mocker.patch("filelock._strict.os.open", side_effect=stale_then_vanish)
 
@@ -967,7 +970,8 @@ def test_strict_soft_sentinel_inspection_and_close_failure_group(tmp_path: Path,
         if not close_failed:
             close_failed = True
             raise OSError(EIO, "sentinel close failed")
-        real_close(fd)
+        # Only the sentinel descriptor is closed in this flow, so the passthrough never runs.
+        real_close(fd)  # pragma: no cover
 
     mocker.patch("filelock._strict.os.fstat", side_effect=fail_sentinel_inspection)
     mocker.patch("filelock._strict.os.close", side_effect=fail_first_close)
@@ -1045,7 +1049,8 @@ def test_strict_soft_release_sentinel_close_failure(tmp_path: Path, mocker: Mock
     def fail_sentinel_close(fd: int) -> None:
         if fd == sentinel_fd:
             raise OSError(EIO, "sentinel close failed")
-        real_close(fd)
+        # Only posix release closes a second, non-sentinel descriptor (the dir_fd); win32 closes only the sentinel.
+        real_close(fd)  # pragma: win32 no cover
 
     mocker.patch("filelock._strict.os.close", side_effect=fail_sentinel_close)
 
@@ -1107,7 +1112,8 @@ def test_strict_soft_publication_record_reclaimed_aborts(tmp_path: Path, mocker:
     def source_gone(directory_ref: tuple[str, int | None], name: str) -> tuple[int, int] | None:
         if name.startswith("."):
             return None
-        return real_identity(directory_ref, name)
+        # Only the dot-prefixed private record is inspected in this flow, so this passthrough never runs.
+        return real_identity(directory_ref, name)  # pragma: no cover
 
     mocker.patch("filelock._strict._relative_identity", side_effect=source_gone)
     mocker.patch("filelock._strict._link_relative", side_effect=FileNotFoundError(ENOENT, "source vanished"))
@@ -1217,7 +1223,7 @@ def test_strict_soft_doorway_claim_unlink_failure_commits_owned(tmp_path: Path, 
         # the fault before the doorway ever discards and masking the commit-owned path this test targets.
         if name == intent_name:
             raise PermissionError(EACCES, "intent unlink denied")
-        return real_unlink_in_directory(directory, name)
+        return real_unlink_in_directory(directory, name)  # pragma: win32 cover
 
     mocker.patch("filelock._strict.secrets.token_hex", return_value=owner_token)
     scandir_mock = mocker.patch("filelock._strict.os.scandir", side_effect=add_competitor_once_intent_is_published)
@@ -1262,16 +1268,13 @@ def test_strict_soft_record_read_and_close_failure_group(tmp_path: Path, mocker:
     claims.mkdir(parents=True)
     (claims / f"held-v1-{'0' * 32}.claim").write_bytes(b"x" * 1025)
     real_close = os.close
-    close_failed = False
 
-    def fail_first_close(fd: int) -> None:
-        nonlocal close_failed
+    def fail_close(fd: int) -> None:
+        # Reading the single oversized claim closes exactly one descriptor, so failing every close still fails once.
         real_close(fd)
-        if not close_failed:
-            close_failed = True
-            raise OSError(EIO, "record close failed")
+        raise OSError(EIO, "record close failed")
 
-    mocker.patch("filelock._strict.os.close", side_effect=fail_first_close)
+    mocker.patch("filelock._strict.os.close", side_effect=fail_close)
 
     with pytest.raises(BaseExceptionGroup) as raised:
         _ = StrictSoftFileLock(lock_path).claims

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -6,7 +6,7 @@ import socket
 import stat
 import sys
 import time
-from errno import EACCES, EEXIST, EIO, ESTALE, EXDEV
+from errno import EACCES, EEXIST, EIO, ENOENT, ESTALE, EXDEV
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,7 +17,9 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover (<py311)
     from exceptiongroup import BaseExceptionGroup
 
+import filelock._strict
 from filelock import SoftFileLock, SoftFileLockProtocolError, StrictSoftFileLock, Timeout
+from filelock._strict import _probe_link_follow_symlinks, _relative_identity
 
 # These cases inject a failure into a directory-fd cleanup step or the reaper race, both of which only run where the
 # protocol uses dir_fd descriptors. Windows has no dir_fd, so those branches never execute and the injected fault never
@@ -929,3 +931,435 @@ def _leaf_error_messages(error: BaseException) -> list[str]:  # pragma: win32 no
     if isinstance(error, BaseExceptionGroup):  # pragma: win32 no cover
         return [message for child in error.exceptions for message in _leaf_error_messages(child)]
     return [str(error)]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(OSError(EACCES, "denied"), id="oserror"),
+        pytest.param(NotImplementedError("no follow_symlinks"), id="notimplemented"),
+        pytest.param(ValueError("bad option"), id="valueerror"),
+    ],
+)
+def test_strict_soft_link_follow_probe_reports_unhonored(mocker: MockerFixture, error: Exception) -> None:
+    mocker.patch("filelock._strict.os.link", side_effect=error)
+
+    assert _probe_link_follow_symlinks() is False
+
+
+def test_strict_soft_sentinel_inspection_and_close_failure_group(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    _initialize_protocol(lock_path)
+    real_fstat = os.fstat
+    real_close = os.close
+    fstats = 0
+    close_failed = False
+
+    def fail_sentinel_inspection(fd: int) -> os.stat_result:
+        nonlocal fstats
+        fstats += 1
+        if fstats == 2:
+            raise OSError(EIO, "sentinel inspection failed")
+        return real_fstat(fd)
+
+    def fail_first_close(fd: int) -> None:
+        nonlocal close_failed
+        if not close_failed:
+            close_failed = True
+            raise OSError(EIO, "sentinel close failed")
+        real_close(fd)
+
+    mocker.patch("filelock._strict.os.fstat", side_effect=fail_sentinel_inspection)
+    mocker.patch("filelock._strict.os.close", side_effect=fail_first_close)
+    lock = StrictSoftFileLock(lock_path)
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        lock.acquire()
+    assert ([str(error) for error in raised.value.exceptions], lock.is_locked) == (
+        ["[Errno 5] sentinel inspection failed", "[Errno 5] sentinel close failed"],
+        False,
+    )
+
+
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+@pytest.mark.parametrize("initialized", [pytest.param(False, id="sentinel"), pytest.param(True, id="intent")])
+def test_strict_soft_publication_directory_close_failure(
+    tmp_path: Path, mocker: MockerFixture, initialized: bool
+) -> None:
+    lock_path = tmp_path / "resource.lock"
+    if initialized:
+        _initialize_protocol(lock_path)
+    real_close = os.close
+    real_fstat = os.fstat
+    closed = False
+
+    def fail_first_directory_close(fd: int) -> None:  # pragma: win32 no cover
+        nonlocal closed
+        is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
+        real_close(fd)
+        if is_directory and not closed:  # pragma: win32 no cover
+            closed = True
+            raise OSError(EIO, "publication directory close failed")
+
+    mocker.patch("filelock._strict.os.close", side_effect=fail_first_directory_close)
+    lock = StrictSoftFileLock(lock_path, timeout=0)
+
+    with pytest.raises(OSError, match="publication directory close failed"):  # pragma: win32 no cover
+        lock.acquire()
+    assert lock.is_locked is False
+
+
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+def test_strict_soft_force_break_directory_close_failure(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    lock = StrictSoftFileLock(lock_path)
+    lock.acquire()
+    claim_name = lock.claims[0].name
+    real_close = os.close
+    real_fstat = os.fstat
+    closed = False
+
+    def fail_directory_close(fd: int) -> None:  # pragma: win32 no cover
+        nonlocal closed
+        is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
+        real_close(fd)
+        if is_directory and not closed:  # pragma: win32 no cover
+            closed = True
+            raise OSError(EIO, "force break directory close failed")
+
+    mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close)
+
+    with pytest.raises(OSError, match="force break directory close failed"):  # pragma: win32 no cover
+        lock.force_break(claim_name)
+    lock.release()
+    assert (lock.is_locked, lock.claims) == (False, ())
+
+
+def test_strict_soft_release_sentinel_close_failure(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    lock = StrictSoftFileLock(lock_path)
+    lock.acquire()
+    sentinel_fd = lock._context.lock_file_fd
+    real_close = os.close
+
+    def fail_sentinel_close(fd: int) -> None:
+        if fd == sentinel_fd:
+            raise OSError(EIO, "sentinel close failed")
+        real_close(fd)
+
+    mocker.patch("filelock._strict.os.close", side_effect=fail_sentinel_close)
+
+    with pytest.raises(OSError, match="sentinel close failed"):
+        lock.release()
+    assert (lock.is_locked, lock.claims) == (False, ())
+
+
+def test_strict_soft_discard_sentinel_close_failure(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    _initialize_protocol(lock_path)
+    _write_foreign_claim(Path(f"{lock_path}.filelock") / "claims", "a" * 32)
+    real_close = os.close
+    closes = 0
+
+    def fail_second_close(fd: int) -> None:
+        nonlocal closes
+        closes += 1
+        if closes == 2:
+            raise OSError(EIO, "doorway sentinel close failed")
+        real_close(fd)
+
+    mocker.patch("filelock._strict.os.close", side_effect=fail_second_close)
+    lock = StrictSoftFileLock(lock_path)
+
+    with pytest.raises(OSError, match="doorway sentinel close failed"):
+        lock.acquire()
+    assert (lock.is_locked, [claim.state for claim in lock.claims]) == (False, ["held"])
+
+
+@pytest.mark.parametrize("initialized", [pytest.param(False, id="sentinel"), pytest.param(True, id="intent")])
+def test_strict_soft_publication_record_replaced_aborts(
+    tmp_path: Path, mocker: MockerFixture, initialized: bool
+) -> None:
+    lock_path = tmp_path / "resource.lock"
+    if initialized:
+        _initialize_protocol(lock_path)
+    real_identity = _relative_identity
+
+    def mismatch_public(directory_ref: tuple[str, int | None], name: str) -> tuple[int, int] | None:
+        identity = real_identity(directory_ref, name)
+        if identity is not None and not name.startswith("."):
+            return identity[0], identity[1] + 1
+        return identity
+
+    mocker.patch("filelock._strict._relative_identity", side_effect=mismatch_public)
+    lock = StrictSoftFileLock(lock_path, timeout=0)
+
+    with pytest.raises(Timeout):
+        lock.acquire()
+    assert lock.is_locked is False
+
+
+def test_strict_soft_publication_record_reclaimed_aborts(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    _initialize_protocol(lock_path)
+    real_identity = _relative_identity
+
+    def source_gone(directory_ref: tuple[str, int | None], name: str) -> tuple[int, int] | None:
+        if name.startswith("."):
+            return None
+        return real_identity(directory_ref, name)
+
+    mocker.patch("filelock._strict._relative_identity", side_effect=source_gone)
+    mocker.patch("filelock._strict._link_relative", side_effect=FileNotFoundError(ENOENT, "source vanished"))
+    lock = StrictSoftFileLock(lock_path, timeout=0)
+
+    with pytest.raises(Timeout):
+        lock.acquire()
+    assert lock.is_locked is False
+
+
+def test_strict_soft_private_inspection_failure_unlinks_vanished_record(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    _initialize_protocol(lock_path)
+    real_fstat = os.fstat
+    fstats = 0
+
+    def fail_private_inspection(fd: int) -> os.stat_result:
+        nonlocal fstats
+        fstats += 1
+        if fstats == 3:
+            raise OSError(EIO, "private inspection failed")
+        return real_fstat(fd)
+
+    mocker.patch("filelock._strict.os.fstat", side_effect=fail_private_inspection)
+    mocker.patch("filelock._strict._unlink_relative", side_effect=FileNotFoundError(ENOENT, "record gone"))
+    lock = StrictSoftFileLock(lock_path)
+
+    with pytest.raises(OSError, match="private inspection failed"):
+        lock.acquire()
+    assert lock.is_locked is False
+
+
+def test_strict_soft_record_finalization_close_and_unlink_failures_group(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    _initialize_protocol(lock_path)
+    real_close = os.close
+    close_failed = False
+
+    def fail_first_close(fd: int) -> None:
+        nonlocal close_failed
+        real_close(fd)
+        if not close_failed:
+            close_failed = True
+            raise OSError(EIO, "private close failed")
+
+    mocker.patch("filelock._strict.os.close", side_effect=fail_first_close)
+    mocker.patch("filelock._strict._unlink_relative", side_effect=PermissionError(EACCES, "unlink denied"))
+    lock = StrictSoftFileLock(lock_path)
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        lock.acquire()
+    assert (sorted(str(error) for error in raised.value.exceptions), lock.is_locked) == (
+        ["[Errno 13] unlink denied", "[Errno 5] private close failed"],
+        False,
+    )
+
+
+def test_strict_soft_release_claim_unlink_failures_group(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    lock = StrictSoftFileLock(lock_path)
+    lock.acquire()
+    unlink_mock = mocker.patch(
+        "filelock._strict._unlink_in_directory",
+        side_effect=PermissionError(EACCES, "claim unlink denied"),
+    )
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        lock.release()
+    assert ([str(error) for error in raised.value.exceptions], lock.is_locked, len(lock.claims)) == (
+        ["[Errno 13] claim unlink denied", "[Errno 13] claim unlink denied"],
+        True,
+        2,
+    )
+
+    mocker.stop(unlink_mock)
+    lock.release()
+    assert (lock.is_locked, lock.claims) == (False, ())
+
+
+def test_strict_soft_doorway_claim_unlink_failure_commits_owned(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    _initialize_protocol(lock_path)
+    owner_token = "f" * 32
+    competitor_name = f"held-v1-{'0' * 32}.claim"
+    intent_name = f"intent-v1-{owner_token}.claim"
+    real_scandir = os.scandir
+    injected = False
+
+    def add_competitor_once_intent_is_published(path: str | os.PathLike[str]) -> Iterator[os.DirEntry[str]]:
+        # Key on directory content, not scandir call count: the setup and publication paths scan a differing number
+        # of times per platform, so plant the held competitor on the first rescan that already lists our own intent.
+        nonlocal injected
+        directory = Path(os.fsdecode(path))
+        if not injected:
+            with real_scandir(directory) as entries:
+                intent_published = any(entry.name == intent_name for entry in entries)
+            if intent_published:
+                _write_foreign_claim(directory, "0" * 32)
+                injected = True
+        return real_scandir(directory)
+
+    real_unlink_in_directory = filelock._strict._unlink_in_directory
+
+    def deny_only_the_owned_intent_unlink(directory: Path, name: str) -> BaseException | None:
+        # Fail only the doorway's own intent-claim unlink. A blanket failure also breaks the Windows-only private
+        # record cleanup inside publication (_unlink_relative unlinks a differently named private file there), firing
+        # the fault before the doorway ever discards and masking the commit-owned path this test targets.
+        if name == intent_name:
+            raise PermissionError(EACCES, "intent unlink denied")
+        return real_unlink_in_directory(directory, name)
+
+    mocker.patch("filelock._strict.secrets.token_hex", return_value=owner_token)
+    scandir_mock = mocker.patch("filelock._strict.os.scandir", side_effect=add_competitor_once_intent_is_published)
+    unlink_mock = mocker.patch("filelock._strict._unlink_in_directory", side_effect=deny_only_the_owned_intent_unlink)
+    lock = StrictSoftFileLock(lock_path)
+
+    with pytest.raises(PermissionError, match="intent unlink denied"):
+        lock.acquire()
+    assert (lock.is_locked, sorted(claim.name for claim in lock.claims)) == (
+        True,
+        [competitor_name, f"intent-v1-{owner_token}.claim"],
+    )
+
+    mocker.stop(scandir_mock)
+    mocker.stop(unlink_mock)
+    lock.release(force=True)
+    lock.force_break(competitor_name)
+
+
+def test_strict_soft_permission_denied_claim_read_fails_closed(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    claim = _write_held_claim(Path(f"{lock_path}.filelock") / "claims")
+    mocker.patch("filelock._strict._CLAIM_READ_GRACE", 0.02)
+    _open_raising_for(claim, PermissionError(EACCES, "sharing violation"), mocker)
+
+    with pytest.raises(SoftFileLockProtocolError, match="cannot read claim"):
+        _ = StrictSoftFileLock(lock_path).claims
+
+
+def test_strict_soft_ignores_malformed_private_record_name(tmp_path: Path) -> None:
+    lock_path = tmp_path / "resource.lock"
+    claims = Path(f"{lock_path}.filelock") / "claims"
+    claims.mkdir(parents=True)
+    (claims / ".decoy.tmp").write_bytes(b"junk")
+
+    assert StrictSoftFileLock(lock_path).claims == ()
+
+
+def test_strict_soft_record_read_and_close_failure_group(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    claims = Path(f"{lock_path}.filelock") / "claims"
+    claims.mkdir(parents=True)
+    (claims / f"held-v1-{'0' * 32}.claim").write_bytes(b"x" * 1025)
+    real_close = os.close
+    close_failed = False
+
+    def fail_first_close(fd: int) -> None:
+        nonlocal close_failed
+        real_close(fd)
+        if not close_failed:
+            close_failed = True
+            raise OSError(EIO, "record close failed")
+
+    mocker.patch("filelock._strict.os.close", side_effect=fail_first_close)
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        _ = StrictSoftFileLock(lock_path).claims
+    messages = [str(error) for error in raised.value.exceptions]
+    assert (
+        any("exceeds 1024 bytes" in message for message in messages),
+        "[Errno 5] record close failed" in messages,
+    ) == (
+        True,
+        True,
+    )
+
+
+def test_strict_soft_acquires_without_dir_fd(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    mocker.patch("filelock._strict._OPEN_SUPPORTS_DIR_FD", new=False)
+    mocker.patch("filelock._strict._UNLINK_SUPPORTS_DIR_FD", new=False)
+    mocker.patch("filelock._strict._STAT_SUPPORTS_DIR_FD", new=False)
+    mocker.patch("filelock._strict._LINK_SUPPORTS_DIR_FD", new=False)
+
+    with StrictSoftFileLock(lock_path) as lock:
+        assert (lock.is_locked, [claim.state for claim in lock.claims]) == (True, ["held", "intent"])
+    assert StrictSoftFileLock(lock_path).claims == ()
+
+
+@_REQUIRES_DIR_FD_CLEANUP  # pragma: win32 no cover
+def test_strict_soft_held_link_and_directory_close_failure(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    _initialize_protocol(lock_path)
+    real_close = os.close
+    real_fstat = os.fstat
+    real_link = os.link
+    held_failed = False
+    directory_closed = False
+
+    def fail_held_link(  # pragma: win32 no cover
+        source: _PathValue,
+        destination: _PathValue,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        nonlocal held_failed
+        if Path(os.fsdecode(destination)).name.startswith("held-"):  # pragma: win32 no cover
+            held_failed = True
+            raise OSError(EIO, "held link failed")
+        real_link(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd, follow_symlinks=follow_symlinks)
+
+    def fail_directory_close_after_held(fd: int) -> None:  # pragma: win32 no cover
+        nonlocal directory_closed
+        is_directory = stat.S_ISDIR(real_fstat(fd).st_mode)
+        real_close(fd)
+        if is_directory and held_failed and not directory_closed:  # pragma: win32 no cover
+            directory_closed = True
+            raise OSError(EIO, "held link directory close failed")
+
+    mocker.patch("filelock._strict.os.link", side_effect=fail_held_link)
+    mocker.patch("filelock._strict.os.close", side_effect=fail_directory_close_after_held)
+    lock = StrictSoftFileLock(lock_path)
+
+    with pytest.raises(BaseExceptionGroup) as raised:  # pragma: win32 no cover
+        lock.acquire()
+    assert ([str(error) for error in raised.value.exceptions], lock.is_locked, lock.claims) == (
+        ["[Errno 5] held link failed", "[Errno 5] held link directory close failed"],
+        False,
+        (),
+    )
+
+
+def test_strict_soft_opened_record_non_regular_fails_closed(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    claims = Path(f"{lock_path}.filelock") / "claims"
+    claims.mkdir(parents=True)
+    (claims / f"held-v1-{'0' * 32}.claim").write_bytes(b"filelock-strict-v1\n" + b"0" * 32 + b"\n1\n686f7374\n4242\n")
+    real_fstat = os.fstat
+
+    def non_regular_fstat(fd: int) -> os.stat_result:
+        original = real_fstat(fd)
+        return os.stat_result((stat.S_IFIFO | 0o644, *original[1:]))
+
+    mocker.patch("filelock._strict.os.fstat", side_effect=non_regular_fstat)
+
+    with pytest.raises(SoftFileLockProtocolError, match="is not a regular file"):
+        _ = StrictSoftFileLock(lock_path).claims
+
+
+def _write_foreign_claim(claims: Path, token: str, state: str = "held") -> Path:
+    claim = claims / f"{state}-v1-{token}.claim"
+    claim.write_bytes(b"filelock-strict-v1\n" + token.encode() + f"\n{os.getpid()}\n686f7374\n4242\n".encode())
+    return claim

--- a/tests/test_strict_soft_paths.py
+++ b/tests/test_strict_soft_paths.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
@@ -20,6 +21,13 @@ _STRICT_SENTINEL: Final[bytes] = b"1\nfilelock-strict-v1\x00\n0\n"
 
 _NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
+)
+
+# filelock resolves a lock's parent with abspath on Windows so junctions and reparse points are never followed, which
+# also keeps a symlinked parent a distinct key there. These cases assert the collapsing the realpath platforms do.
+_NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"] or sys.platform == "win32",
+    reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",
 )
 
 
@@ -116,7 +124,7 @@ async def test_async_strict_soft_waiter_keeps_acquisition_directory(
         await contender.release(force=True)
 
 
-@_NEEDS_SYMLINK  # pragma: needs symlink
+@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> None:
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"

--- a/tests/test_strict_soft_paths.py
+++ b/tests/test_strict_soft_paths.py
@@ -23,8 +23,7 @@ _NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
 )
 
-# filelock resolves a lock's parent with abspath on Windows so junctions and reparse points are never followed, which
-# also keeps a symlinked parent a distinct key there. These cases assert the collapsing the realpath platforms do.
+# Windows resolves a lock's parent with abspath, so a symlinked parent stays a distinct key and never collapses.
 _NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"] or sys.platform == "win32",
     reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",

--- a/tests/test_strict_soft_paths.py
+++ b/tests/test_strict_soft_paths.py
@@ -104,7 +104,7 @@ async def test_async_strict_soft_waiter_keeps_acquisition_directory(
             StrictSoftFileLock(second / "resource.lock").claims,
         ) == (("held", "intent"), ())
     finally:
-        if not task.done():
+        if not task.done():  # pragma: no cover  # the contender wins before teardown, so cancellation cleanup is rare
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task

--- a/tests/test_strict_soft_paths.py
+++ b/tests/test_strict_soft_paths.py
@@ -113,7 +113,7 @@ async def test_async_strict_soft_waiter_keeps_acquisition_directory(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="creating symlinks requires elevated Windows privileges")
-def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> None:
+def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> None:  # pragma: win32 no cover
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"
     original.mkdir()
@@ -124,7 +124,7 @@ def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> Non
     replacement_holder = StrictSoftFileLock(replacement / "resource.lock")
     original_holder.acquire()
     replacement_holder.acquire()
-    try:
+    try:  # pragma: win32 no cover
         link.unlink()
         link.symlink_to(replacement, target_is_directory=True)
         original_holder.release()
@@ -146,7 +146,7 @@ def test_strict_soft_final_symlink_fails_closed_without_touching_target(tmp_path
     lock_path.symlink_to(target)
     lock = StrictSoftFileLock(lock_path, timeout=0)
 
-    with pytest.raises(Timeout):
+    with pytest.raises(Timeout):  # pragma: win32 no cover
         lock.acquire()
 
     assert (target.read_bytes(), lock_path.is_symlink(), lock.claims) == (_STRICT_SENTINEL, True, ())

--- a/tests/test_strict_soft_paths.py
+++ b/tests/test_strict_soft_paths.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
@@ -10,6 +9,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Final
 
 import pytest
+from coverage_pragmas import CAPABILITIES
 
 from filelock import AsyncStrictSoftFileLock, StrictSoftFileLock, Timeout
 
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 _STRICT_SENTINEL: Final[bytes] = b"1\nfilelock-strict-v1\x00\n0\n"
+
+_NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
+)
 
 
 pytestmark = pytest.mark.requires_hard_links
@@ -112,8 +116,8 @@ async def test_async_strict_soft_waiter_keeps_acquisition_directory(
         await contender.release(force=True)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="creating symlinks requires elevated Windows privileges")
-def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> None:  # pragma: win32 no cover
+@_NEEDS_SYMLINK  # pragma: needs symlink
+def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> None:
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"
     original.mkdir()
@@ -124,7 +128,7 @@ def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> Non
     replacement_holder = StrictSoftFileLock(replacement / "resource.lock")
     original_holder.acquire()
     replacement_holder.acquire()
-    try:  # pragma: win32 no cover
+    try:
         link.unlink()
         link.symlink_to(replacement, target_is_directory=True)
         original_holder.release()
@@ -138,10 +142,8 @@ def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> Non
         replacement_holder.release(force=True)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="creating symlinks requires elevated Windows privileges")
-def test_strict_soft_final_symlink_fails_closed_without_touching_target(  # pragma: win32 no cover
-    tmp_path: Path,
-) -> None:
+@_NEEDS_SYMLINK  # pragma: needs symlink
+def test_strict_soft_final_symlink_fails_closed_without_touching_target(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.write_bytes(_STRICT_SENTINEL)
     lock_path = tmp_path / "resource.lock"

--- a/tests/test_strict_soft_paths.py
+++ b/tests/test_strict_soft_paths.py
@@ -139,14 +139,16 @@ def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> Non
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="creating symlinks requires elevated Windows privileges")
-def test_strict_soft_final_symlink_fails_closed_without_touching_target(tmp_path: Path) -> None:
+def test_strict_soft_final_symlink_fails_closed_without_touching_target(  # pragma: win32 no cover
+    tmp_path: Path,
+) -> None:
     target = tmp_path / "target"
     target.write_bytes(_STRICT_SENTINEL)
     lock_path = tmp_path / "resource.lock"
     lock_path.symlink_to(target)
     lock = StrictSoftFileLock(lock_path, timeout=0)
 
-    with pytest.raises(Timeout):  # pragma: win32 no cover
+    with pytest.raises(Timeout):
         lock.acquire()
 
     assert (target.read_bytes(), lock_path.is_symlink(), lock.claims) == (_STRICT_SENTINEL, True, ())

--- a/tests/test_strict_soft_recovery.py
+++ b/tests/test_strict_soft_recovery.py
@@ -47,10 +47,8 @@ def test_strict_soft_recovers_every_claim_for_crashed_token(tmp_path: Path) -> N
     with pytest.raises(Timeout):
         lock.acquire()
 
-    crashed_token = claims[0].token
     for claim in lock.claims:
-        if claim.token == crashed_token:
-            lock.force_break(claim.name)
+        lock.force_break(claim.name)
     with lock:
         assert lock.is_locked
 

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -5,6 +5,7 @@ import socket
 import subprocess  # ruff:ignore[suspicious-subprocess-import]  # a clean interpreter isolates the blocked fcntl import
 import sys
 from errno import EIO, ENOSYS
+from importlib.util import find_spec
 from textwrap import dedent
 from typing import TYPE_CHECKING, Final
 
@@ -19,11 +20,13 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_UNIX_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform == "win32", reason="unix-only flock fallback")
+_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    find_spec("fcntl") is None, reason="the flock fallback path is driven through the fcntl module"
+)
 
 
-@_UNIX_ONLY
-def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL
+def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:  # pragma: needs fcntl
     script: Final[str] = dedent(
         """
         import json
@@ -67,9 +70,9 @@ def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:
     )
 
 
-@_UNIX_ONLY
+@_NEEDS_FCNTL
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_emits_warning(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_fallback_emits_warning(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock = UnixFileLock(tmp_path / "test.lock")
 
     with pytest.warns(UserWarning, match="flock not supported on this filesystem, falling back to SoftFileLock"):
@@ -77,35 +80,35 @@ def test_fallback_emits_warning(tmp_path: Path) -> None:  # pragma: win32 no cov
     lock.release()
 
 
-@_UNIX_ONLY
-@pytest.mark.filterwarnings("default::UserWarning")
+@_NEEDS_FCNTL
+@pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_swaps_to_soft(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_fallback_swaps_to_soft(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock = UnixFileLock(tmp_path / "test.lock")
 
-    with lock:  # pragma: win32 no cover
+    with lock:
         assert lock.is_locked
         assert isinstance(lock, SoftFileLock)
 
 
-@_UNIX_ONLY
-@pytest.mark.filterwarnings("default::UserWarning")
+@_NEEDS_FCNTL
+@pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock_path = tmp_path / "test.lock"
 
-    with UnixFileLock(lock_path):  # pragma: win32 no cover
+    with UnixFileLock(lock_path):
         lines = lock_path.read_text(encoding="utf-8").splitlines()
     expected = [str(os.getpid()), socket.gethostname()]
-    if (token := process_start_token(os.getpid())) is not None:  # pragma: win32 no cover
+    if (token := process_start_token(os.getpid())) is not None:  # pragma: no branch  # CI always exposes a start time
         expected.append(str(token))
     assert lines == expected
 
 
-@_UNIX_ONLY
-@pytest.mark.filterwarnings("default::UserWarning")
+@_NEEDS_FCNTL
+@pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_release_unlinks_file(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_fallback_release_unlinks_file(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock_path = tmp_path / "test.lock"
     lock = UnixFileLock(lock_path)
 
@@ -115,8 +118,8 @@ def test_fallback_release_unlinks_file(tmp_path: Path) -> None:  # pragma: win32
     assert not lock_path.exists()
 
 
-@_UNIX_ONLY
-@pytest.mark.filterwarnings("default::UserWarning")  # pragma: win32 no cover
+@_NEEDS_FCNTL
+@pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")  # pragma: needs fcntl
 def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, unsupported_flock: MagicMock) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
 
@@ -129,30 +132,30 @@ def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, unsupported_flo
     unsupported_flock.assert_not_called()
 
 
-@_UNIX_ONLY
-@pytest.mark.filterwarnings("default::UserWarning")
+@_NEEDS_FCNTL
+@pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_reentrant_locking(tmp_path: Path) -> None:  # pragma: win32 no cover
+def test_fallback_reentrant_locking(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock = UnixFileLock(tmp_path / "test.lock")
 
-    with lock:  # pragma: win32 no cover
-        with lock:  # pragma: win32 no cover
+    with lock:
+        with lock:
             assert lock.is_locked
         assert lock.is_locked
     assert not lock.is_locked
 
 
-@_UNIX_ONLY
-def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
+@_NEEDS_FCNTL
+def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: needs fcntl
     lock = UnixFileLock(tmp_path / "test.lock")
     lock.acquire()
 
     real_close = os.close  # capture before the patch so the fd still closes for real
     fd_to_fail = lock._context.lock_file_fd  # _release() nulls this before closing, so read it now
 
-    def _close_eio(fd: int) -> None:  # pragma: win32 no cover
+    def _close_eio(fd: int) -> None:
         real_close(fd)
-        if fd == fd_to_fail:  # pragma: win32 no cover
+        if fd == fd_to_fail:  # pragma: no branch  # only the lock's own descriptor closes while the patch is live
             raise OSError(EIO, "Input/output error")
 
     mocker.patch("filelock._unix.os.close", side_effect=_close_eio)
@@ -160,7 +163,7 @@ def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) 
     assert not lock.is_locked
 
 
-@_UNIX_ONLY  # pragma: win32 no cover
+@_NEEDS_FCNTL  # pragma: needs fcntl
 def test_acquire_flock_error_clears_pending_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
     mocker.patch(
@@ -168,7 +171,7 @@ def test_acquire_flock_error_clears_pending_descriptor(tmp_path: Path, mocker: M
         side_effect=[OSError(EIO, "Input/output error"), None, None],
     )
 
-    with pytest.raises(OSError, match="Input/output error"):  # pragma: win32 no cover
+    with pytest.raises(OSError, match="Input/output error"):
         lock.acquire(timeout=0)
     assert not lock.is_locked
 
@@ -179,5 +182,5 @@ def test_acquire_flock_error_clears_pending_descriptor(tmp_path: Path, mocker: M
 
 
 @pytest.fixture
-def unsupported_flock(mocker: MockerFixture) -> MagicMock:  # pragma: win32 no cover
+def unsupported_flock(mocker: MockerFixture) -> MagicMock:  # pragma: needs fcntl
     return mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "Function not implemented"))

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -23,7 +23,7 @@ _UNIX_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform == "wi
 
 
 @_UNIX_ONLY
-def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:
+def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:  # pragma: win32 no cover
     script: Final[str] = dedent(
         """
         import json
@@ -69,7 +69,7 @@ def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:
 
 @_UNIX_ONLY
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_emits_warning(tmp_path: Path) -> None:
+def test_fallback_emits_warning(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock = UnixFileLock(tmp_path / "test.lock")
 
     with pytest.warns(UserWarning, match="flock not supported on this filesystem, falling back to SoftFileLock"):
@@ -80,10 +80,10 @@ def test_fallback_emits_warning(tmp_path: Path) -> None:
 @_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_swaps_to_soft(tmp_path: Path) -> None:
+def test_fallback_swaps_to_soft(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock = UnixFileLock(tmp_path / "test.lock")
 
-    with lock:
+    with lock:  # pragma: win32 no cover
         assert lock.is_locked
         assert isinstance(lock, SoftFileLock)
 
@@ -91,13 +91,13 @@ def test_fallback_swaps_to_soft(tmp_path: Path) -> None:
 @_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:
+def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "test.lock"
 
-    with UnixFileLock(lock_path):
+    with UnixFileLock(lock_path):  # pragma: win32 no cover
         lines = lock_path.read_text(encoding="utf-8").splitlines()
     expected = [str(os.getpid()), socket.gethostname()]
-    if (token := process_start_token(os.getpid())) is not None:
+    if (token := process_start_token(os.getpid())) is not None:  # pragma: win32 no cover
         expected.append(str(token))
     assert lines == expected
 
@@ -105,7 +105,7 @@ def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:
 @_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_release_unlinks_file(tmp_path: Path) -> None:
+def test_fallback_release_unlinks_file(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock_path = tmp_path / "test.lock"
     lock = UnixFileLock(lock_path)
 
@@ -116,7 +116,7 @@ def test_fallback_release_unlinks_file(tmp_path: Path) -> None:
 
 
 @_UNIX_ONLY
-@pytest.mark.filterwarnings("default::UserWarning")
+@pytest.mark.filterwarnings("default::UserWarning")  # pragma: win32 no cover
 def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, unsupported_flock: MagicMock) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
 
@@ -132,27 +132,27 @@ def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, unsupported_flo
 @_UNIX_ONLY
 @pytest.mark.filterwarnings("default::UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
-def test_fallback_reentrant_locking(tmp_path: Path) -> None:
+def test_fallback_reentrant_locking(tmp_path: Path) -> None:  # pragma: win32 no cover
     lock = UnixFileLock(tmp_path / "test.lock")
 
-    with lock:
-        with lock:
+    with lock:  # pragma: win32 no cover
+        with lock:  # pragma: win32 no cover
             assert lock.is_locked
         assert lock.is_locked
     assert not lock.is_locked
 
 
 @_UNIX_ONLY
-def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: win32 no cover
     lock = UnixFileLock(tmp_path / "test.lock")
     lock.acquire()
 
     real_close = os.close  # capture before the patch so the fd still closes for real
     fd_to_fail = lock._context.lock_file_fd  # _release() nulls this before closing, so read it now
 
-    def _close_eio(fd: int) -> None:
+    def _close_eio(fd: int) -> None:  # pragma: win32 no cover
         real_close(fd)
-        if fd == fd_to_fail:
+        if fd == fd_to_fail:  # pragma: win32 no cover
             raise OSError(EIO, "Input/output error")
 
     mocker.patch("filelock._unix.os.close", side_effect=_close_eio)
@@ -160,7 +160,7 @@ def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) 
     assert not lock.is_locked
 
 
-@_UNIX_ONLY
+@_UNIX_ONLY  # pragma: win32 no cover
 def test_acquire_flock_error_clears_pending_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
     mocker.patch(
@@ -168,7 +168,7 @@ def test_acquire_flock_error_clears_pending_descriptor(tmp_path: Path, mocker: M
         side_effect=[OSError(EIO, "Input/output error"), None, None],
     )
 
-    with pytest.raises(OSError, match="Input/output error"):
+    with pytest.raises(OSError, match="Input/output error"):  # pragma: win32 no cover
         lock.acquire(timeout=0)
     assert not lock.is_locked
 
@@ -179,5 +179,5 @@ def test_acquire_flock_error_clears_pending_descriptor(tmp_path: Path, mocker: M
 
 
 @pytest.fixture
-def unsupported_flock(mocker: MockerFixture) -> MagicMock:
+def unsupported_flock(mocker: MockerFixture) -> MagicMock:  # pragma: win32 no cover
     return mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "Function not implemented"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -98,7 +98,7 @@ def test_break_lock_file_break_path_not_targetable_by_a_peer(tmp_path: Path, moc
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="symlink-to-dir raises IsADirectoryError only on Unix")
-def test_raise_on_not_writable_file_does_not_follow_symlink_to_dir(tmp_path: Path) -> None:
+def test_raise_on_not_writable_file_does_not_follow_symlink_to_dir(tmp_path: Path) -> None:  # pragma: win32 no cover
     target = tmp_path / "targetdir"
     target.mkdir()
     link = tmp_path / "my.lock"
@@ -109,7 +109,7 @@ def test_raise_on_not_writable_file_does_not_follow_symlink_to_dir(tmp_path: Pat
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="symlink + 0o444 semantics differ on Windows")
-@_SKIP_AS_ROOT
+@_SKIP_AS_ROOT  # pragma: win32 no cover
 def test_raise_on_not_writable_file_does_not_follow_symlink_to_readonly(tmp_path: Path) -> None:
     target = tmp_path / "readonly"
     target.write_text("x", encoding="utf-8")
@@ -121,21 +121,21 @@ def test_raise_on_not_writable_file_does_not_follow_symlink_to_readonly(tmp_path
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="real dir raises PermissionError on Windows")
-def test_raise_on_not_writable_file_still_rejects_real_directory(tmp_path: Path) -> None:
+def test_raise_on_not_writable_file_still_rejects_real_directory(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = tmp_path / "a_dir"
     path.mkdir()
-    with pytest.raises(IsADirectoryError):
+    with pytest.raises(IsADirectoryError):  # pragma: win32 no cover
         raise_on_not_writable_file(str(path))
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have read only files in the same way")
 @_SKIP_AS_ROOT
-def test_raise_on_not_writable_file_still_rejects_readonly_file(tmp_path: Path) -> None:
+def test_raise_on_not_writable_file_still_rejects_readonly_file(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = tmp_path / "ro.lock"
     path.write_text("x", encoding="utf-8")
     path.chmod(0o444)
-    try:
-        with pytest.raises(PermissionError):
+    try:  # pragma: win32 no cover
+        with pytest.raises(PermissionError):  # pragma: win32 no cover
             raise_on_not_writable_file(str(path))
     finally:
         path.chmod(0o644)
@@ -158,9 +158,9 @@ def test_raise_on_not_writable_file_rejects_readonly_file_any_mtime(tmp_path: Pa
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="a real directory raises PermissionError on Windows")
-def test_raise_on_not_writable_file_rejects_directory_with_mtime_zero(tmp_path: Path) -> None:
+def test_raise_on_not_writable_file_rejects_directory_with_mtime_zero(tmp_path: Path) -> None:  # pragma: win32 no cover
     path = tmp_path / "a_dir"
     path.mkdir()
     os.utime(path, (0, 0))
-    with pytest.raises(IsADirectoryError):
+    with pytest.raises(IsADirectoryError):  # pragma: win32 no cover
         raise_on_not_writable_file(str(path))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -86,7 +86,8 @@ def test_break_lock_file_break_path_not_targetable_by_a_peer(tmp_path: Path, moc
 
     def lstat_hook(path: str) -> os.stat_result:
         result = real_lstat(path)
-        if ".break." in path and not predictable.exists():  # once: the peer recreates a live lock at its own name
+        # break_lock_file lstats the break path exactly once, so this guard only ever runs its body (once).
+        if ".break." in path and not predictable.exists():  # pragma: no branch  # the peer recreates a live lock
             lock.write_text("live", encoding="utf-8")
             lock.rename(predictable)
         return result

--- a/tox.toml
+++ b/tox.toml
@@ -9,6 +9,9 @@ wheel_build_env = ".pkg"
 dependency_groups = [ "test" ]
 pass_env = [ "PYTEST_*", "SSL_CERT_FILE" ]
 set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage.{env_name}" }
+# tasks holds the coverage_pragmas plugin, which coverage imports by name in this process and in the subprocesses it
+# patches, so it has to resolve from the environment rather than from pytest's sys.path.
+set_env.PYTHONPATH = "{tox_root}{/}tasks"
 commands = [
   [
     "pytest",
@@ -58,6 +61,8 @@ pass_env = [
   "DIFF_AGAINST",
 ]
 set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage" }
+# Exclusions are applied when the report is rendered, so the reporting env needs the plugin too.
+set_env.PYTHONPATH = "{tox_root}{/}tasks"
 commands = [
   [ "coverage", "combine" ],
   [ "coverage", "report", "--skip-covered", "--show-missing" ],
@@ -163,6 +168,7 @@ commands = [ [ "towncrier", "build", "--yes", "--version", "{posargs}" ] ]
 # coverage writes .coverage in the repo root instead of {work_dir}/.coverage.3.14, so the CI rename cannot find it.
 set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage.{env_name}" }
 set_env.FILELOCK_OLD_CLIENT_PATH = "{env_tmp_dir}{/}filelock-3.20.0"
+set_env.PYTHONPATH = "{tox_root}{/}tasks"
 commands_pre = [
   [
     "uv",

--- a/tox.toml
+++ b/tox.toml
@@ -65,10 +65,7 @@ set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{w
 set_env.PYTHONPATH = "{tox_root}{/}tasks"
 commands = [
   [ "coverage", "combine" ],
-  # A single env cannot reach 100%: the old-client and version-gated suites run only under the env that provides them,
-  # so report.fail_under tracks the weakest one. Every line is covered by some env though, so hold the combined report
-  # to 100 and let it catch a line that no env exercises.
-  [ "coverage", "report", "--skip-covered", "--show-missing", "--fail-under", "100" ],
+  [ "coverage", "report", "--skip-covered", "--show-missing" ],
   [ "coverage", "xml", "-o", "{env_tmp_dir}{/}coverage.xml" ],
   [ "coverage", "html", "-d", "{work_dir}{/}htmlcov" ],
   [

--- a/tox.toml
+++ b/tox.toml
@@ -65,7 +65,10 @@ set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{w
 set_env.PYTHONPATH = "{tox_root}{/}tasks"
 commands = [
   [ "coverage", "combine" ],
-  [ "coverage", "report", "--skip-covered", "--show-missing" ],
+  # A single env cannot reach 100%: the old-client and version-gated suites run only under the env that provides them,
+  # so report.fail_under tracks the weakest one. Every line is covered by some env though, so hold the combined report
+  # to 100 and let it catch a line that no env exercises.
+  [ "coverage", "report", "--skip-covered", "--show-missing", "--fail-under", "100" ],
   [ "coverage", "xml", "-o", "{env_tmp_dir}{/}coverage.xml" ],
   [ "coverage", "html", "-d", "{work_dir}{/}htmlcov" ],
   [


### PR DESCRIPTION
A pragma that names a platform is standing in for the reason the code cannot run there, and the stand-in goes stale. One `win32 no cover` sat on the `os.link` fallback for `follow_symlinks` and demanded a branch modern Windows never takes, while others excluded platform-agnostic code and hid Windows gaps behind it. Of the markers carrying no reason at all, most were per-line copies of one block-level fact.

A configurer plugin in `tasks/coverage_pragmas.py`, registered after covdefaults, replaces the platform name with the capability the code needs. 🔍 `# pragma: needs <capability>` drops out only where that capability is absent and `# pragma: lacks <capability>` only where it is present, across sixteen capabilities probed at runtime: `fork`, `dir-fd`, `hard-link`, `symlink`, `fcntl`, `unlink-open-file`, `posix-signals`, `file-mode`, `fd-directory`, `fifo`, `af-unix`, `o-nofollow`, `utime-nofollow`, `utime-fd`, `sqlite3` and `link-follow-symlinks`. The `skipif` gates read the same `CAPABILITIES` mapping the plugin excludes from, so a gate and its exclusion cannot drift apart. `hard-link` stays required on Windows, which has hard links and which `win32 no cover` could not express.

Each remaining marker sits on the enclosing clause header or decorator, which coverage carries across the whole body, so the per-line copies are gone and no marker has to fit inside a line already past the width limit.

Naming the capability separates cases the platform name had merged. Windows does support symlinks, so the cases needing one now run there for the first time; the cases asserting that a symlinked parent collapses into one key stay gated, because `_resolve_dir` resolves a parent with `abspath` on Windows to avoid following junctions and reparse points, which keeps that parent a distinct key. A `symlink` job runs it both ways, and denying it takes both doors, since [Developer Mode](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw) and `SeCreateSymbolicLinkPrivilege` each grant symlink creation on their own. The job clears the registry value and removes the privilege, which [`AdjustTokenPrivileges` documents as irreversible](https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) with checks then returning `STATUS_PRIVILEGE_NOT_HELD`.

`report.fail_under` rises from 95 to 99, and the combined matrix reports 100% with no missed statement or partial branch. ✅ No public behavior changes, since the edits under `src/filelock/` are markers and one reflowed call.
