### PR TITLE
🐛 fix(strict): tolerate an errno without ENOTSUP

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -27,12 +27,17 @@ jobs:
           - "3.11"
           - "3.10"
           - "pypy3.11"
+          - "graalpy3.11"
         os:
           - ubuntu-24.04
           - windows-2025
           - macos-15
         exclude:
           - {os: windows-2025, py: pypy3.11}
+          # GraalPy validates the capability probes the suite gates on, which is a per-OS answer, not a per-arch one.
+          # One Linux job settles it; the Windows and macOS builds only repeat it at triple the runtime.
+          - {os: windows-2025, py: graalpy3.11}
+          - {os: macos-15, py: graalpy3.11}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -52,9 +57,10 @@ jobs:
           UV_PYTHON_PREFERENCE: only-managed
       # PyPy runs unmeasured: coverage has no JIT path there, so the suite takes 12m rather than 2m and roughly 60 of
       # its lock, heartbeat and poll deadlines lapse under the added latency, though they pass measured in isolation.
+      # GraalPy runs unmeasured for the same reason, and neither is a coverage source: the 100% gate stays CPython's.
       - name: "✅ Run test suite"
         run: |
-          if [[ "${{ matrix.py }}" == pypy* ]]; then
+          if [[ "${{ matrix.py }}" == pypy* || "${{ matrix.py }}" == graalpy* ]]; then
             tox run --skip-pkg-install -e ${{ matrix.py }} --
           else
             tox run --skip-pkg-install -e ${{ matrix.py }}
@@ -65,13 +71,13 @@ jobs:
           UV_PYTHON_PREFERENCE: only-managed
           DIFF_AGAINST: HEAD
       - name: "📝 Rename coverage report file"
-        if: ${{ !startsWith(matrix.py, 'pypy')}}
+        if: ${{ !startsWith(matrix.py, 'pypy') && !startsWith(matrix.py, 'graalpy') }}
         run: |
           import os; import sys
           os.rename(f".tox/.coverage.${{ matrix.py }}", f".tox/.coverage.${{ matrix.py }}-{sys.platform}")
         shell: python
       - name: "📦 Upload coverage data"
-        if: ${{ !startsWith(matrix.py, 'pypy')}}
+        if: ${{ !startsWith(matrix.py, 'pypy') && !startsWith(matrix.py, 'graalpy') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           include-hidden-files: true

--- a/docs/changelog/681.bugfix.rst
+++ b/docs/changelog/681.bugfix.rst
@@ -1,3 +1,4 @@
-``filelock`` imports again on runtimes whose ``errno`` module does not define ``ENOTSUP``, such as GraalPy 24.1, where
-importing the package raised ``ImportError``. The code is probed instead, falling back to ``EOPNOTSUPP`` and then to
-``ENOSYS``/``EXDEV`` alone, so platforms that define ``ENOTSUP`` keep their behavior.
+``filelock`` imports again on runtimes whose ``errno`` omits ``ENOTSUP``, such as GraalPy, where importing the package
+raised ``ImportError``. It probes the code instead, preferring ``ENOTSUP``, falling back to ``EOPNOTSUPP`` where that
+name is absent, and dropping to ``ENOSYS``/``EXDEV`` where neither exists. Platforms defining ``ENOTSUP`` keep their
+behavior.

--- a/docs/changelog/681.bugfix.rst
+++ b/docs/changelog/681.bugfix.rst
@@ -1,0 +1,3 @@
+``filelock`` imports again on runtimes whose ``errno`` module does not define ``ENOTSUP``, such as GraalPy 24.1, where
+importing the package raised ``ImportError``. The code is probed instead, falling back to ``EOPNOTSUPP`` and then to
+``ENOSYS``/``EXDEV`` alone, so platforms that define ``ENOTSUP`` keep their behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ max_supported_python = "3.14"
 src.exclude = []
 # Mirrors pytest's pythonpath so the tests' `coverage_pragmas` import resolves here too.
 environment.extra-paths = [
+  ".",
   "tasks",
 ]
 environment.python-version = "3.14"
@@ -183,9 +184,11 @@ environment.python-version = "3.14"
 ini_options.testpaths = [
   "tests",
 ]
-# tasks holds coverage_pragmas, whose CAPABILITIES probes drive both the coverage exclusions and the skipif gates, so a
-# test can never be skipped while coverage still demands its lines.
+# The project root lets the tests import each other as tests.*; tasks holds coverage_pragmas, whose CAPABILITIES probes
+# drive both the coverage exclusions and the skipif gates, so a test can never be skipped while coverage still demands
+# its lines. coverage imports that plugin by name in the subprocesses it patches, so it stays a top-level module.
 ini_options.pythonpath = [
+  ".",
   "tasks",
 ]
 ini_options.markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,6 @@ paths.source = [
   "**\\src",
 ]
 report.fail_under = 100
-html.show_contexts = true
 html.skip_covered = false
 
 [tool.towncrier]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,40 +120,40 @@ lint.select = [
   "ALL",
 ]
 lint.ignore = [
-  "COM812", # Conflict with formatter
-  "CPY",    # No copyright statements
-  "D203",   # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible
-  "D205",   # 1 blank line required between summary line and description
-  "D212",   # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible
-  "D301",   # Use `r"""` if any backslashes in a docstring
-  "D401",   # First line of docstring should be in imperative mood
-  "DOC",    # no support yet
-  "ISC001", # Conflict with formatter
-  "RUF067", # `__init__` module should only contain docstrings and re-exports
-  "S104",   # Possible binding to all interface
+  "CPY",                                       # No copyright statements
+  "DOC",                                       # no support yet
+  "escape-sequence-in-docstring",              # Use `r"""` if any backslashes in a docstring
+  "hardcoded-bind-all-interfaces",             # Possible binding to all interface
+  "incorrect-blank-line-before-class",         # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible
+  "missing-blank-line-after-summary",          # 1 blank line required between summary line and description
+  "missing-trailing-comma",                    # Conflict with formatter
+  "multi-line-summary-first-line",             # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible
+  "non-empty-init-module",                     # `__init__` module should only contain docstrings and re-exports
+  "non-imperative-mood",                       # First line of docstring should be in imperative mood
+  "single-line-implicit-string-concatenation", # Conflict with formatter
 ]
 lint.per-file-ignores."tasks/**/*.py" = [
-  "D",      # don't care about documentation in tasks scripts
-  "INP001", # no implicit namespace
-  "S101",   # asserts state the platform a Windows-only script already refuses to run outside of, narrowing it for ty
-  "S603",   # `subprocess` call: check for execution of untrusted input
-  "T201",   # print allowed in scripts
+  "assert",                               # asserts state the platform a Windows-only script already refuses to run outside of, narrowing it for ty
+  "D",                                    # don't care about documentation in tasks scripts
+  "implicit-namespace-package",           # no implicit namespace
+  "print",                                # print allowed in scripts
+  "subprocess-without-shell-equals-true", # `subprocess` call: check for execution of untrusted input
 ]
 lint.per-file-ignores."tests/**/*.py" = [
-  "BLE001",  # blind exception catching acceptable in test helpers
-  "D",       # don't care about documentation in tests
-  "FBT",     # don't care about booleans as positional arguments in tests
-  "INP001",  # no implicit namespace
-  "N806",    # variable in function should be lowercase
-  "PLC0415", # import should be at top-level
-  "PLC2701", # private name import from external module
-  "PLR0913", # too many arguments in function definition
-  "PLR0917", # too many positional arguments
-  "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
-  "PLW0717", # try/finally cleanup blocks in tests legitimately hold many statements
-  "S101",    # asserts allowed in tests
-  "S603",    # `subprocess` call: check for execution of untrusted input
-  "SLF001",  # accessing private members acceptable in tests
+  "assert",                               # asserts allowed in tests
+  "blind-except",                         # blind exception catching acceptable in test helpers
+  "D",                                    # don't care about documentation in tests
+  "FBT",                                  # don't care about booleans as positional arguments in tests
+  "implicit-namespace-package",           # no implicit namespace
+  "import-outside-top-level",             # import should be at top-level
+  "import-private-name",                  # private name import from external module
+  "magic-value-comparison",               # Magic value used in comparison, consider replacing with a constant variable
+  "non-lowercase-variable-in-function",   # variable in function should be lowercase
+  "private-member-access",                # accessing private members acceptable in tests
+  "subprocess-without-shell-equals-true", # `subprocess` call: check for execution of untrusted input
+  "too-many-arguments",                   # too many arguments in function definition
+  "too-many-positional-arguments",        # too many positional arguments
+  "too-many-statements-in-try-clause",    # try/finally cleanup blocks in tests legitimately hold many statements
 ]
 lint.isort = { known-first-party = [
   "filelock",

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -80,10 +80,11 @@ _LINK_HONORS_FOLLOW_SYMLINKS: Final[bool] = _probe_link_follow_symlinks()
 
 
 def _probe_hard_link_unsupported_errnos() -> frozenset[int]:
-    # GraalPy's errno omits ENOTSUP, so importing the name outright breaks every runtime that ships without it. Where
-    # both names exist outside Windows they are the same code, so EOPNOTSUPP stands in exactly; where neither exists a
-    # runtime that cannot name "operation not supported" cannot raise it either, and ENOSYS/EXDEV still classify the
-    # link failures it can raise.
+    # GraalPy's errno omits ENOTSUP, so importing the name outright breaks every runtime that ships without it. ENOTSUP
+    # wins wherever it exists, leaving every runtime that names it unchanged. EOPNOTSUPP only stands in for the ones
+    # that do not, and it approximates rather than matches: the two codes agree on Linux but differ on macOS/BSD and on
+    # Windows. Where neither exists a runtime that cannot name "operation not supported" cannot raise it either, and
+    # ENOSYS/EXDEV still classify the link failures it can raise.
     not_supported = getattr(errno, "ENOTSUP", getattr(errno, "EOPNOTSUPP", None))
     return frozenset({ENOSYS, EXDEV} if not_supported is None else {ENOSYS, EXDEV, not_supported})
 

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
 import secrets
 import stat
@@ -8,7 +9,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
-from errno import EACCES, EEXIST, ENOENT, ENOSYS, ENOTSUP, EPERM, ESTALE, EXDEV
+from errno import EACCES, EEXIST, ENOENT, ENOSYS, EPERM, ESTALE, EXDEV
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal, cast
 
@@ -76,6 +77,18 @@ def _probe_link_follow_symlinks() -> bool:
 
 
 _LINK_HONORS_FOLLOW_SYMLINKS: Final[bool] = _probe_link_follow_symlinks()
+
+
+def _probe_hard_link_unsupported_errnos() -> frozenset[int]:
+    # GraalPy's errno omits ENOTSUP, so importing the name outright breaks every runtime that ships without it. Where
+    # both names exist outside Windows they are the same code, so EOPNOTSUPP stands in exactly; where neither exists a
+    # runtime that cannot name "operation not supported" cannot raise it either, and ENOSYS/EXDEV still classify the
+    # link failures it can raise.
+    not_supported = getattr(errno, "ENOTSUP", getattr(errno, "EOPNOTSUPP", None))
+    return frozenset({ENOSYS, EXDEV} if not_supported is None else {ENOSYS, EXDEV, not_supported})
+
+
+_HARD_LINK_UNSUPPORTED_ERRNOS: Final[frozenset[int]] = _probe_hard_link_unsupported_errnos()
 
 
 class StrictSoftFileLock(BaseFileLock):
@@ -841,7 +854,7 @@ def _require_exact_name(directory: Path, name: str) -> None:
 def _raise_if_hard_links_unsupported(lock_file: str, error: NotImplementedError | OSError) -> None:
     unsupported = (
         isinstance(error, NotImplementedError)
-        or error.errno in {ENOSYS, ENOTSUP, EXDEV}
+        or error.errno in _HARD_LINK_UNSUPPORTED_ERRNOS
         or (getattr(error, "winerror", None) in _WINDOWS_HARD_LINK_UNSUPPORTED)
     )
     if unsupported:

--- a/tasks/coverage_pragmas.py
+++ b/tasks/coverage_pragmas.py
@@ -14,21 +14,36 @@ List this after covdefaults in ``[tool.coverage] run.plugins``; both merge into 
 
 from __future__ import annotations
 
+import gc
 import os
 import signal
 import socket
+import sys
 import tempfile
+import weakref
+from asyncio import CancelledError
+from contextlib import asynccontextmanager, contextmanager
 from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from coverage import CoveragePlugin
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import AsyncIterator, Generator, Iterable, Iterator
 
     from coverage.plugin_support import Plugins
     from coverage.types import TConfigurable
+
+
+class _Suspend:
+    """An awaitable that parks its coroutine once, so a probe can throw into a suspended frame without a loop."""
+
+    def __await__(self) -> Generator[None, Any, None]:
+        yield
+
+
+_AUDIT_PROBE_EVENT: Final[str] = "filelock.capability-probe"
 
 
 # coverage passes the config's plugin options; this plugin takes none.
@@ -102,6 +117,111 @@ def _honors_link_follow_symlinks() -> bool:
         return True
 
 
+def _finalizes_on_last_reference() -> bool:
+    # Only a refcounting collector runs __del__ the moment the last reference goes; a tracing one defers it.
+    finalized: list[bool] = []
+
+    class Probe:
+        def __del__(self) -> None:
+            finalized.append(True)
+
+    Probe()
+    return bool(finalized)
+
+
+def _finalizes_on_collection() -> bool:
+    # GraalPy queues finalizers on the host collector, so even a forced collection does not run __del__.
+    finalized: list[bool] = []
+
+    class Probe:
+        def __del__(self) -> None:
+            finalized.append(True)
+
+    Probe()
+    gc.collect()
+    return bool(finalized)
+
+
+def _collects_classes() -> bool:
+    # A dynamically built lock subclass must not outlive its last reference, or the registries keyed on it leak.
+    def build() -> type:
+        class Probe:
+            pass
+
+        return Probe
+
+    reference = weakref.ref(build())
+    gc.collect()
+    return reference() is None
+
+
+def _preserves_context_thrown_into_a_generator() -> bool:
+    # GraalPy resets __context__ when contextlib throws into the suspended generator, losing the chained cause.
+    @contextmanager
+    def probe() -> Iterator[None]:
+        yield
+
+    error = KeyError("thrown")
+    error.__context__ = ValueError("context")
+    try:
+        with probe():
+            raise error
+    except KeyError as caught:
+        return caught.__context__ is not None
+    return False  # pragma: no cover  # the raise above always propagates
+
+
+def _propagates_a_cancellation_thrown_into_a_coroutine() -> bool:
+    # Driven by hand so the probe needs no event loop: GraalPy answers athrow with RuntimeError instead of the
+    # CancelledError, so every cancellation crossing an async context manager surfaces as the wrong exception.
+    @asynccontextmanager
+    async def gate() -> AsyncIterator[None]:
+        await _Suspend()
+        yield
+
+    async def body() -> None:
+        async with gate():
+            pass
+
+    coroutine = body()
+    coroutine.send(None)
+    try:
+        coroutine.throw(CancelledError())
+    except CancelledError:
+        return True
+    except BaseException:  # ruff:ignore[blind-except]  # whatever else a runtime substitutes counts as the deviation
+        return False
+    return False  # pragma: no cover  # throwing into the suspended coroutine always raises
+
+
+def _delivers_audit_events() -> bool:
+    # GraalPy accepts a hook and never calls it. The hook is a permanent no-op; tests install their own anyway.
+    delivered: list[bool] = []
+    sys.addaudithook(lambda event, _args: delivered.append(True) if event == _AUDIT_PROBE_EVENT else None)
+    sys.audit(_AUDIT_PROBE_EVENT)
+    return bool(delivered)
+
+
+def _refuses_to_open_a_symlink() -> bool:
+    # GraalPy accepts O_NOFOLLOW then follows the link anyway, so ask for the refusal rather than the constant.
+    if not hasattr(os, "O_NOFOLLOW"):
+        return False
+    if not _supports_symlink():
+        # Nothing to point the probe at, so keep the constant's answer rather than reporting a gap we cannot see.
+        return True
+    with tempfile.TemporaryDirectory() as directory:
+        target = Path(directory, "target")
+        target.touch()
+        link = Path(directory, "link")
+        link.symlink_to(target)
+        try:
+            descriptor = os.open(link, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError:
+            return True
+        os.close(descriptor)
+        return False
+
+
 def _enforces_file_mode() -> bool:
     # Without POSIX permission bits a chmod does not read back.
     with tempfile.TemporaryDirectory() as directory:
@@ -117,17 +237,25 @@ _OWNER_READ_WRITE: Final[int] = 0o600
 CAPABILITIES: Final[dict[str, bool]] = {
     "fork": hasattr(os, "fork") and hasattr(os, "register_at_fork"),
     "dir-fd": os.open in os.supports_dir_fd,
+    # Narrower than "dir-fd": GraalPy takes os.open relative to a directory descriptor but not os.link.
+    "link-dir-fd": hasattr(os, "link") and os.link in os.supports_dir_fd,
     "hard-link": hasattr(os, "link"),
     "symlink": _supports_symlink(),
     "fcntl": find_spec("fcntl") is not None,
     "unlink-open-file": _supports_unlinking_an_open_file(),
     "posix-signals": hasattr(signal, "SIGKILL"),
     "file-mode": _enforces_file_mode(),
+    "prompt-finalization": _finalizes_on_last_reference(),
+    "collected-finalization": _finalizes_on_collection(),
+    "class-collection": _collects_classes(),
+    "generator-exception-context": _preserves_context_thrown_into_a_generator(),
+    "coroutine-cancellation": _propagates_a_cancellation_thrown_into_a_coroutine(),
+    "audit-events": _delivers_audit_events(),
     "fd-directory": any(Path(view).is_dir() for view in ("/dev/fd", "/proc/self/fd")),
     "fifo": hasattr(os, "mkfifo"),
     "af-unix": hasattr(socket, "AF_UNIX"),
     # Distinct from "symlink": a runtime can create them yet still not refuse to follow one.
-    "o-nofollow": hasattr(os, "O_NOFOLLOW"),
+    "o-nofollow": _refuses_to_open_a_symlink(),
     "utime-nofollow": os.utime in os.supports_follow_symlinks,
     "utime-fd": os.utime in os.supports_fd,
     "sqlite3": find_spec("sqlite3") is not None,

--- a/tasks/coverage_pragmas.py
+++ b/tasks/coverage_pragmas.py
@@ -236,6 +236,8 @@ _OWNER_READ_WRITE: Final[int] = 0o600
 #: Capability -> whether this runtime provides it. Tests gate their skipif on this same mapping.
 CAPABILITIES: Final[dict[str, bool]] = {
     "fork": hasattr(os, "fork") and hasattr(os, "register_at_fork"),
+    # Narrower than "fork": GraalPy registers fork handlers but cannot fork.
+    "register-at-fork": hasattr(os, "register_at_fork"),
     "dir-fd": os.open in os.supports_dir_fd,
     # Narrower than "dir-fd": GraalPy takes os.open relative to a directory descriptor but not os.link.
     "link-dir-fd": hasattr(os, "link") and os.link in os.supports_dir_fd,

--- a/tasks/coverage_pragmas.py
+++ b/tasks/coverage_pragmas.py
@@ -25,7 +25,7 @@ from asyncio import CancelledError
 from contextlib import asynccontextmanager, contextmanager
 from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Final, cast
 
 from coverage import CoveragePlugin
 
@@ -34,16 +34,6 @@ if TYPE_CHECKING:
 
     from coverage.plugin_support import Plugins
     from coverage.types import TConfigurable
-
-
-class _Suspend:
-    """An awaitable that parks its coroutine once, so a probe can throw into a suspended frame without a loop."""
-
-    def __await__(self) -> Generator[None, Any, None]:
-        yield
-
-
-_AUDIT_PROBE_EVENT: Final[str] = "filelock.capability-probe"
 
 
 # coverage passes the config's plugin options; this plugin takes none.
@@ -171,6 +161,13 @@ def _preserves_context_thrown_into_a_generator() -> bool:
     return False  # pragma: no cover  # the raise above always propagates
 
 
+class _Suspend:
+    """An awaitable that parks its coroutine once, so a probe can throw into a suspended frame without a loop."""
+
+    def __await__(self) -> Generator[None, None, None]:
+        yield
+
+
 def _propagates_a_cancellation_thrown_into_a_coroutine() -> bool:
     # Driven by hand so the probe needs no event loop: GraalPy answers athrow with RuntimeError instead of the
     # CancelledError, so every cancellation crossing an async context manager surfaces as the wrong exception.
@@ -192,6 +189,9 @@ def _propagates_a_cancellation_thrown_into_a_coroutine() -> bool:
     except BaseException:  # ruff:ignore[blind-except]  # whatever else a runtime substitutes counts as the deviation
         return False
     return False  # pragma: no cover  # throwing into the suspended coroutine always raises
+
+
+_AUDIT_PROBE_EVENT: Final[str] = "filelock.capability-probe"
 
 
 def _delivers_audit_events() -> bool:
@@ -239,6 +239,7 @@ CAPABILITIES: Final[dict[str, bool]] = {
     "dir-fd": os.open in os.supports_dir_fd,
     # Narrower than "dir-fd": GraalPy takes os.open relative to a directory descriptor but not os.link.
     "link-dir-fd": hasattr(os, "link") and os.link in os.supports_dir_fd,
+    "fork1": hasattr(os, "fork1"),
     "hard-link": hasattr(os, "link"),
     "symlink": _supports_symlink(),
     "fcntl": find_spec("fcntl") is not None,

--- a/tests/capability_marks.py
+++ b/tests/capability_marks.py
@@ -1,0 +1,59 @@
+"""Marks for runtime capabilities several test modules gate on.
+
+Capabilities used by a single module stay private to it, as ``_NEEDS_SYMLINK`` and friends do. These span modules, so
+they live here and read the same ``CAPABILITIES`` probes the coverage pragmas use.
+"""
+
+from __future__ import annotations
+
+import pytest
+from coverage_pragmas import CAPABILITIES
+
+#: A dropped reference releases what its __del__ releases. Only a refcounting collector does this.
+NEEDS_PROMPT_FINALIZATION = pytest.mark.skipif(
+    not CAPABILITIES["prompt-finalization"],
+    reason="a dropped reference does not run __del__ on a deferred collector",
+)
+
+#: gc.collect() runs pending __del__ methods. GraalPy hands them to the host collector and never gets them back.
+NEEDS_COLLECTED_FINALIZATION = pytest.mark.skipif(
+    not CAPABILITIES["collected-finalization"],
+    reason="gc.collect() does not run __del__ on this runtime",
+)
+
+#: gc.collect() reclaims a dynamically built class once its last reference goes.
+NEEDS_CLASS_COLLECTION = pytest.mark.skipif(
+    not CAPABILITIES["class-collection"],
+    reason="gc.collect() does not reclaim classes on this runtime",
+)
+
+#: An exception thrown into a suspended generator or coroutine keeps its __context__.
+NEEDS_GENERATOR_EXCEPTION_CONTEXT = pytest.mark.skipif(
+    not CAPABILITIES["generator-exception-context"],
+    reason="this runtime clears __context__ when an exception is thrown into a suspended frame",
+)
+
+#: sys.audit delivers to hooks installed with sys.addaudithook. GraalPy accepts the hook and never calls it.
+NEEDS_AUDIT_EVENTS = pytest.mark.skipif(
+    not CAPABILITIES["audit-events"],
+    reason="this runtime never delivers audit events to an installed hook",
+)
+
+#: A cancellation crossing an async context manager surfaces as CancelledError rather than the interpreter's own
+#: bookkeeping error. GraalPy's contextlib raises ``RuntimeError: generator didn't stop after athrow()`` from
+#: ``_GeneratorContextManagerBase.__aexit__`` instead, so the lock's cancellation contract cannot be observed there.
+#: Not strict: the deviation depends on where the cancellation lands, so some of these tests still pass.
+XFAIL_WITHOUT_COROUTINE_CANCELLATION = pytest.mark.xfail(
+    not CAPABILITIES["coroutine-cancellation"],
+    reason="GraalPy's contextlib answers athrow() with RuntimeError instead of propagating the CancelledError",
+    strict=False,
+)
+
+__all__ = [
+    "NEEDS_AUDIT_EVENTS",
+    "NEEDS_CLASS_COLLECTION",
+    "NEEDS_COLLECTED_FINALIZATION",
+    "NEEDS_GENERATOR_EXCEPTION_CONTEXT",
+    "NEEDS_PROMPT_FINALIZATION",
+    "XFAIL_WITHOUT_COROUTINE_CANCELLATION",
+]

--- a/tests/capability_marks.py
+++ b/tests/capability_marks.py
@@ -1,49 +1,85 @@
 """Marks for runtime capabilities several test modules gate on.
 
-Capabilities used by a single module stay private to it, as ``_NEEDS_SYMLINK`` and friends do. These span modules, so
-they live here and read the same ``CAPABILITIES`` probes the coverage pragmas use.
+Capabilities used by a single module stay private to it, as ``_NEEDS_LINK_DIR_FD`` and friends do. These span modules,
+so they live here and read the same ``CAPABILITIES`` probes the coverage pragmas use. Gate on a probe rather than on an
+interpreter or platform name: a name answers who is running, and every one of these questions is about what the runtime
+can do.
 """
 
 from __future__ import annotations
 
+import sys
+from typing import TYPE_CHECKING
+
 import pytest
 from coverage_pragmas import CAPABILITIES
 
-#: A dropped reference releases what its __del__ releases. Only a refcounting collector does this.
-NEEDS_PROMPT_FINALIZATION = pytest.mark.skipif(
+if TYPE_CHECKING:
+    from typing import Final
+
+NEEDS_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["fork"], reason="installing fork handlers needs os.register_at_fork"
+)
+
+NEEDS_FORK1: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["fork1"], reason="forking a single thread needs the Solaris os.fork1"
+)
+
+NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["fcntl"], reason="native flock semantics need the fcntl module"
+)
+
+NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"], reason="creating a symlink needs a privilege this runtime does not grant"
+)
+
+#: Windows resolves a lock's parent with abspath, so a symlinked parent stays a distinct key and never collapses.
+NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["symlink"] or sys.platform == "win32",
+    reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",
+)
+
+NEEDS_FILE_MODE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["file-mode"], reason="making a folder or a claim unreadable needs POSIX permission bits"
+)
+
+NEEDS_UNLINK_OPEN_FILE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["unlink-open-file"],
+    reason="this runtime keeps an open marker undeletable, so no peer can take it from a live holder",
+)
+
+NEEDS_POSIX_SIGNALS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["posix-signals"], reason="liveness is probed with os.kill only where POSIX signals exist"
+)
+
+NEEDS_PROMPT_FINALIZATION: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["prompt-finalization"],
     reason="a dropped reference does not run __del__ on a deferred collector",
 )
 
-#: gc.collect() runs pending __del__ methods. GraalPy hands them to the host collector and never gets them back.
-NEEDS_COLLECTED_FINALIZATION = pytest.mark.skipif(
+NEEDS_COLLECTED_FINALIZATION: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["collected-finalization"],
     reason="gc.collect() does not run __del__ on this runtime",
 )
 
-#: gc.collect() reclaims a dynamically built class once its last reference goes.
-NEEDS_CLASS_COLLECTION = pytest.mark.skipif(
+NEEDS_CLASS_COLLECTION: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["class-collection"],
     reason="gc.collect() does not reclaim classes on this runtime",
 )
 
-#: An exception thrown into a suspended generator or coroutine keeps its __context__.
-NEEDS_GENERATOR_EXCEPTION_CONTEXT = pytest.mark.skipif(
+NEEDS_GENERATOR_EXCEPTION_CONTEXT: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["generator-exception-context"],
     reason="this runtime clears __context__ when an exception is thrown into a suspended frame",
 )
 
-#: sys.audit delivers to hooks installed with sys.addaudithook. GraalPy accepts the hook and never calls it.
-NEEDS_AUDIT_EVENTS = pytest.mark.skipif(
+NEEDS_AUDIT_EVENTS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["audit-events"],
     reason="this runtime never delivers audit events to an installed hook",
 )
 
-#: A cancellation crossing an async context manager surfaces as CancelledError rather than the interpreter's own
-#: bookkeeping error. GraalPy's contextlib raises ``RuntimeError: generator didn't stop after athrow()`` from
-#: ``_GeneratorContextManagerBase.__aexit__`` instead, so the lock's cancellation contract cannot be observed there.
-#: Not strict: the deviation depends on where the cancellation lands, so some of these tests still pass.
-XFAIL_WITHOUT_COROUTINE_CANCELLATION = pytest.mark.xfail(
+#: Raised from ``_GeneratorContextManagerBase.__aexit__``, so the lock's cancellation contract cannot be observed at
+#: all there. Not strict: the deviation depends on where the cancellation lands, so some of these tests still pass.
+XFAIL_WITHOUT_COROUTINE_CANCELLATION: Final[pytest.MarkDecorator] = pytest.mark.xfail(
     not CAPABILITIES["coroutine-cancellation"],
     reason="GraalPy's contextlib answers athrow() with RuntimeError instead of propagating the CancelledError",
     strict=False,
@@ -53,7 +89,15 @@ __all__ = [
     "NEEDS_AUDIT_EVENTS",
     "NEEDS_CLASS_COLLECTION",
     "NEEDS_COLLECTED_FINALIZATION",
+    "NEEDS_FCNTL",
+    "NEEDS_FILE_MODE",
+    "NEEDS_FORK",
+    "NEEDS_FORK1",
     "NEEDS_GENERATOR_EXCEPTION_CONTEXT",
+    "NEEDS_PARENT_SYMLINK_COLLAPSE",
+    "NEEDS_POSIX_SIGNALS",
     "NEEDS_PROMPT_FINALIZATION",
+    "NEEDS_SYMLINK",
+    "NEEDS_UNLINK_OPEN_FILE",
     "XFAIL_WITHOUT_COROUTINE_CANCELLATION",
 ]

--- a/tests/capability_marks.py
+++ b/tests/capability_marks.py
@@ -21,6 +21,10 @@ NEEDS_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["fork"], reason="installing fork handlers needs os.register_at_fork"
 )
 
+NEEDS_REGISTER_AT_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["register-at-fork"], reason="the fork transition gate is installed through os.register_at_fork"
+)
+
 NEEDS_FORK1: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["fork1"], reason="forking a single thread needs the Solaris os.fork1"
 )
@@ -97,6 +101,7 @@ __all__ = [
     "NEEDS_PARENT_SYMLINK_COLLAPSE",
     "NEEDS_POSIX_SIGNALS",
     "NEEDS_PROMPT_FINALIZATION",
+    "NEEDS_REGISTER_AT_FORK",
     "NEEDS_SYMLINK",
     "NEEDS_UNLINK_OPEN_FILE",
     "XFAIL_WITHOUT_COROUTINE_CANCELLATION",

--- a/tests/capability_marks.py
+++ b/tests/capability_marks.py
@@ -17,6 +17,16 @@ from coverage_pragmas import CAPABILITIES
 if TYPE_CHECKING:
     from typing import Final
 
+#: The one gate here that asks who is running rather than what it can do. GraalPy's multiprocessing semaphores raise
+#: ``OSError: [Errno 0] Success`` from ``_wait_semaphore.acquire(False)`` when ``Event.set()`` notifies a contended
+#: condition, which fails whichever test happens to be coordinating processes at the time. The defect is in the
+#: interpreter's own ``multiprocessing/synchronize.py``, it only appears on Linux under load, and an uncontended probe
+#: cannot see it, so there is nothing to measure and no fix to make from here.
+SKIP_ON_UNRELIABLE_PROCESS_SYNC: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    sys.implementation.name == "graalpy",
+    reason="this runtime raises OSError from multiprocessing Event.set() under contention",
+)
+
 NEEDS_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["fork"], reason="installing fork handlers needs os.register_at_fork"
 )
@@ -104,5 +114,6 @@ __all__ = [
     "NEEDS_REGISTER_AT_FORK",
     "NEEDS_SYMLINK",
     "NEEDS_UNLINK_OPEN_FILE",
+    "SKIP_ON_UNRELIABLE_PROCESS_SYNC",
     "XFAIL_WITHOUT_COROUTINE_CANCELLATION",
 ]

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -32,6 +32,11 @@ if TYPE_CHECKING:
 
 _OWNER_READ_WRITE: Final[int] = 0o600
 
+# Bounds how long a spawned process or thread may take to reach the lock, not how fast it must be: an interpreter
+# that starts slowly under a loaded suite is not a locking failure. The short negative waits below are deliberate,
+# since those assert a contender stays blocked and have to stay brief.
+_PROCESS_DEADLINE: Final[int] = 30
+
 
 @pytest.fixture(autouse=True)
 def _clear_singletons() -> Generator[None]:
@@ -214,9 +219,9 @@ def test_blocking_acquire_without_timeout_waits_for_release(lock_file: str) -> N
     try:
         assert not acquired.wait(timeout=0.2)
         holder.release()
-        assert acquired.wait(timeout=5)
+        assert acquired.wait(timeout=_PROCESS_DEADLINE)
     finally:
-        thread.join(timeout=5)
+        thread.join(timeout=_PROCESS_DEADLINE)
         holder.close()
 
 
@@ -264,7 +269,7 @@ def test_acquire_on_closed_raises(lock_file: str) -> None:
         lock.acquire_write(timeout=1)
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 5)
 def test_multiple_readers_can_hold_simultaneously(lock_file: str) -> None:
     r1, r2, release = Event(), Event(), Event()
     p1 = Process(target=_worker, args=(lock_file, "read", r1, release))
@@ -272,14 +277,14 @@ def test_multiple_readers_can_hold_simultaneously(lock_file: str) -> None:
     with _cleanup([p1, p2]):
         p1.start()
         p2.start()
-        assert r1.wait(timeout=5)
-        assert r2.wait(timeout=5)
+        assert r1.wait(timeout=_PROCESS_DEADLINE)
+        assert r2.wait(timeout=_PROCESS_DEADLINE)
         release.set()
-        p1.join(timeout=5)
-        p2.join(timeout=5)
+        p1.join(timeout=_PROCESS_DEADLINE)
+        p2.join(timeout=_PROCESS_DEADLINE)
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 4)
 def test_write_lock_excludes_writers(lock_file: str) -> None:
     held, release = Event(), Event()
     second = Event()
@@ -287,15 +292,15 @@ def test_write_lock_excludes_writers(lock_file: str) -> None:
     contender = Process(target=_worker, args=(lock_file, "write", second, None, 0.3, True))
     with _cleanup([holder, contender]):
         holder.start()
-        assert held.wait(timeout=5)
+        assert held.wait(timeout=_PROCESS_DEADLINE)
         contender.start()
         assert not second.wait(timeout=0.5)
         release.set()
-        holder.join(timeout=5)
-        contender.join(timeout=5)
+        holder.join(timeout=_PROCESS_DEADLINE)
+        contender.join(timeout=_PROCESS_DEADLINE)
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 4)
 def test_write_lock_excludes_readers(lock_file: str) -> None:
     held, release = Event(), Event()
     reader_acquired = Event()
@@ -303,15 +308,15 @@ def test_write_lock_excludes_readers(lock_file: str) -> None:
     reader = Process(target=_worker, args=(lock_file, "read", reader_acquired, None, 0.3, True))
     with _cleanup([writer, reader]):
         writer.start()
-        assert held.wait(timeout=5)
+        assert held.wait(timeout=_PROCESS_DEADLINE)
         reader.start()
         assert not reader_acquired.wait(timeout=0.5)
         release.set()
-        writer.join(timeout=5)
-        reader.join(timeout=5)
+        writer.join(timeout=_PROCESS_DEADLINE)
+        reader.join(timeout=_PROCESS_DEADLINE)
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 5)
 def test_writer_drains_existing_readers(lock_file: str) -> None:
     r_held, r_release = Event(), Event()
     w_held = Event()
@@ -319,16 +324,16 @@ def test_writer_drains_existing_readers(lock_file: str) -> None:
     writer = Process(target=_worker, args=(lock_file, "write", w_held))
     with _cleanup([reader, writer]):
         reader.start()
-        assert r_held.wait(timeout=5)
+        assert r_held.wait(timeout=_PROCESS_DEADLINE)
         writer.start()
         assert not w_held.wait(timeout=0.5)
         r_release.set()
-        reader.join(timeout=5)
-        assert w_held.wait(timeout=5)
-        writer.join(timeout=5)
+        reader.join(timeout=_PROCESS_DEADLINE)
+        assert w_held.wait(timeout=_PROCESS_DEADLINE)
+        writer.join(timeout=_PROCESS_DEADLINE)
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 7)
 def test_writer_preference_blocks_new_readers(lock_file: str) -> None:
     r1_held, r1_release = Event(), Event()
     w_held, w_release = Event(), Event()
@@ -338,22 +343,22 @@ def test_writer_preference_blocks_new_readers(lock_file: str) -> None:
     reader2 = Process(target=_worker, args=(lock_file, "read", r2_held, None, 10, True))
     with _cleanup([reader1, writer, reader2]):
         reader1.start()
-        assert r1_held.wait(timeout=5)
+        assert r1_held.wait(timeout=_PROCESS_DEADLINE)
         writer.start()
         time.sleep(0.3)
         reader2.start()
         assert not r2_held.wait(timeout=0.5)
         r1_release.set()
-        assert w_held.wait(timeout=5)
+        assert w_held.wait(timeout=_PROCESS_DEADLINE)
         assert not r2_held.wait(timeout=0.3)
         w_release.set()
-        assert r2_held.wait(timeout=5)
-        reader1.join(timeout=5)
-        writer.join(timeout=5)
-        reader2.join(timeout=5)
+        assert r2_held.wait(timeout=_PROCESS_DEADLINE)
+        reader1.join(timeout=_PROCESS_DEADLINE)
+        writer.join(timeout=_PROCESS_DEADLINE)
+        reader2.join(timeout=_PROCESS_DEADLINE)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 4)
 def test_transaction_lock_timeout_across_threads(lock_file: str) -> None:
     # Two threads share one lock instance. Thread A holds the transaction lock while spinning on a peer
     # writer; thread B times out on the transaction lock, exercising the in-process Timeout path rather
@@ -382,18 +387,18 @@ def test_transaction_lock_timeout_across_threads(lock_file: str) -> None:
                 thread_ready.set()
                 with suppress(Timeout):
                     lock.acquire_write(timeout=2)
-                release_thread.wait(timeout=5)
+                release_thread.wait(timeout=_PROCESS_DEADLINE)
 
             thread_a = threading.Thread(target=target_a)
             thread_a.start()
             try:
-                thread_ready.wait(timeout=2)
+                thread_ready.wait(timeout=_PROCESS_DEADLINE)
                 time.sleep(0.05)
                 with pytest.raises(Timeout):
                     lock.acquire_write(timeout=0.1)
             finally:
                 release_thread.set()
-                thread_a.join(timeout=5)
+                thread_a.join(timeout=_PROCESS_DEADLINE)
         finally:
             lock.close()
     finally:
@@ -401,7 +406,7 @@ def test_transaction_lock_timeout_across_threads(lock_file: str) -> None:
         peer.close()
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_two_readers_in_same_process_share_slot(lock_file: str) -> None:
     # Many threads take a read lock on one instance; one hits the inner reentrant branch (lock level
     # above 0 after waiting on the transaction lock).
@@ -416,7 +421,7 @@ def test_two_readers_in_same_process_share_slot(lock_file: str) -> None:
         barrier = threading.Barrier(8)
 
         def target() -> None:
-            barrier.wait(timeout=2)
+            barrier.wait(timeout=_PROCESS_DEADLINE)
             with lock.read_lock(timeout=5):
                 time.sleep(0.05)
 
@@ -424,18 +429,18 @@ def test_two_readers_in_same_process_share_slot(lock_file: str) -> None:
         for thread in threads:
             thread.start()
         for thread in threads:
-            thread.join(timeout=5)
+            thread.join(timeout=_PROCESS_DEADLINE)
     finally:
         lock.close()
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_timeout_raises(lock_file: str) -> None:
     held, release = Event(), Event()
     holder = Process(target=_worker, args=(lock_file, "write", held, release))
     with _cleanup([holder]):
         holder.start()
-        assert held.wait(timeout=5)
+        assert held.wait(timeout=_PROCESS_DEADLINE)
         lock = _make_lock(lock_file)
         try:
             with pytest.raises(Timeout):
@@ -443,16 +448,16 @@ def test_timeout_raises(lock_file: str) -> None:
         finally:
             lock.close()
         release.set()
-        holder.join(timeout=5)
+        holder.join(timeout=_PROCESS_DEADLINE)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_non_blocking_writer_contended_raises(lock_file: str) -> None:
     held, release = Event(), Event()
     holder = Process(target=_worker, args=(lock_file, "write", held, release))
     with _cleanup([holder]):
         holder.start()
-        assert held.wait(timeout=5)
+        assert held.wait(timeout=_PROCESS_DEADLINE)
         lock = _make_lock(lock_file)
         try:
             with pytest.raises(Timeout):
@@ -462,7 +467,7 @@ def test_non_blocking_writer_contended_raises(lock_file: str) -> None:
         finally:
             lock.close()
         release.set()
-        holder.join(timeout=5)
+        holder.join(timeout=_PROCESS_DEADLINE)
 
 
 @pytest.mark.timeout(10)
@@ -485,17 +490,17 @@ def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
 
 
 @NEEDS_POSIX_SIGNALS
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs posix-signals
     held = Event()
     holder = Process(target=_sigkill_worker, args=(lock_file, "write", held, 0.1, 0.5))
     with _cleanup([holder]):
         holder.start()
-        assert held.wait(timeout=5)
+        assert held.wait(timeout=_PROCESS_DEADLINE)
         pid = holder.pid
         assert pid is not None
         os.kill(pid, getattr(signal, "SIGKILL"))  # ruff:ignore[get-attr-with-constant] - signal.SIGKILL is POSIX-only
-        holder.join(timeout=5)
+        holder.join(timeout=_PROCESS_DEADLINE)
         time.sleep(0.8)
         lock = _make_lock(lock_file)
         try:
@@ -507,17 +512,17 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs
 
 
 @NEEDS_POSIX_SIGNALS
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_dead_reader_evicted_by_writer(lock_file: str) -> None:  # pragma: needs posix-signals
     held = Event()
     holder = Process(target=_sigkill_worker, args=(lock_file, "read", held, 0.1, 0.5))
     with _cleanup([holder]):
         holder.start()
-        assert held.wait(timeout=5)
+        assert held.wait(timeout=_PROCESS_DEADLINE)
         pid = holder.pid
         assert pid is not None
         os.kill(pid, getattr(signal, "SIGKILL"))  # ruff:ignore[get-attr-with-constant] - signal.SIGKILL is POSIX-only
-        holder.join(timeout=5)
+        holder.join(timeout=_PROCESS_DEADLINE)
         time.sleep(0.8)
         lock = _make_lock(lock_file)
         try:
@@ -664,15 +669,15 @@ def test_heartbeat_stops_when_marker_evicted(lock_file: str, monkeypatch: pytest
         hold = lock._hold
         assert hold is not None
         monkeypatch.setattr(sync_mod, "_open_marker_fd", gone)
-        assert hold.heartbeat_stop.wait(timeout=2)
-        hold.heartbeat_thread.join(timeout=2)
+        assert hold.heartbeat_stop.wait(timeout=_PROCESS_DEADLINE)
+        hold.heartbeat_thread.join(timeout=_PROCESS_DEADLINE)
         assert not hold.heartbeat_thread.is_alive()
     finally:
         lock.release(force=True)
         lock.close()
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_live_heartbeat_keeps_lock_alive_past_stale_threshold(lock_file: str) -> None:
     # Generous timing here so the test stays stable on slow Windows runners where the holder's
     # multiprocessing.spawn startup, the heartbeat thread scheduling, and the parent's mtime resolution
@@ -685,7 +690,7 @@ def test_live_heartbeat_keeps_lock_alive_past_stale_threshold(lock_file: str) ->
     )
     with _cleanup([holder]):
         holder.start()
-        assert held.wait(timeout=5)
+        assert held.wait(timeout=_PROCESS_DEADLINE)
         time.sleep(stale * 2)
         lock = _make_lock(lock_file, heartbeat_interval=heartbeat, stale_threshold=stale)
         try:
@@ -694,7 +699,7 @@ def test_live_heartbeat_keeps_lock_alive_past_stale_threshold(lock_file: str) ->
         finally:
             lock.close()
         release.set()
-        holder.join(timeout=5)
+        holder.join(timeout=_PROCESS_DEADLINE)
 
 
 @pytest.mark.parametrize(
@@ -899,31 +904,31 @@ def test_reader_file_is_created_with_0600(lock_file: str) -> None:  # pragma: ne
 
 
 @NEEDS_FORK
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 2)
 def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(target=_reuse_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
     proc.start()
-    proc.join(timeout=10)
+    proc.join(timeout=_PROCESS_DEADLINE)
     assert not failure.is_set()
     assert result.is_set()
 
 
 @NEEDS_FORK
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 2)
 def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(target=_release_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
     proc.start()
-    proc.join(timeout=10)
+    proc.join(timeout=_PROCESS_DEADLINE)
     assert not failure.is_set()
     assert result.is_set()
 
 
 @NEEDS_FORK
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 2)
 def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
@@ -932,13 +937,13 @@ def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None: 
         args=(str(tmp_path / "parent.lock"), str(tmp_path / "child.lock"), result, failure),
     )
     proc.start()
-    proc.join(timeout=10)
+    proc.join(timeout=_PROCESS_DEADLINE)
     assert not failure.is_set()
     assert result.is_set()
 
 
 @NEEDS_FORK
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 2)
 # Holding the write lock keeps the heartbeat thread alive, so this fork is necessarily from a multi-threaded
 # process and Python 3.15 warns that it may deadlock. That is the scenario under test, and it is already safe:
 # register_at_fork resets inherited state in the child (any child use raises "invalidated by fork()"). Expected.
@@ -950,7 +955,7 @@ def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:  # pragma: nee
     try:
         child = _fork_process(target=time.sleep, args=(0.05,))
         child.start()
-        child.join(timeout=5)
+        child.join(timeout=_PROCESS_DEADLINE)
         assert Path(f"{path}.write").exists()
         peer = SoftReadWriteLock(
             path,
@@ -1011,7 +1016,7 @@ def _worker(
         with lock.read_lock() if mode == "read" else lock.write_lock():
             acquired_event.set()
             if release_event is not None:
-                release_event.wait(timeout=10)
+                release_event.wait(timeout=_PROCESS_DEADLINE)
             else:
                 time.sleep(0.2)
     finally:
@@ -1026,11 +1031,11 @@ def _cleanup(processes: list[Process]) -> Generator[None]:
         for proc in processes:
             if proc.is_alive():
                 proc.terminate()
-                proc.join(timeout=5)
+                proc.join(timeout=_PROCESS_DEADLINE)
             # A worker that outlives its test wedges the next one, and SIGTERM can be slow on a loaded runner.
             if proc.is_alive():  # pragma: no cover  # the terminate lands first whenever the runner is not saturated
                 proc.kill()
-                proc.join(timeout=5)
+                proc.join(timeout=_PROCESS_DEADLINE)
 
 
 def _sigkill_worker(  # pragma: forked child
@@ -1075,7 +1080,7 @@ def _reuse_inherited_lock(lock_file: str, result: EventType, failure: EventType)
 
     child = _fork_process(target=child_entry)
     child.start()
-    child.join(timeout=5)
+    child.join(timeout=_PROCESS_DEADLINE)
     if ok.is_set():
         result.set()
     else:  # pragma: no cover  # reached only if the child fails to report the inherited lock, i.e. a regression
@@ -1098,7 +1103,7 @@ def _release_inherited_lock(lock_file: str, result: EventType, failure: EventTyp
 
     child = _fork_process(target=child_entry)
     child.start()
-    child.join(timeout=5)
+    child.join(timeout=_PROCESS_DEADLINE)
     if ok.is_set():
         result.set()
     else:  # pragma: no cover  # reached only if the child's silent release regresses into raising
@@ -1130,7 +1135,7 @@ def _reacquire_fresh_lock_in_child(  # pragma: needs fork
 
     child = _fork_process(target=child_entry)
     child.start()
-    child.join(timeout=5)
+    child.join(timeout=_PROCESS_DEADLINE)
     if ok.is_set():
         result.set()
     else:  # pragma: no cover  # reached only if the child cannot acquire a fresh lock after the fork, i.e. a regression

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -731,8 +731,8 @@ def test_stale_malformed_marker_is_evicted(lock_file: str, content: bytes) -> No
 
 
 def test_fifo_write_marker_does_not_block(lock_file: str) -> None:  # pragma: needs fifo
-    if sys.platform == "win32":  # pragma: win32 cover
-        pytest.skip("os.mkfifo is unix-only")  # also narrows sys.platform so ty resolves os.mkfifo below
+    if sys.platform == "win32" or not CAPABILITIES["fifo"]:  # pragma: win32 cover
+        pytest.skip("os.mkfifo is unavailable")  # the platform arm also narrows so ty resolves os.mkfifo below
     marker = f"{lock_file}.write"
     os.mkfifo(marker)
     past = time.time() - 1000
@@ -747,8 +747,8 @@ def test_fifo_write_marker_does_not_block(lock_file: str) -> None:  # pragma: ne
 
 
 def test_fifo_write_marker_with_writer_is_evicted(lock_file: str) -> None:  # pragma: needs fifo
-    if sys.platform == "win32":  # pragma: win32 cover
-        pytest.skip("os.mkfifo is unix-only")  # also narrows sys.platform so ty resolves os.mkfifo below
+    if sys.platform == "win32" or not CAPABILITIES["fifo"]:  # pragma: win32 cover
+        pytest.skip("os.mkfifo is unavailable")  # the platform arm also narrows so ty resolves os.mkfifo below
     marker = f"{lock_file}.write"
     os.mkfifo(marker)
     past = time.time() - 1000
@@ -797,7 +797,7 @@ def test_touch_does_not_follow_symlink(lock_file: str, tmp_path: Path) -> None: 
 
     util_mod.touch(str(marker))
 
-    assert victim.stat().st_mtime == past
+    assert victim.stat().st_mtime == pytest.approx(past)  # a timestamp round-trip need not be bit-exact
     assert victim.read_text() == "do-not-touch"
 
 
@@ -827,7 +827,7 @@ def test_refresh_touches_verified_fd_not_swapped_path(  # pragma: needs utime-fd
 
         monkeypatch.setattr(sync_mod, "_open_marker", swap_after_open)
         assert lock._refresh_marker() is True
-        assert victim.stat().st_mtime == past
+        assert victim.stat().st_mtime == pytest.approx(past)  # a timestamp round-trip need not be bit-exact
         assert victim.read_text() == "do-not-touch"
     finally:
         lock.release(force=True)

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -21,7 +21,7 @@ from filelock import Timeout
 from filelock import _util as util_mod
 from filelock._soft_rw import SoftReadWriteLock
 from filelock._soft_rw import _sync as sync_mod
-from tests.capability_marks import NEEDS_FILE_MODE, NEEDS_FORK, NEEDS_POSIX_SIGNALS
+from tests.capability_marks import NEEDS_FILE_MODE, NEEDS_FORK, NEEDS_POSIX_SIGNALS, SKIP_ON_UNRELIABLE_PROCESS_SYNC
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -272,6 +272,7 @@ def test_acquire_on_closed_raises(lock_file: str) -> None:
         lock.acquire_write(timeout=1)
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 5)
 def test_multiple_readers_can_hold_simultaneously(lock_file: str) -> None:
     r1, r2, release = Event(), Event(), Event()
@@ -287,6 +288,7 @@ def test_multiple_readers_can_hold_simultaneously(lock_file: str) -> None:
         p2.join(timeout=_PROCESS_DEADLINE)
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 4)
 def test_write_lock_excludes_writers(lock_file: str) -> None:
     held, release = Event(), Event()
@@ -303,6 +305,7 @@ def test_write_lock_excludes_writers(lock_file: str) -> None:
         contender.join(timeout=_PROCESS_DEADLINE)
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 4)
 def test_write_lock_excludes_readers(lock_file: str) -> None:
     held, release = Event(), Event()
@@ -319,6 +322,7 @@ def test_write_lock_excludes_readers(lock_file: str) -> None:
         reader.join(timeout=_PROCESS_DEADLINE)
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 5)
 def test_writer_drains_existing_readers(lock_file: str) -> None:
     r_held, r_release = Event(), Event()
@@ -336,6 +340,7 @@ def test_writer_drains_existing_readers(lock_file: str) -> None:
         writer.join(timeout=_PROCESS_DEADLINE)
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 7)
 def test_writer_preference_blocks_new_readers(lock_file: str) -> None:
     r1_held, r1_release = Event(), Event()
@@ -437,6 +442,7 @@ def test_two_readers_in_same_process_share_slot(lock_file: str) -> None:
         lock.close()
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_timeout_raises(lock_file: str) -> None:
     held, release = Event(), Event()
@@ -454,6 +460,7 @@ def test_timeout_raises(lock_file: str) -> None:
         holder.join(timeout=_PROCESS_DEADLINE)
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_non_blocking_writer_contended_raises(lock_file: str) -> None:
     held, release = Event(), Event()
@@ -492,6 +499,7 @@ def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
         reader.close()
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @NEEDS_POSIX_SIGNALS
 @pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs posix-signals
@@ -514,6 +522,7 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs
         assert not Path(f"{lock_file}.write").exists()
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @NEEDS_POSIX_SIGNALS
 @pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_dead_reader_evicted_by_writer(lock_file: str) -> None:  # pragma: needs posix-signals
@@ -680,6 +689,7 @@ def test_heartbeat_stops_when_marker_evicted(lock_file: str, monkeypatch: pytest
         lock.close()
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_live_heartbeat_keeps_lock_alive_past_stale_threshold(lock_file: str) -> None:
     # Generous timing here so the test stays stable on slow Windows runners where the holder's
@@ -906,6 +916,7 @@ def test_reader_file_is_created_with_0600(lock_file: str) -> None:  # pragma: ne
         lock.close()
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @NEEDS_FORK
 @pytest.mark.timeout(_PROCESS_DEADLINE * 2)
 def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pragma: needs fork
@@ -918,6 +929,7 @@ def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pr
     assert result.is_set()
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @NEEDS_FORK
 @pytest.mark.timeout(_PROCESS_DEADLINE * 2)
 def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # pragma: needs fork
@@ -930,6 +942,7 @@ def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # p
     assert result.is_set()
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @NEEDS_FORK
 @pytest.mark.timeout(_PROCESS_DEADLINE * 2)
 def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:  # pragma: needs fork
@@ -950,6 +963,7 @@ def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None: 
 # Holding the write lock keeps the heartbeat thread alive, so this fork is necessarily from a multi-threaded
 # process and Python 3.15 warns that it may deadlock. That is the scenario under test, and it is already safe:
 # register_at_fork resets inherited state in the child (any child use raises "invalidated by fork()"). Expected.
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.filterwarnings("ignore:.*multi-threaded, use of fork.*:DeprecationWarning")
 def test_parent_retains_lock_across_fork(tmp_path: Path) -> None:  # pragma: needs fork
     path = str(tmp_path / "foo.lock")
@@ -1163,6 +1177,7 @@ def _fork_event() -> EventType:  # pragma: needs fork
     return mp.get_context("fork").Event()
 
 
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
 def test_cleanup_terminates_a_still_running_process() -> None:
     proc = Process(target=time.sleep, args=(30,))
     proc.start()

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -36,6 +36,9 @@ _OWNER_READ_WRITE: Final[int] = 0o600
 # that starts slowly under a loaded suite is not a locking failure. The short negative waits below are deliberate,
 # since those assert a contender stays blocked and have to stay brief.
 _PROCESS_DEADLINE: Final[int] = 30
+# Reaping a process that has already been signaled is not a startup wait, and it has to stay under the suite's own
+# per-test timeout so the guard still reports the hang it was put there for.
+_REAP_DEADLINE: Final[int] = 5
 
 
 @pytest.fixture(autouse=True)
@@ -1031,11 +1034,11 @@ def _cleanup(processes: list[Process]) -> Generator[None]:
         for proc in processes:
             if proc.is_alive():
                 proc.terminate()
-                proc.join(timeout=_PROCESS_DEADLINE)
+                proc.join(timeout=_REAP_DEADLINE)
             # A worker that outlives its test wedges the next one, and SIGTERM can be slow on a loaded runner.
             if proc.is_alive():  # pragma: no cover  # the terminate lands first whenever the runner is not saturated
                 proc.kill()
-                proc.join(timeout=_PROCESS_DEADLINE)
+                proc.join(timeout=_REAP_DEADLINE)
 
 
 def _sigkill_worker(  # pragma: forked child

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -15,13 +15,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
-from capability_marks import NEEDS_FILE_MODE, NEEDS_FORK, NEEDS_POSIX_SIGNALS
 from coverage_pragmas import CAPABILITIES
 
 from filelock import Timeout
 from filelock import _util as util_mod
 from filelock._soft_rw import SoftReadWriteLock
 from filelock._soft_rw import _sync as sync_mod
+from tests.capability_marks import NEEDS_FILE_MODE, NEEDS_FORK, NEEDS_POSIX_SIGNALS
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
+from capability_marks import NEEDS_FILE_MODE, NEEDS_FORK, NEEDS_POSIX_SIGNALS
 from coverage_pragmas import CAPABILITIES
 
 from filelock import Timeout
@@ -30,14 +31,6 @@ if TYPE_CHECKING:
 
 
 _OWNER_READ_WRITE: Final[int] = 0o600
-
-_REQUIRES_POSIX_SIGNALS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not hasattr(signal, "SIGKILL"), reason="POSIX signals required"
-)
-_REQUIRES_FILE_MODE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["file-mode"], reason="POSIX file-mode bits required"
-)
-_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
 
 
 @pytest.fixture(autouse=True)
@@ -491,7 +484,7 @@ def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
         reader.close()
 
 
-@_REQUIRES_POSIX_SIGNALS
+@NEEDS_POSIX_SIGNALS
 @pytest.mark.timeout(20)
 def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs posix-signals
     held = Event()
@@ -513,7 +506,7 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs
         assert not Path(f"{lock_file}.write").exists()
 
 
-@_REQUIRES_POSIX_SIGNALS
+@NEEDS_POSIX_SIGNALS
 @pytest.mark.timeout(20)
 def test_dead_reader_evicted_by_writer(lock_file: str) -> None:  # pragma: needs posix-signals
     held = Event()
@@ -858,7 +851,7 @@ def test_readers_path_as_regular_file_is_refused(lock_file: str) -> None:
         lock.close()
 
 
-@_REQUIRES_FILE_MODE
+@NEEDS_FILE_MODE
 def test_write_marker_is_created_with_0600(lock_file: str) -> None:  # pragma: needs file-mode
     lock = _make_lock(lock_file)
     try:
@@ -868,7 +861,7 @@ def test_write_marker_is_created_with_0600(lock_file: str) -> None:  # pragma: n
         lock.close()
 
 
-@_REQUIRES_FILE_MODE
+@NEEDS_FILE_MODE
 def test_readers_directory_is_created_with_0700(lock_file: str) -> None:  # pragma: needs file-mode
     lock = _make_lock(lock_file)
     try:
@@ -893,7 +886,7 @@ def test_writer_ignores_housekeeping_files_in_readers_dir(lock_file: str) -> Non
         lock.close()
 
 
-@_REQUIRES_FILE_MODE
+@NEEDS_FILE_MODE
 def test_reader_file_is_created_with_0600(lock_file: str) -> None:  # pragma: needs file-mode
     lock = _make_lock(lock_file)
     try:
@@ -905,7 +898,7 @@ def test_reader_file_is_created_with_0600(lock_file: str) -> None:  # pragma: ne
         lock.close()
 
 
-@_REQUIRES_FORK
+@NEEDS_FORK
 @pytest.mark.timeout(15)
 def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
@@ -917,7 +910,7 @@ def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pr
     assert result.is_set()
 
 
-@_REQUIRES_FORK
+@NEEDS_FORK
 @pytest.mark.timeout(15)
 def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
@@ -929,7 +922,7 @@ def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # p
     assert result.is_set()
 
 
-@_REQUIRES_FORK
+@NEEDS_FORK
 @pytest.mark.timeout(15)
 def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None:  # pragma: needs fork
     ctx = mp.get_context("spawn")
@@ -944,7 +937,7 @@ def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None: 
     assert result.is_set()
 
 
-@_REQUIRES_FORK
+@NEEDS_FORK
 @pytest.mark.timeout(15)
 # Holding the write lock keeps the heartbeat thread alive, so this fork is necessarily from a multi-threaded
 # process and Python 3.15 warns that it may deadlock. That is the scenario under test, and it is already safe:

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -1120,9 +1120,13 @@ async def test_on_acquired_rollback_group_detaches_release_context(
 def test_async_del_without_any_loop_returns(tmp_path: Path, mocker: MockerFixture) -> None:
     # GC can finalize a lock with no loop running and none remembered, where releasing is impossible. Raise the lookup
     # rather than rely on no loop running here, which the surrounding tests decide.
+    get_running_loop = mocker.patch("filelock.asyncio.asyncio.get_running_loop", side_effect=RuntimeError)
     lock = AsyncSoftFileLock(str(tmp_path / "a"))
-    mocker.patch("filelock.asyncio.asyncio.get_running_loop", side_effect=RuntimeError)
+    release = mocker.patch.object(lock, "release", autospec=True)
+    # Any lock another test dropped reaches the same patched lookup, so only calls from here on count.
+    get_running_loop.reset_mock()
 
     lock.__del__()  # ruff:ignore[unnecessary-dunder-call]  # a finalizer test cannot ride on collection timing
 
-    assert not lock.is_locked
+    # An unlocked finalizer asserts nothing on its own; the lookup and the absent release pin the path it took.
+    assert (get_running_loop.called, release.called, lock.is_locked) == (True, False, False)

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -10,12 +10,11 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from errno import EINTR, EIO, ENOSYS
-from importlib.util import find_spec
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Final, Literal
+from typing import TYPE_CHECKING, Literal
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capability_marks import NEEDS_FCNTL, NEEDS_PARENT_SYMLINK_COLLAPSE
 
 from filelock import (
     AsyncFileLock,
@@ -36,18 +35,8 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    find_spec("fcntl") is None, reason="native flock semantics come from the fcntl module"
-)
-_NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["symlink"], reason="creating a symlink needs a privilege this runtime does not grant"
-)
 
 # Windows resolves a lock's parent with abspath, so a symlinked parent stays a distinct key and never collapses.
-_NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["symlink"] or sys.platform == "win32",
-    reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",
-)
 
 
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
@@ -551,7 +540,7 @@ async def test_release_from_different_task_clears_registry(tmp_path: Path, lock_
         pass
 
 
-@_NEEDS_PARENT_SYMLINK_COLLAPSE
+@NEEDS_PARENT_SYMLINK_COLLAPSE
 @pytest.mark.parametrize("lock_type", [AsyncFileLock, AsyncSoftFileLock])
 @pytest.mark.asyncio  # pragma: win32 no cover
 async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseAsyncFileLock]) -> None:
@@ -567,7 +556,7 @@ async def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseA
             await lock2.acquire()
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.parametrize(
     ("depth", "force"),
     [
@@ -594,7 +583,7 @@ async def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Pat
         assert successor.is_locked
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio
 async def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
@@ -658,7 +647,7 @@ async def _acquire_for_mode(lock: BaseAsyncFileLock, mode: Literal["finite", "no
         await lock.acquire(blocking=False)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio  # pragma: needs fcntl
 async def test_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))
@@ -1002,7 +991,7 @@ def _fail_close_of(mocker: MockerFixture, lock: BaseAsyncFileLock, error: OSErro
     mocker.patch("filelock._api.os.close", side_effect=close)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio
 async def test_close_error_raise_propagates(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: needs fcntl
     lock = AsyncFileLock(str(tmp_path / "a"), close_error_policy="raise")
@@ -1013,7 +1002,7 @@ async def test_close_error_raise_propagates(tmp_path: Path, mocker: MockerFixtur
     assert not lock.is_locked
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio  # pragma: needs fcntl
 async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))  # default policy
@@ -1023,7 +1012,7 @@ async def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: Mo
     assert not lock.is_locked
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio  # pragma: needs fcntl
 async def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
@@ -1039,7 +1028,7 @@ def test_preserve_lock_file_async_soft_rejects(tmp_path: Path) -> None:
         AsyncSoftFileLock(str(tmp_path / "a"), preserve_lock_file=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio
 async def test_preserve_lock_file_async_release_keeps_pathname(tmp_path: Path) -> None:  # pragma: needs fcntl
     path = tmp_path / "a"
@@ -1060,7 +1049,7 @@ def test_on_acquired_async_soft_rejects(tmp_path: Path) -> None:
         AsyncSoftFileLock(str(tmp_path / "a"), on_acquired=lambda _fd: None)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio
 async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_thread = -1
@@ -1081,7 +1070,7 @@ async def test_on_acquired_runs_in_backend_executor(tmp_path: Path) -> None:  # 
         await lock.release()
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio
 async def test_on_acquired_async_failure_releases(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock = AsyncFileLock(str(tmp_path / "a"), thread_local=False, on_acquired=_failing_on_acquired)

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -14,7 +14,6 @@ from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Literal
 
 import pytest
-from capability_marks import NEEDS_FCNTL, NEEDS_PARENT_SYMLINK_COLLAPSE
 
 from filelock import (
     AsyncFileLock,
@@ -24,6 +23,7 @@ from filelock import (
     ContextErrorPolicy,
     Timeout,
 )
+from tests.capability_marks import NEEDS_FCNTL, NEEDS_PARENT_SYMLINK_COLLAPSE
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_async_filelock_acquire_cancellation.py
+++ b/tests/test_async_filelock_acquire_cancellation.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Final
 
 import pytest
 from async_filelock_cancellation_helpers import assert_cancellation_message, assert_file_lock_state
+from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import (
     AsyncFileLock,
@@ -56,6 +57,7 @@ async def test_backend_cancellation_after_acquire_rolls_back(tmp_path: Path) -> 
 
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_backend_cancellation_rollback_failure_follows_policy(tmp_path: Path, policy: ContextErrorPolicy) -> None:
     backend_cancellation = asyncio.CancelledError("backend canceled")
     rollback_error = OSError(EIO, "rollback failed")
@@ -185,6 +187,7 @@ async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path)
 
 @_NEEDS_FCNTL
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_started = asyncio.Event()
     finish_hook = threading.Event()
@@ -251,6 +254,7 @@ async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, 
 @_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pragma: needs fcntl
     tmp_path: Path, policy: ContextErrorPolicy
 ) -> None:
@@ -299,6 +303,7 @@ async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pr
     [pytest.param("unrelated", True, id="distinct"), pytest.param("attempt", False, id="equivalent")],
 )
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma: needs fcntl
     tmp_path: Path, context_message: str, *, preserved: bool
 ) -> None:
@@ -347,6 +352,7 @@ async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma:
 @_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: needs fcntl
     tmp_path: Path,
     mocker: MockerFixture,
@@ -395,6 +401,7 @@ async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: needs fc
 @_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_cancellation_surfaces_attempt_and_rollback_errors(  # pragma: needs fcntl
     tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
 ) -> None:

--- a/tests/test_async_filelock_acquire_cancellation.py
+++ b/tests/test_async_filelock_acquire_cancellation.py
@@ -6,12 +6,11 @@ import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from errno import EIO
-from importlib.util import find_spec
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 import pytest
 from async_filelock_cancellation_helpers import assert_cancellation_message, assert_file_lock_state
-from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
+from capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import (
     AsyncFileLock,
@@ -28,10 +27,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pytest_mock import MockerFixture
-
-_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    find_spec("fcntl") is None, reason="native flock semantics come from the fcntl module"
-)
 
 
 @pytest.mark.asyncio
@@ -157,7 +152,7 @@ async def test_acquire_cancellation_before_executor_start_rolls_back(tmp_path: P
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio
 async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_started = asyncio.Event()
@@ -185,7 +180,7 @@ async def test_acquire_cancellation_does_not_release_later_claim(tmp_path: Path)
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio
 @XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path) -> None:  # pragma: needs fcntl
@@ -217,7 +212,7 @@ async def test_cancelled_queued_acquire_does_not_claim_transition(tmp_path: Path
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio  # pragma: needs fcntl
 async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, mocker: MockerFixture) -> None:
     hook_started = asyncio.Event()
@@ -251,7 +246,7 @@ async def test_acquire_repeated_cancellation_waits_for_rollback(tmp_path: Path, 
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
 @XFAIL_WITHOUT_COROUTINE_CANCELLATION
@@ -297,7 +292,7 @@ async def test_acquire_cancellation_surfaces_attempt_error_after_rollback(  # pr
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.parametrize(
     ("context_message", "preserved"),
     [pytest.param("unrelated", True, id="distinct"), pytest.param("attempt", False, id="equivalent")],
@@ -349,7 +344,7 @@ async def test_acquire_cancellation_group_reconciles_attempt_context(  # pragma:
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
 @XFAIL_WITHOUT_COROUTINE_CANCELLATION
@@ -398,7 +393,7 @@ async def test_acquire_cancellation_surfaces_rollback_error(  # pragma: needs fc
     await lock.release()
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
 @XFAIL_WITHOUT_COROUTINE_CANCELLATION

--- a/tests/test_async_filelock_acquire_cancellation.py
+++ b/tests/test_async_filelock_acquire_cancellation.py
@@ -9,14 +9,14 @@ from errno import EIO
 from typing import TYPE_CHECKING
 
 import pytest
-from async_filelock_cancellation_helpers import assert_cancellation_message, assert_file_lock_state
-from capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import (
     AsyncFileLock,
     BaseAsyncFileLock,
     ContextErrorPolicy,
 )
+from tests.async_filelock_cancellation_helpers import assert_cancellation_message, assert_file_lock_state
+from tests.capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_async_filelock_release_cancellation.py
+++ b/tests/test_async_filelock_release_cancellation.py
@@ -15,6 +15,7 @@ from async_filelock_cancellation_helpers import (
     get_fcntl,
     start_file_lock_holder,
 )
+from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import AsyncFileLock, BaseAsyncFileLock, ContextErrorPolicy
 
@@ -59,6 +60,7 @@ async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: Mo
 
 @_NEEDS_FCNTL
 @pytest.mark.asyncio  # pragma: needs fcntl
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(tmp_path / "a")
     await lock.acquire()
@@ -158,6 +160,7 @@ async def test_release_returns_while_acquire_waits_for_external_holder(tmp_path:
 @_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_release_cancellation_surfaces_backend_error(  # pragma: needs fcntl
     tmp_path: Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture, policy: ContextErrorPolicy
 ) -> None:

--- a/tests/test_async_filelock_release_cancellation.py
+++ b/tests/test_async_filelock_release_cancellation.py
@@ -8,15 +8,15 @@ from errno import EIO
 from typing import TYPE_CHECKING
 
 import pytest
-from async_filelock_cancellation_helpers import (
+
+from filelock import AsyncFileLock, BaseAsyncFileLock, ContextErrorPolicy
+from tests.async_filelock_cancellation_helpers import (
     assert_cancellation_message,
     assert_file_lock_state,
     get_fcntl,
     start_file_lock_holder,
 )
-from capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
-
-from filelock import AsyncFileLock, BaseAsyncFileLock, ContextErrorPolicy
+from tests.capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_async_filelock_release_cancellation.py
+++ b/tests/test_async_filelock_release_cancellation.py
@@ -5,8 +5,7 @@ import logging
 import sys
 import threading
 from errno import EIO
-from importlib.util import find_spec
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 import pytest
 from async_filelock_cancellation_helpers import (
@@ -15,7 +14,7 @@ from async_filelock_cancellation_helpers import (
     get_fcntl,
     start_file_lock_holder,
 )
-from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
+from capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import AsyncFileLock, BaseAsyncFileLock, ContextErrorPolicy
 
@@ -29,12 +28,8 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    find_spec("fcntl") is None, reason="native flock semantics come from the fcntl module"
-)
 
-
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio  # pragma: needs fcntl
 async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = AsyncFileLock(str(tmp_path / "a"))
@@ -58,7 +53,7 @@ async def test_release_completes_despite_cancellation(tmp_path: Path, mocker: Mo
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio  # pragma: needs fcntl
 @XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path, mocker: MockerFixture) -> None:
@@ -100,7 +95,7 @@ async def test_acquire_proceeds_after_queued_release_is_canceled(tmp_path: Path,
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.asyncio
 async def test_release_waits_for_provisional_acquire(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_started = asyncio.Event()
@@ -157,7 +152,7 @@ async def test_release_returns_while_acquire_waits_for_external_holder(tmp_path:
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @pytest.mark.asyncio
 @XFAIL_WITHOUT_COROUTINE_CANCELLATION

--- a/tests/test_async_filelock_rollback_agnostic.py
+++ b/tests/test_async_filelock_rollback_agnostic.py
@@ -6,6 +6,7 @@ from errno import EIO
 from typing import TYPE_CHECKING
 
 import pytest
+from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import AsyncFileLock, BaseAsyncFileLock
 
@@ -50,6 +51,7 @@ async def test_release_serialized_skips_when_peer_already_released(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_release_cancellation_surfaces_backend_error(tmp_path: Path) -> None:
     backend_error = OSError(EIO, "backend release failed")
     release_started = asyncio.Event()
@@ -86,6 +88,7 @@ async def test_release_cancellation_surfaces_backend_error(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_cancellation_rollback_failure_surfaces_backend_error(tmp_path: Path) -> None:
     rollback_error = OSError(EIO, "rollback release failed")
     acquire_started = asyncio.Event()

--- a/tests/test_async_filelock_rollback_agnostic.py
+++ b/tests/test_async_filelock_rollback_agnostic.py
@@ -6,9 +6,9 @@ from errno import EIO
 from typing import TYPE_CHECKING
 
 import pytest
-from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import AsyncFileLock, BaseAsyncFileLock
+from tests.capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_async_filelock_runner_shutdown.py
+++ b/tests/test_async_filelock_runner_shutdown.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Final, TypeVar
 
 import pytest
 from async_filelock_cancellation_helpers import assert_file_lock_state, get_fcntl
+from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import AsyncAcquireReturnProxy, AsyncFileLock, ContextErrorPolicy
 
@@ -78,6 +79,7 @@ def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> 
 
 @_NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # pragma: needs fcntl
     tmp_path: Path, mocker: MockerFixture, policy: ContextErrorPolicy
 ) -> None:

--- a/tests/test_async_filelock_runner_shutdown.py
+++ b/tests/test_async_filelock_runner_shutdown.py
@@ -4,13 +4,12 @@ import asyncio
 import sys
 import threading
 from errno import EIO
-from importlib.util import find_spec
 from queue import Queue
-from typing import TYPE_CHECKING, Final, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import pytest
 from async_filelock_cancellation_helpers import assert_file_lock_state, get_fcntl
-from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
+from capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import AsyncAcquireReturnProxy, AsyncFileLock, ContextErrorPolicy
 
@@ -25,9 +24,6 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    find_spec("fcntl") is None, reason="native flock semantics come from the fcntl module"
-)
 _T = TypeVar("_T")
 
 
@@ -48,7 +44,7 @@ class _CancellationObservedTask(asyncio.Task[_T]):  # pragma: needs fcntl
         return super().cancel(msg)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> None:  # pragma: needs fcntl
     hook_started = threading.Event()
     finish_hook = threading.Event()
@@ -77,7 +73,7 @@ def test_runner_shutdown_waits_for_executor_acquire_rollback(tmp_path: Path) -> 
     assert_file_lock_state(str(tmp_path / "a"), available=True)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.parametrize("policy", [pytest.param("chain", id="chain"), pytest.param("group", id="group")])
 @XFAIL_WITHOUT_COROUTINE_CANCELLATION
 def test_runner_shutdown_preserves_body_cancellation_and_release_errors(  # pragma: needs fcntl

--- a/tests/test_async_filelock_runner_shutdown.py
+++ b/tests/test_async_filelock_runner_shutdown.py
@@ -8,10 +8,10 @@ from queue import Queue
 from typing import TYPE_CHECKING, TypeVar
 
 import pytest
-from async_filelock_cancellation_helpers import assert_file_lock_state, get_fcntl
-from capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import AsyncAcquireReturnProxy, AsyncFileLock, ContextErrorPolicy
+from tests.async_filelock_cancellation_helpers import assert_file_lock_state, get_fcntl
+from tests.capability_marks import NEEDS_FCNTL, XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import BaseExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_async_filelock_transition_admission.py
+++ b/tests/test_async_filelock_transition_admission.py
@@ -6,14 +6,14 @@ import threading
 from typing import TYPE_CHECKING, Final
 
 import pytest
-from async_filelock_cancellation_helpers import (
+
+from filelock import AsyncFileLock, Timeout
+from tests.async_filelock_cancellation_helpers import (
     assert_cancellation_message,
     assert_file_lock_state,
     start_file_lock_holder,
 )
-from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
-
-from filelock import AsyncFileLock, Timeout
+from tests.capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/test_async_filelock_transition_admission.py
+++ b/tests/test_async_filelock_transition_admission.py
@@ -11,6 +11,7 @@ from async_filelock_cancellation_helpers import (
     assert_file_lock_state,
     start_file_lock_holder,
 )
+from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock import AsyncFileLock, Timeout
 
@@ -32,6 +33,7 @@ _UNIX_FLOCK_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     ],
 )
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_queued_acquire_honors_own_admission_policy(
     tmp_path: Path, admission: Literal["nonblocking", "deadline", "cancel-check"]
 ) -> None:
@@ -80,6 +82,7 @@ async def test_queued_acquire_honors_own_admission_policy(
 
 @_UNIX_FLOCK_ONLY
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_queued_acquire_proceeds_after_prior_waiter_cancels(tmp_path: Path) -> None:  # pragma: win32 no cover
     hook_started = asyncio.Event()
     finish_hook = threading.Event()

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Literal
 
 import pytest
+from capability_marks import NEEDS_COLLECTED_FINALIZATION
 
 pytest.importorskip("sqlite3")
 
@@ -201,6 +202,7 @@ async def test_close_keeps_provided_executor_open(lock_file: str) -> None:
     executor.shutdown(wait=False)
 
 
+@NEEDS_COLLECTED_FINALIZATION
 def test_del_shuts_down_owned_executor(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     executor = lock.executor

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -5,7 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Literal
 
 import pytest
-from capability_marks import NEEDS_COLLECTED_FINALIZATION
+
+from tests.capability_marks import NEEDS_COLLECTED_FINALIZATION
 
 pytest.importorskip("sqlite3")
 

--- a/tests/test_async_read_write_cancellation.py
+++ b/tests/test_async_read_write_cancellation.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 import pytest
 from async_filelock_cancellation_helpers import assert_cancellation_message
+from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 from read_write_helpers import assert_read_write_lock_state
 
 from filelock import AsyncReadWriteLock, ReadWriteLock
@@ -68,6 +69,7 @@ async def test_acquire_cancellation_before_executor_start_rolls_back(
     "cancel_caller",
     [pytest.param(False, id="executor"), pytest.param(True, id="caller-and-executor")],
 )
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 def test_executor_cancels_queued_acquire_without_compensation(lock_file: str, *, cancel_caller: bool) -> None:
     context = multiprocessing.get_context("spawn")
     canceled = context.Value("b", False)
@@ -82,6 +84,7 @@ def test_executor_cancels_queued_acquire_without_compensation(lock_file: str, *,
 
 
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_caller_cancellation_preserves_cancelled_executor_acquire(lock_file: str) -> None:
     executor_started = threading.Event()
     release_executor = threading.Event()
@@ -115,6 +118,7 @@ async def test_caller_cancellation_preserves_cancelled_executor_acquire(lock_fil
 
 
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_cancellation_surfaces_compensation_failure(lock_file: str, mocker: MockerFixture) -> None:
     executor_started = threading.Event()
     release_executor = threading.Event()
@@ -188,6 +192,7 @@ async def test_acquire_cancellation_while_sqlite_waits_rolls_back(
 
 @pytest.mark.parametrize("mode", [pytest.param("read", id="read"), pytest.param("write", id="write")])
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_acquire_cancellation_surfaces_acquire_and_rollback_errors(
     lock_file: str, mocker: MockerFixture, mode: Literal["read", "write"]
 ) -> None:
@@ -245,6 +250,7 @@ async def test_close_cancellation_shuts_down_owned_executor(lock_file: str, mock
 
 @pytest.mark.parametrize("operation", [pytest.param("release", id="release"), pytest.param("close", id="close")])
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_cancellation_surfaces_rollback_error(
     lock_file: str, mocker: MockerFixture, operation: Literal["release", "close"]
 ) -> None:
@@ -280,6 +286,7 @@ async def test_cancellation_surfaces_rollback_error(
 
 @pytest.mark.parametrize("mode", [pytest.param("read", id="read"), pytest.param("write", id="write")])
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_context_cancellation_preserves_body_and_rollback_contexts(
     lock_file: str, mocker: MockerFixture, mode: Literal["read", "write"]
 ) -> None:

--- a/tests/test_async_read_write_cancellation.py
+++ b/tests/test_async_read_write_cancellation.py
@@ -10,11 +10,11 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Literal, cast
 
 import pytest
-from async_filelock_cancellation_helpers import assert_cancellation_message
-from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
-from read_write_helpers import assert_read_write_lock_state
 
 from filelock import AsyncReadWriteLock, ReadWriteLock
+from tests.async_filelock_cancellation_helpers import assert_cancellation_message
+from tests.capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
+from tests.read_write_helpers import assert_read_write_lock_state
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/tests/test_async_transition_gate.py
+++ b/tests/test_async_transition_gate.py
@@ -4,9 +4,9 @@ import asyncio
 from concurrent.futures import Future as ConcurrentFuture
 
 import pytest
-from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock._async import _AsyncTransitionGate
+from tests.capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 
 @pytest.mark.asyncio

--- a/tests/test_async_transition_gate.py
+++ b/tests/test_async_transition_gate.py
@@ -4,6 +4,7 @@ import asyncio
 from concurrent.futures import Future as ConcurrentFuture
 
 import pytest
+from capability_marks import XFAIL_WITHOUT_COROUTINE_CANCELLATION
 
 from filelock._async import _AsyncTransitionGate
 
@@ -38,6 +39,7 @@ async def test_hold_waits_for_a_predecessor_before_entering() -> None:
 
 
 @pytest.mark.asyncio
+@XFAIL_WITHOUT_COROUTINE_CANCELLATION
 async def test_hold_canceled_while_waiting_lets_the_predecessor_free_the_ticket() -> None:
     gate = _AsyncTransitionGate()
     first_holding = asyncio.Event()

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -20,13 +20,6 @@ from uuid import uuid4
 from weakref import WeakValueDictionary
 
 import pytest
-from capability_marks import (
-    NEEDS_FCNTL,
-    NEEDS_FILE_MODE,
-    NEEDS_PARENT_SYMLINK_COLLAPSE,
-    NEEDS_PROMPT_FINALIZATION,
-    NEEDS_SYMLINK,
-)
 from coverage_pragmas import CAPABILITIES
 
 from filelock import (
@@ -43,6 +36,13 @@ from filelock import (
     unlock_descriptor,
 )
 from filelock._api import _append_exception_context, _raise_grouped_errors, _registry
+from tests.capability_marks import (
+    NEEDS_FCNTL,
+    NEEDS_FILE_MODE,
+    NEEDS_PARENT_SYMLINK_COLLAPSE,
+    NEEDS_PROMPT_FINALIZATION,
+    NEEDS_SYMLINK,
+)
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from builtins import BaseExceptionGroup, ExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -11,7 +11,6 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from errno import EAGAIN, EINTR, EIO, ENOSPC, ENOSYS, EWOULDBLOCK
-from importlib.util import find_spec
 from inspect import getframeinfo, stack
 from pathlib import Path, PurePath
 from stat import S_IMODE, S_IWGRP, S_IWOTH, S_IWUSR, filemode
@@ -21,7 +20,13 @@ from uuid import uuid4
 from weakref import WeakValueDictionary
 
 import pytest
-from capability_marks import NEEDS_PROMPT_FINALIZATION
+from capability_marks import (
+    NEEDS_FCNTL,
+    NEEDS_FILE_MODE,
+    NEEDS_PARENT_SYMLINK_COLLAPSE,
+    NEEDS_PROMPT_FINALIZATION,
+    NEEDS_SYMLINK,
+)
 from coverage_pragmas import CAPABILITIES
 
 from filelock import (
@@ -90,11 +95,6 @@ def make_ro(path: Path) -> Iterator[None]:
         path.chmod(path.stat().st_mode | write)
 
 
-_NEEDS_FILE_MODE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["file-mode"], reason="a read-only folder needs POSIX permission bits"
-)
-
-
 @pytest.fixture
 def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:  # pragma: needs file-mode
     with make_ro(tmp_path):
@@ -102,7 +102,7 @@ def tmp_path_ro(tmp_path: Path) -> Iterator[Path]:  # pragma: needs file-mode
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
-@_NEEDS_FILE_MODE  # pragma: needs file-mode
+@NEEDS_FILE_MODE  # pragma: needs file-mode
 @pytest.mark.skipif(
     sys.platform != "win32" and os.geteuid() == 0,
     reason="Cannot make a read only file (that the current user: root can't read)",
@@ -133,9 +133,6 @@ def test_ro_file(lock_type: type[BaseFileLock], tmp_file_ro: Path) -> None:
 
 
 _WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    find_spec("fcntl") is None, reason="native flock semantics need the fcntl module"
-)
 _INVALID_DESCRIPTOR_POLL_INTERVALS: Final = (
     pytest.param(0.0, id="zero"),
     pytest.param(-0.01, id="negative"),
@@ -668,7 +665,7 @@ def test_wrong_platform(tmp_path: Path) -> None:
         lock._release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 @pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 def test_flock_not_implemented_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("fcntl.flock", side_effect=OSError(ENOSYS, "mock error"))
@@ -979,7 +976,7 @@ def test_lock_file_removed_after_release(tmp_path: Path, lock_type: type[BaseFil
     assert not lock_path.exists()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_concurrent_acquire_release_keeps_lock_file(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     errors: list[Exception] = []
@@ -1002,7 +999,7 @@ def test_concurrent_acquire_release_keeps_lock_file(tmp_path: Path) -> None:
     assert lock_path.exists()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
     lock_path = tmp_path / "test.lock"
     first = FileLock(str(lock_path), is_singleton=False)
@@ -1019,7 +1016,7 @@ def test_lock_acquired_after_release_keeps_path(tmp_path: Path) -> None:
     assert lock_path.exists()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_waiter_fd_cannot_split_lock_after_release(tmp_path: Path) -> None:
     # typeshed hides fcntl's members off POSIX, so state the invariant the capability gate already enforces.
     assert sys.platform != "win32"
@@ -1047,7 +1044,7 @@ def test_waiter_fd_cannot_split_lock_after_release(tmp_path: Path) -> None:
         os.close(waiter_fd)
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_stale_inode_retry_on_unlinked_lock(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
@@ -1070,7 +1067,7 @@ def test_stale_inode_retry_on_unlinked_lock(tmp_path: Path, mocker: MockerFixtur
     lock.release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_permission_error_fallback_without_o_creat(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
@@ -1093,7 +1090,7 @@ def test_permission_error_fallback_without_o_creat(tmp_path: Path, mocker: Mocke
     lock.release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_permission_error_propagates_when_file_missing(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock = FileLock(str(lock_path), is_singleton=False)
@@ -1112,7 +1109,7 @@ def test_permission_error_propagates_when_file_missing(tmp_path: Path, mocker: M
         lock.acquire(timeout=0)
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_sticky_bit_fallback_handles_concurrent_unlink(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "test.lock"
     lock_path.touch()
@@ -1219,7 +1216,7 @@ def test_cancel_check_log_message(
     lock_1.release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_filenotfound_on_fuse_nfs_retries(tmp_path: Path, mocker: MockerFixture) -> None:
     """Retry recovers from the FUSE/NFS os.open(O_CREAT) race that raises FileNotFoundError."""
     lock_path = tmp_path / "test.lock"
@@ -1339,22 +1336,12 @@ def test_different_threads_no_false_positive(tmp_path: Path, lock_type: type[Bas
     assert not isinstance(error, RuntimeError), "Should not raise RuntimeError in different thread"
 
 
-_NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
-)
-
 _NEEDS_O_NOFOLLOW: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["o-nofollow"], reason="refusing to open through a final symlink needs a honored O_NOFOLLOW"
 )
 
-# Windows resolves a lock's parent with abspath, so a symlinked parent stays a distinct key and never collapses.
-_NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["symlink"] or sys.platform == "win32",
-    reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",
-)
 
-
-@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
+@NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
     # A symlinked parent directory resolves to the same canonical key (the final component is kept literal, so a final
@@ -1370,7 +1357,7 @@ def test_symlink_same_canonical_path(tmp_path: Path, lock_type: type[BaseFileLoc
             lock2.acquire()
 
 
-@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
+@NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 @pytest.mark.parametrize(
     ("depth", "force"),
     [
@@ -1396,7 +1383,7 @@ def test_release_drops_acquisition_key_after_parent_retarget(tmp_path: Path, dep
         assert successor.is_locked
 
 
-@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
+@NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 def test_release_keeps_retargeted_parent_holder_registered(tmp_path: Path) -> None:
     lock_path, _original_path, replacement_path = _symlinked_lock_paths(tmp_path)
     original = FileLock(lock_path)
@@ -1464,7 +1451,7 @@ def held_lock_path(tmp_path: Path) -> Iterator[Path]:  # pragma: needs fcntl
         yield path
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_winner_truncates_stale_content(tmp_path: Path) -> None:
     lock_path = tmp_path / "resource.lock"
     lock_path.write_text("stale from a previous holder", encoding="utf-8")
@@ -1473,7 +1460,7 @@ def test_winner_truncates_stale_content(tmp_path: Path) -> None:
         assert lock_path.stat().st_size == 0
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_contender_preserves_holder_contents(held_lock_path: Path) -> None:
     held_lock_path.write_text("holder metadata", encoding="utf-8")
 
@@ -1483,7 +1470,7 @@ def test_contender_preserves_holder_contents(held_lock_path: Path) -> None:
     assert held_lock_path.read_text(encoding="utf-8") == "holder metadata"
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_contender_preserves_holder_mode(held_lock_path: Path) -> None:
     held_lock_path.chmod(0o600)
 
@@ -1493,7 +1480,7 @@ def test_contender_preserves_holder_mode(held_lock_path: Path) -> None:
     assert S_IMODE(held_lock_path.stat().st_mode) == 0o600
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_contender_does_not_fchmod(held_lock_path: Path, mocker: MockerFixture) -> None:
     fchmod_spy = mocker.spy(os, "fchmod")
 
@@ -1503,7 +1490,7 @@ def test_contender_does_not_fchmod(held_lock_path: Path, mocker: MockerFixture) 
     fchmod_spy.assert_not_called()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_post_lock_truncate_failure_closes_fd(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("os.ftruncate", side_effect=OSError(ENOSPC, "No space left on device"))
     open_spy = mocker.spy(os, "open")
@@ -1517,7 +1504,7 @@ def test_post_lock_truncate_failure_closes_fd(tmp_path: Path, mocker: MockerFixt
 
 # Only a Windows run that also holds the symlink privilege reaches this body, so both exclusions apply.
 @_WINDOWS_ONLY  # pragma: win32 cover  # pragma: needs symlink
-@_NEEDS_SYMLINK
+@NEEDS_SYMLINK
 def test_windows_reparse_point_lock_file_rejected(tmp_path: Path) -> None:
     target = tmp_path / "target.txt"
     target.write_text("sensitive", encoding="utf-8")
@@ -1551,7 +1538,7 @@ def test_forced_release_drops_all_holds(tmp_path: Path) -> None:
     assert lock.lock_counter == 0
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_unix_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))
     lock.acquire()
@@ -1564,7 +1551,7 @@ def test_unix_release_keeps_lock_held_when_unlock_fails(tmp_path: Path, mocker: 
     assert not lock.is_locked
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_unix_context_exit_propagates_unlock_failure(tmp_path: Path, mocker: MockerFixture) -> None:
     # One LOCK_EX for acquire, then one LOCK_UN per release; fail only the first unlock so __exit__ propagates it.
     mocker.patch("filelock._unix.fcntl.flock", side_effect=[None, OSError(EIO, "unlock failed"), None])
@@ -1873,7 +1860,7 @@ def _fail_close_of(mocker: MockerFixture, lock: BaseFileLock, error: OSError) ->
     return attempts
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_close_error_default_suppressed_on_unix(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"))  # default policy
     lock.acquire()
@@ -1914,7 +1901,7 @@ def test_close_error_raise_is_exact_and_committed(tmp_path: Path, mocker: Mocker
     assert lock.lock_counter == 0
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_close_not_reached_when_unlock_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = FileLock(str(tmp_path / "a"), close_error_policy="raise")
     lock.acquire()
@@ -1970,7 +1957,7 @@ def test_singleton_shares_across_equivalent_spellings(tmp_path: Path) -> None:
         absolute.release(force=True)
 
 
-@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
+@NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 def test_singleton_shares_through_symlinked_parent(tmp_path: Path) -> None:
     real = tmp_path / "real"
     real.mkdir()
@@ -1983,7 +1970,7 @@ def test_singleton_shares_through_symlinked_parent(tmp_path: Path) -> None:
         via_real.release(force=True)
 
 
-@_NEEDS_SYMLINK  # pragma: needs symlink
+@NEEDS_SYMLINK  # pragma: needs symlink
 def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.write_text("")
@@ -1997,7 +1984,7 @@ def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
         on_target.release(force=True)
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 @_NEEDS_O_NOFOLLOW  # pragma: needs o-nofollow
 def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:
     (tmp_path / "target").write_text("")
@@ -2018,7 +2005,7 @@ def test_separate_lock_classes_keep_separate_registries(tmp_path: Path) -> None:
         soft.release(force=True)
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), fallback_to_soft=False)
@@ -2030,7 +2017,7 @@ def test_fallback_to_soft_disabled_raises_enosys(tmp_path: Path, mocker: MockerF
     assert lock.lock_counter == 0  # the failed acquire left no holder count
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_fallback_to_soft_default_switches_to_soft(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"))  # default fallback_to_soft=True
@@ -2043,7 +2030,7 @@ def test_fallback_to_soft_default_switches_to_soft(tmp_path: Path, mocker: Mocke
         lock.release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_fallback_disabled_recursive_reraises(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), fallback_to_soft=False)
@@ -2053,7 +2040,7 @@ def test_fallback_disabled_recursive_reraises(tmp_path: Path, mocker: MockerFixt
         assert not lock.is_locked
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_singleton_rejects_different_fallback_to_soft(tmp_path: Path) -> None:
     path = str(tmp_path / "a")
     first = FileLock(path, is_singleton=True, fallback_to_soft=True)
@@ -2143,7 +2130,7 @@ def test_filelock_and_descriptor_contend(tmp_path: Path, direction: str) -> None
         os.close(fd)
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:
     path = tmp_path / "a"
     fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
@@ -2167,7 +2154,7 @@ def test_lock_descriptor_touches_no_paths(tmp_path: Path) -> None:
         os.close(fd)
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_unlock_descriptor_failure_allows_retry(tmp_path: Path, mocker: MockerFixture) -> None:
     fd = os.open(str(tmp_path / "a"), os.O_RDWR | os.O_CREAT)
     try:
@@ -2248,7 +2235,7 @@ def test_singleton_rejects_different_preserve_lock_file(tmp_path: Path) -> None:
         first.release(force=True)
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:
     path = tmp_path / "a"
     lock = FileLock(str(path), preserve_lock_file=True)
@@ -2258,7 +2245,7 @@ def test_preserve_lock_file_unix_keeps_pathname(tmp_path: Path) -> None:
     assert type(lock).__name__ == "UnixFileLock"
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_preserve_lock_file_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     lock = FileLock(str(tmp_path / "a"), preserve_lock_file=True)  # fallback_to_soft still defaults to True
@@ -2382,7 +2369,7 @@ def test_on_acquired_not_called_for_contender(tmp_path: Path) -> None:
         holder.release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_on_acquired_runs_after_truncation_and_mode(tmp_path: Path) -> None:
     path = tmp_path / "a"
     path.write_bytes(b"stale content")
@@ -2401,7 +2388,7 @@ def test_on_acquired_runs_after_truncation_and_mode(tmp_path: Path) -> None:
         lock.release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_on_acquired_writes_survive_contention(tmp_path: Path) -> None:
     path = str(tmp_path / "a")
 
@@ -2431,7 +2418,7 @@ def test_on_acquired_failure_releases_lock(tmp_path: Path) -> None:
     other.release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_on_acquired_and_release_failure_group(tmp_path: Path, mocker: MockerFixture) -> None:
     path = str(tmp_path / "a")
     lock = FileLock(path, on_acquired=_failing_on_acquired)
@@ -2518,7 +2505,7 @@ def test_rollback_failed_acquire_groups_registration_and_release_failures(
         lock.release(force=True)
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_on_acquired_fails_closed_on_enosys(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch("filelock._unix.fcntl.flock", side_effect=OSError(ENOSYS, "no flock"))
     calls: list[int] = []
@@ -2660,7 +2647,7 @@ def test_soft_is_lock_held_by_us_false_for_unparseable_marker(tmp_path: Path) ->
     assert lock.is_lock_held_by_us is False  # an unreadable holder is nobody, so certainly not us
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_unix_acquire_without_o_nofollow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
     lock = FileLock(str(tmp_path / "a"), is_singleton=False)
@@ -2671,7 +2658,7 @@ def test_unix_acquire_without_o_nofollow(tmp_path: Path, monkeypatch: pytest.Mon
         lock.release()
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_unix_soft_fallback_keeps_a_replaced_file(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "a"
     lock = FileLock(str(lock_path), is_singleton=False)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 from weakref import WeakValueDictionary
 
 import pytest
+from capability_marks import NEEDS_PROMPT_FINALIZATION
 from coverage_pragmas import CAPABILITIES
 
 from filelock import (
@@ -480,7 +481,7 @@ def test_acquire_release_on_exc(lock_type: type[BaseFileLock], tmp_path: Path) -
         assert not lock.is_locked
 
 
-@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="del() does not trigger GC in PyPy")
+@NEEDS_PROMPT_FINALIZATION
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_del(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
     lock_path = tmp_path / "a"
@@ -900,7 +901,7 @@ def test_singleton_locks_must_be_initialized_with_the_same_args(lock_type: type[
     del lock, exc_info
 
 
-@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="del() does not trigger GC in PyPy")
+@NEEDS_PROMPT_FINALIZATION
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_singleton_locks_are_deleted_when_no_external_references_exist(
     lock_type: type[BaseFileLock],
@@ -914,7 +915,6 @@ def test_singleton_locks_are_deleted_when_no_external_references_exist(
     assert lock_type._instances == {}
 
 
-@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="del() does not trigger GC in PyPy")
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_singleton_instance_tracking_is_unique_per_subclass(lock_type: type[BaseFileLock]) -> None:
     class Lock1(lock_type):  # ty: ignore[unsupported-base]
@@ -1341,6 +1341,10 @@ def test_different_threads_no_false_positive(tmp_path: Path, lock_type: type[Bas
 
 _NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
+)
+
+_NEEDS_O_NOFOLLOW: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["o-nofollow"], reason="refusing to open through a final symlink needs a honored O_NOFOLLOW"
 )
 
 # Windows resolves a lock's parent with abspath, so a symlinked parent stays a distinct key and never collapses.
@@ -1994,6 +1998,7 @@ def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
 
 
 @_NEEDS_FCNTL  # pragma: needs fcntl
+@_NEEDS_O_NOFOLLOW  # pragma: needs o-nofollow
 def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:
     (tmp_path / "target").write_text("")
     (tmp_path / "link").symlink_to(tmp_path / "target")

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -8,6 +8,7 @@ from errno import EBADF
 from typing import TYPE_CHECKING, Final, NoReturn, cast
 
 import pytest
+from capability_marks import NEEDS_GENERATOR_EXCEPTION_CONTEXT
 from fork_helpers import exit_child, fork_process
 
 from filelock import BaseAsyncFileLock, BaseFileLock
@@ -457,6 +458,7 @@ async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fa
     )
 
 
+@NEEDS_GENERATOR_EXCEPTION_CONTEXT
 @pytest.mark.asyncio
 async def test_coroutine_on_acquired_error_preserves_context(tmp_path: Path) -> None:
     callback_error = RuntimeError("hook failed")

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -8,10 +8,10 @@ from errno import EBADF
 from typing import TYPE_CHECKING, NoReturn, cast
 
 import pytest
-from capability_marks import NEEDS_FORK, NEEDS_GENERATOR_EXCEPTION_CONTEXT
-from fork_helpers import exit_child, fork_process
 
 from filelock import BaseAsyncFileLock, BaseFileLock
+from tests.capability_marks import NEEDS_FORK, NEEDS_GENERATOR_EXCEPTION_CONTEXT
+from tests.fork_helpers import exit_child, fork_process
 
 if sys.version_info >= (3, 11):
     from builtins import BaseExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -5,10 +5,10 @@ import os
 import subprocess  # ruff:ignore[suspicious-subprocess-import]  # isolated interpreter controls child callback registration order
 import sys
 from errno import EBADF
-from typing import TYPE_CHECKING, Final, NoReturn, cast
+from typing import TYPE_CHECKING, NoReturn, cast
 
 import pytest
-from capability_marks import NEEDS_GENERATOR_EXCEPTION_CONTEXT
+from capability_marks import NEEDS_FORK, NEEDS_GENERATOR_EXCEPTION_CONTEXT
 from fork_helpers import exit_child, fork_process
 
 from filelock import BaseAsyncFileLock, BaseFileLock
@@ -23,10 +23,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pytest_mock import MockerFixture
-
-_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not (hasattr(os, "fork") and hasattr(os, "register_at_fork")), reason="os.fork and os.register_at_fork required"
-)
 
 
 class _DescriptorLock(BaseFileLock):
@@ -70,7 +66,7 @@ class _CoroutineDescriptorLock(BaseAsyncFileLock):
             raise self.release_error
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:
     descriptors: list[int] = []
     lock = _DescriptorLock(str(tmp_path / "third-party.lock"), is_singleton=False, on_acquired=descriptors.append)
@@ -83,7 +79,7 @@ def test_third_party_descriptor_is_closed_in_child(tmp_path: Path) -> None:
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:
     descriptors: list[int] = []
     lock = _DescriptorLock(str(tmp_path / "retry.lock"), is_singleton=False, on_acquired=descriptors.append)
@@ -100,7 +96,7 @@ def test_unlock_failure_keeps_descriptor_registered(tmp_path: Path) -> None:
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path: Path) -> None:
     lock = _DescriptorLock(str(tmp_path / "partial.lock"), is_singleton=False)
     lock.acquire_error = RuntimeError("acquire failed")
@@ -141,7 +137,7 @@ def test_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path
         ),
     ],
 )
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_acquisition_and_registration_errors_are_grouped(
     tmp_path: Path,
     mocker: MockerFixture,
@@ -176,7 +172,7 @@ def test_acquisition_and_registration_errors_are_grouped(
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = _DescriptorLock(str(tmp_path / "group.lock"), is_singleton=False)
     lock.fail_release = True
@@ -206,7 +202,7 @@ def test_registration_failure_tracks_descriptor_when_rollback_fails(tmp_path: Pa
     )
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_unverified_descriptor_does_not_close_reused_child_fd(tmp_path: Path) -> None:
     script = """
 from __future__ import annotations
@@ -290,7 +286,7 @@ raise SystemExit(os.waitstatus_to_exitcode(status))
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_control_flow_registration_error_rolls_back_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     descriptors: list[int] = []
 
@@ -317,7 +313,7 @@ def test_control_flow_registration_error_rolls_back_descriptor(tmp_path: Path, m
 
 
 @pytest.mark.asyncio
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 async def test_coroutine_registration_error_rolls_back_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     descriptors: list[int] = []
     real_fstat = os.fstat
@@ -347,7 +343,7 @@ async def test_coroutine_acquisition_failure_before_descriptor_propagates(tmp_pa
     assert (info.value is acquisition_error, lock.is_locked) == (True, False)
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @pytest.mark.asyncio
 async def test_coroutine_acquisition_failure_keeps_descriptor_registered_until_rollback(tmp_path: Path) -> None:
     lock = _CoroutineDescriptorLock(
@@ -390,7 +386,7 @@ async def test_coroutine_acquisition_failure_keeps_descriptor_registered_until_r
         ),
     ],
 )
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @pytest.mark.asyncio
 async def test_coroutine_acquisition_and_registration_errors_are_grouped(
     tmp_path: Path,
@@ -425,7 +421,7 @@ async def test_coroutine_acquisition_and_registration_errors_are_grouped(
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @pytest.mark.asyncio
 async def test_coroutine_registration_failure_tracks_descriptor_when_rollback_fails(
     tmp_path: Path, mocker: MockerFixture

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -7,10 +7,10 @@ import threading
 from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
-from capability_marks import NEEDS_FORK, NEEDS_FORK1
-from fork_helpers import exit_child, fork_process
 
 from filelock import BaseFileLock, Timeout, has_fcntl
+from tests.capability_marks import NEEDS_FORK, NEEDS_FORK1
+from tests.fork_helpers import exit_child, fork_process
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -7,6 +7,7 @@ import threading
 from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
+from capability_marks import NEEDS_FORK, NEEDS_FORK1
 from fork_helpers import exit_child, fork_process
 
 from filelock import BaseFileLock, Timeout, has_fcntl
@@ -14,15 +15,12 @@ from filelock import BaseFileLock, Timeout, has_fcntl
 if TYPE_CHECKING:
     from pathlib import Path
 
-_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not (hasattr(os, "fork") and hasattr(os, "register_at_fork")), reason="os.fork and os.register_at_fork required"
-)
 _FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
     "ignore:.*multi-threaded, use of fork.*:DeprecationWarning"
 )
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_callbacks_registered_before_filelock_can_use_locks(tmp_path: Path) -> None:
     script = """
@@ -86,7 +84,7 @@ if (
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     "audit_mode",
@@ -163,7 +161,7 @@ if second_status != 0 or owner.is_alive() or statuses.get(timeout=1) != 0:
     assert result.returncode == 0, result.stderr
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @pytest.mark.parametrize(
     "event",
     [
@@ -190,7 +188,7 @@ def test_audit_rejects_process_creation_inside_descriptor_transition(
         AuditedLock(str(tmp_path / "audit.lock"), is_singleton=False).acquire(timeout=0)
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     "fork_mode",
@@ -198,7 +196,7 @@ def test_audit_rejects_process_creation_inside_descriptor_transition(
         pytest.param("rejected-audit", id="rejected-audit-hook"),
         pytest.param(
             "fork1",
-            marks=pytest.mark.skipif(not hasattr(os, "fork1"), reason="os.fork1 required"),
+            marks=NEEDS_FORK1,
             id="fork1",
         ),
     ],
@@ -260,7 +258,7 @@ raise SystemExit(lock.child_status)
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.skipif(not has_fcntl, reason="fcntl.flock required")
 @pytest.mark.skipif(sys.implementation.name != "cpython", reason="CPython fcntl audit event required")
@@ -270,7 +268,7 @@ raise SystemExit(lock.child_status)
         pytest.param("rejected-audit", id="rejected-audit-hook"),
         pytest.param(
             "fork1",
-            marks=pytest.mark.skipif(not hasattr(os, "fork1"), reason="os.fork1 required"),
+            marks=NEEDS_FORK1,
             id="fork1",
         ),
     ],
@@ -327,7 +325,7 @@ raise SystemExit(child_status)
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_child_unwinds_pre_fork_transition_before_new_acquire(tmp_path: Path) -> None:
     script = """
@@ -409,7 +407,7 @@ raise SystemExit(os.waitstatus_to_exitcode(status))
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_overlapping_coroutine_transitions_close_every_pending_descriptor(tmp_path: Path) -> None:
     script = """
@@ -483,7 +481,7 @@ asyncio.run(main())
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_pending_descriptor_with_unknown_identity_is_preserved_in_child(tmp_path: Path) -> None:
     script = """
@@ -548,7 +546,7 @@ raise SystemExit(lock.child_status)
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_child_replaces_parameter_model_mutex_held_during_construction(tmp_path: Path) -> None:
     script = """
@@ -635,7 +633,7 @@ if os.waitstatus_to_exitcode(status) != 0 or worker.is_alive() or os.getpid() !=
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_registration_transition_completes_after_fork_closes_admission(tmp_path: Path) -> None:
     script = """
@@ -721,7 +719,7 @@ lock.release()
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.skipif(not has_fcntl, reason="fcntl.flock required")
 def test_cancelled_async_acquire_unregisters_reused_descriptor(tmp_path: Path) -> None:
@@ -809,7 +807,7 @@ raise SystemExit(asyncio.run(main()))
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_parent_callback_rejects_reentrant_singleton_construction(tmp_path: Path) -> None:
     script = """
@@ -914,7 +912,7 @@ if (
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_singleton_construction_crossing_fork_does_not_poison_child_cache(tmp_path: Path) -> None:
     script = """
@@ -971,7 +969,7 @@ if (
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_soft_read_write_construction_crossing_fork_does_not_poison_child_cache(tmp_path: Path) -> None:
     script = """
@@ -1069,7 +1067,7 @@ def test_fork_exec_from_another_thread_remains_available(tmp_path: Path) -> None
     assert (result.returncode, finished.is_set(), worker.is_alive()) == (0, True, False)
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_child_replaces_singleton_mutex_held_by_vanished_thread(tmp_path: Path) -> None:
     entered, release = threading.Event(), threading.Event()

--- a/tests/test_fork_ownership.py
+++ b/tests/test_fork_ownership.py
@@ -12,6 +12,7 @@ from stat import S_ISDIR
 from typing import TYPE_CHECKING, Final, Literal, NoReturn
 
 import pytest
+from capability_marks import NEEDS_FORK
 from fork_helpers import exit_child, fork_process
 
 from filelock import (
@@ -36,15 +37,12 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not (hasattr(os, "fork") and hasattr(os, "register_at_fork")), reason="os.fork and os.register_at_fork required"
-)
 _FORK_WARNING: Final[pytest.MarkDecorator] = pytest.mark.filterwarnings(
     "ignore:.*multi-threaded, use of fork.*:DeprecationWarning"
 )
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     ("lock_type", "action"),
@@ -78,7 +76,7 @@ def test_child_cleanup_preserves_parent_lock(
     assert _probe_lock(lock_type, path)
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     ("async_lock_type", "sync_lock_type"),
@@ -110,7 +108,7 @@ def test_async_child_release_preserves_parent_lock(
     assert _probe_lock(sync_lock_type, path)
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None:
     path = str(tmp_path / "parent.lock")
@@ -138,7 +136,7 @@ def test_soft_read_write_resets_older_same_path_instance(tmp_path: Path) -> None
     older.close()
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None:
     path = str(tmp_path / "parent.lock")
@@ -167,7 +165,7 @@ def test_child_closes_descriptor_held_by_vanished_thread(tmp_path: Path) -> None
     assert (os.waitstatus_to_exitcode(status), worker.is_alive()) == (0, False)
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFixture) -> None:
     path = str(tmp_path / "parent.lock")
@@ -207,7 +205,7 @@ def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFi
     lock.release()
 
 
-@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="fork transition gate requires register_at_fork")
+@NEEDS_FORK
 def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
@@ -245,7 +243,7 @@ def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(  # pragm
     assert [worker.is_alive() for worker in workers] == [False, False]
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize("lock_type", [pytest.param(FileLock, id="native"), pytest.param(SoftFileLock, id="soft")])
 def test_child_singleton_registry_drops_parent_instance(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
@@ -262,7 +260,7 @@ def test_child_singleton_registry_drops_parent_instance(tmp_path: Path, lock_typ
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize("lock_type", [pytest.param(FileLock, id="native"), pytest.param(SoftFileLock, id="soft")])
 def test_inherited_idle_lock_rejects_acquire(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
@@ -281,7 +279,7 @@ def test_inherited_idle_lock_rejects_acquire(tmp_path: Path, lock_type: type[Bas
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     "lock_type", [pytest.param(AsyncFileLock, id="native"), pytest.param(AsyncSoftFileLock, id="soft")]
@@ -302,7 +300,7 @@ def test_inherited_idle_async_lock_rejects_acquire(tmp_path: Path, lock_type: ty
     assert os.waitstatus_to_exitcode(status) == 0
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None:
     path = str(tmp_path / "parent.lock")
@@ -327,7 +325,7 @@ def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None
     lock.release()
 
 
-@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="descriptor registry requires register_at_fork")
+@NEEDS_FORK
 def test_reader_directory_registration_failure_closes_descriptor(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
@@ -356,7 +354,7 @@ def test_reader_directory_registration_failure_closes_descriptor(  # pragma: nee
     lock.close()
 
 
-@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="descriptor registry requires register_at_fork")
+@NEEDS_FORK
 def test_reader_directory_registration_and_close_errors_are_grouped(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
@@ -394,7 +392,7 @@ def test_reader_directory_registration_and_close_errors_are_grouped(  # pragma: 
     ]
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 def test_child_callback_registered_before_filelock_can_acquire(tmp_path: Path) -> None:
     script = """
@@ -443,7 +441,7 @@ parent.release()
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@_REQUIRES_FORK  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(
     "kind",

--- a/tests/test_fork_ownership.py
+++ b/tests/test_fork_ownership.py
@@ -12,8 +12,6 @@ from stat import S_ISDIR
 from typing import TYPE_CHECKING, Final, Literal, NoReturn
 
 import pytest
-from capability_marks import NEEDS_FORK
-from fork_helpers import exit_child, fork_process
 
 from filelock import (
     AcquireReturnProxy,
@@ -26,6 +24,8 @@ from filelock import (
     SoftReadWriteLock,
     Timeout,
 )
+from tests.capability_marks import NEEDS_FORK, NEEDS_REGISTER_AT_FORK
+from tests.fork_helpers import exit_child, fork_process
 
 if sys.version_info >= (3, 11):
     from builtins import BaseExceptionGroup  # pragma: >=3.11 cover
@@ -205,7 +205,7 @@ def test_fork_waits_for_descriptor_registration(tmp_path: Path, mocker: MockerFi
     lock.release()
 
 
-@NEEDS_FORK
+@NEEDS_REGISTER_AT_FORK
 def test_unrelated_acquisitions_reach_filesystem_boundary_concurrently(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
@@ -325,7 +325,7 @@ def test_fork_from_on_acquired_invalidates_child_acquire(tmp_path: Path) -> None
     lock.release()
 
 
-@NEEDS_FORK
+@NEEDS_REGISTER_AT_FORK
 def test_reader_directory_registration_failure_closes_descriptor(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
@@ -354,7 +354,7 @@ def test_reader_directory_registration_failure_closes_descriptor(  # pragma: nee
     lock.close()
 
 
-@NEEDS_FORK
+@NEEDS_REGISTER_AT_FORK
 def test_reader_directory_registration_and_close_errors_are_grouped(  # pragma: needs fork
     tmp_path: Path, mocker: MockerFixture
 ) -> None:

--- a/tests/test_fork_registries.py
+++ b/tests/test_fork_registries.py
@@ -6,10 +6,9 @@ import subprocess  # ruff:ignore[suspicious-subprocess-import]  # interpreter ex
 import sys
 import weakref
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Final, NoReturn
+from typing import TYPE_CHECKING, NoReturn
 
-import pytest
-from capability_marks import NEEDS_CLASS_COLLECTION
+from capability_marks import NEEDS_CLASS_COLLECTION, NEEDS_FORK
 from fork_helpers import exit_child, fork_process
 
 from filelock import BaseFileLock
@@ -17,10 +16,8 @@ from filelock import BaseFileLock
 if TYPE_CHECKING:
     from pathlib import Path
 
-_REQUIRES_FORK: Final[pytest.MarkDecorator] = pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork required")
 
-
-@_REQUIRES_FORK
+@NEEDS_FORK
 def test_equal_unhashable_locks_reset_independently(tmp_path: Path) -> None:  # pragma: win32 no cover
     @dataclass(eq=True, init=False)  # pragma: win32 no cover
     class EqualLock(BaseFileLock):  # pragma: win32 no cover

--- a/tests/test_fork_registries.py
+++ b/tests/test_fork_registries.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, NoReturn
 
 import pytest
+from capability_marks import NEEDS_CLASS_COLLECTION
 from fork_helpers import exit_child, fork_process
 
 from filelock import BaseFileLock
@@ -76,6 +77,7 @@ for lock in locks:
     assert (result.returncode, [path.with_name(f"{path.name}.write").exists() for path in paths]) == (0, [False, False])
 
 
+@NEEDS_CLASS_COLLECTION
 def test_dynamic_lock_class_can_be_collected() -> None:
     class EphemeralLock(BaseFileLock):
         _acquire = _release = BaseFileLock._acquire

--- a/tests/test_fork_registries.py
+++ b/tests/test_fork_registries.py
@@ -8,10 +8,9 @@ import weakref
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NoReturn
 
-from capability_marks import NEEDS_CLASS_COLLECTION, NEEDS_FORK
-from fork_helpers import exit_child, fork_process
-
 from filelock import BaseFileLock
+from tests.capability_marks import NEEDS_CLASS_COLLECTION, NEEDS_FORK
+from tests.fork_helpers import exit_child, fork_process
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -13,6 +13,7 @@ pytest.importorskip("sqlite3")
 import sqlite3
 
 from filelock import ReadWriteLock, Timeout
+from tests.capability_marks import SKIP_ON_UNRELIABLE_PROCESS_SYNC
 from tests.read_write_helpers import assert_read_write_lock_state
 
 # Bounds how long a spawned process may take to reach the lock, not how fast it must be: an interpreter that starts
@@ -22,6 +23,8 @@ _PROCESS_DEADLINE: Final[int] = 30
 # Reaping a process that has already been signaled is not a startup wait, and it has to stay under the suite's own
 # per-test timeout so the guard still reports the hang it was put there for.
 _REAP_DEADLINE: Final[int] = 5
+
+pytestmark = SKIP_ON_UNRELIABLE_PROCESS_SYNC
 
 if sys.implementation.name == "pypy":
     set_start_method(

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -15,8 +15,9 @@ import sqlite3
 from filelock import ReadWriteLock, Timeout
 from tests.read_write_helpers import assert_read_write_lock_state
 
-# Bounds how long a spawned process may take to reach the lock, not how fast it must be: an interpreter that
-# starts slowly under a loaded suite is not a locking failure. Only a genuine hang waits this out.
+# Bounds how long a spawned process may take to reach the lock, not how fast it must be: an interpreter that starts
+# slowly under a loaded suite is not a locking failure. Only a genuine hang waits this out. Each test's own timeout
+# has to outlast the waits it makes, so those are multiples of this rather than bare seconds.
 _PROCESS_DEADLINE: Final[int] = 30
 
 if sys.implementation.name == "pypy":
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 5)
 def test_read_locks_are_shared(lock_file: str) -> None:
     read1_acquired = Event()
     read2_acquired = Event()
@@ -55,7 +56,7 @@ def test_read_locks_are_shared(lock_file: str) -> None:
         assert not reader2.is_alive(), "Reader 2 did not exit cleanly"
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 5)
 def test_write_lock_excludes_other_write_locks(lock_file: str) -> None:
     write1_acquired = Event()
     release_write1 = Event()
@@ -133,7 +134,7 @@ def test_lock_excludes_opposite_mode(
         assert not contender.is_alive(), "Contender did not exit cleanly"
 
 
-@pytest.mark.timeout(40)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 8)
 def test_write_non_starvation(lock_file: str) -> None:
     """A writer that joins after the first reader must acquire before the reader chain drains.
 
@@ -171,16 +172,16 @@ def test_write_non_starvation(lock_file: str) -> None:
 
         chain_forward[0].set()
 
-        assert writer_ready.wait(timeout=10), "First reader did not acquire lock"
+        assert writer_ready.wait(timeout=_PROCESS_DEADLINE), "First reader did not acquire lock"
 
         writer.start()
 
         # Count only the releases the writer actually waited through; a slow interpreter start is not starvation.
-        assert writer_contending.wait(timeout=20), "Writer process did not reach the lock"
+        assert writer_contending.wait(timeout=_PROCESS_DEADLINE), "Writer process did not reach the lock"
         with release_count.get_lock():
             releases_before_contending = release_count.value
 
-        assert writer_acquired.wait(timeout=22), "Writer couldn't acquire lock - possible starvation"
+        assert writer_acquired.wait(timeout=_PROCESS_DEADLINE), "Writer couldn't acquire lock - possible starvation"
 
         with release_count.get_lock():
             read_releases = release_count.value - releases_before_contending
@@ -202,7 +203,7 @@ def test_write_non_starvation(lock_file: str) -> None:
     "hold_mode",
     [pytest.param("read", id="upgrade"), pytest.param("write", id="downgrade")],
 )
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_lock_mode_transition_prohibited(lock_file: str, hold_mode: Literal["read", "write"]) -> None:
     result = Value("i", -1)
 
@@ -216,7 +217,7 @@ def test_lock_mode_transition_prohibited(lock_file: str, hold_mode: Literal["rea
     assert result.value == 0, f"Illegal {hold_mode} transition was permitted"
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_timeout_behavior(lock_file: str) -> None:
     write_acquired = Event()
     release_write = Event()
@@ -286,7 +287,7 @@ def test_recursive_lock_acquisition(lock_file: str, mode: Literal["read", "write
     "mode",
     [pytest.param("read", id="read"), pytest.param("write", id="write")],
 )
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 4)
 def test_lock_release_on_process_termination(lock_file: str, mode: Literal["read", "write"]) -> None:
     lock_acquired = Event()
 
@@ -515,14 +516,29 @@ def acquire_lock(
             time.sleep(0.5)  # hold briefly to simulate work
 
 
+def test_cleanup_reports_the_failure_that_escaped_before_a_start() -> None:
+    unstarted = Process(target=time.sleep, args=(0,))
+
+    def fail_before_start() -> None:
+        with cleanup_processes([unstarted]):
+            msg = "the real failure"
+            raise AssertionError(msg)
+
+    with pytest.raises(AssertionError, match="the real failure"):
+        fail_before_start()
+
+
 @contextmanager
 def cleanup_processes(processes: list[Process]) -> Generator[None]:
     try:
         yield
     finally:
         for proc in processes:
-            proc.terminate()
-            proc.join(timeout=1)
+            # An assertion can escape before every process starts, and terminating an unstarted one raises over the
+            # failure that caused it, hiding the real error.
+            if proc.pid is not None:
+                proc.terminate()
+                proc.join(timeout=1)
             proc.close()
 
 

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -138,6 +138,7 @@ def test_write_non_starvation(lock_file: str) -> None:
     chain_forward = [Event() for _ in range(NUM_READERS)]
     chain_backward = [Event() for _ in range(NUM_READERS)]
     writer_ready = Event()
+    writer_contending = Event()
     writer_acquired = Event()
 
     release_count = Value("i", 0)
@@ -152,7 +153,10 @@ def test_write_non_starvation(lock_file: str) -> None:
         )
         readers.append(reader)
 
-    writer = Process(target=acquire_lock, args=(lock_file, "write", writer_acquired, None, 20, True, writer_ready))
+    writer = Process(
+        target=acquire_lock,
+        args=(lock_file, "write", writer_acquired, None, 20, True, writer_ready, writer_contending),
+    )
 
     with cleanup_processes([*readers, writer]):
         for reader in readers:
@@ -164,10 +168,15 @@ def test_write_non_starvation(lock_file: str) -> None:
 
         writer.start()
 
+        # Count only the releases the writer actually waited through; a slow interpreter start is not starvation.
+        assert writer_contending.wait(timeout=20), "Writer process did not reach the lock"
+        with release_count.get_lock():
+            releases_before_contending = release_count.value
+
         assert writer_acquired.wait(timeout=22), "Writer couldn't acquire lock - possible starvation"
 
         with release_count.get_lock():
-            read_releases = release_count.value
+            read_releases = release_count.value - releases_before_contending
 
         assert read_releases < 3, f"Writer acquired after {read_releases} readers released - this indicates starvation"
 
@@ -483,11 +492,14 @@ def acquire_lock(
     timeout: float = -1,
     blocking: bool = True,
     ready_event: EventType | None = None,
+    contending_event: EventType | None = None,
 ) -> None:
     if ready_event:
         ready_event.wait(timeout=10)
 
     lock = ReadWriteLock(lock_file, timeout=timeout, blocking=blocking)
+    if contending_event:
+        contending_event.set()  # interpreter start-up is over, so a caller can time the contention itself
     with lock.read_lock() if mode == "read" else lock.write_lock():
         acquired_event.set()
         if release_event:

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -12,9 +12,12 @@ pytest.importorskip("sqlite3")
 
 import sqlite3
 
-from read_write_helpers import assert_read_write_lock_state
-
 from filelock import ReadWriteLock, Timeout
+from tests.read_write_helpers import assert_read_write_lock_state
+
+# Bounds how long a spawned process may take to reach the lock, not how fast it must be: an interpreter that
+# starts slowly under a loaded suite is not a locking failure. Only a genuine hang waits this out.
+_PROCESS_DEADLINE: Final[int] = 30
 
 if sys.implementation.name == "pypy":
     set_start_method(
@@ -63,14 +66,14 @@ def test_write_lock_excludes_other_write_locks(lock_file: str) -> None:
 
     with cleanup_processes([holder]):
         holder.start()
-        assert write1_acquired.wait(timeout=2), "First write lock not acquired"
+        assert write1_acquired.wait(timeout=_PROCESS_DEADLINE), "First write lock not acquired"
 
         with cleanup_processes([contender]):
             contender.start()
             assert not write2_acquired.wait(timeout=1), "Second write lock should not be acquired"
 
             release_write1.set()
-            holder.join(timeout=2)
+            holder.join(timeout=_PROCESS_DEADLINE)
             assert not holder.is_alive(), "Holder did not exit cleanly"
 
         write2_acquired.clear()
@@ -78,8 +81,10 @@ def test_write_lock_excludes_other_write_locks(lock_file: str) -> None:
 
         with cleanup_processes([successor]):
             successor.start()
-            assert write2_acquired.wait(timeout=2), "Second write lock not acquired after first released"
-            successor.join(timeout=2)
+            assert write2_acquired.wait(timeout=_PROCESS_DEADLINE), (
+                "Second write lock not acquired after first released"
+            )
+            successor.join(timeout=_PROCESS_DEADLINE)
             assert not successor.is_alive(), "Successor did not exit cleanly"
 
 
@@ -109,7 +114,7 @@ def test_lock_excludes_opposite_mode(
 
     with cleanup_processes([holder, contender]):
         holder.start()
-        assert holder_acquired.wait(timeout=2), f"{holder_mode} lock not acquired"
+        assert holder_acquired.wait(timeout=_PROCESS_DEADLINE), f"{holder_mode} lock not acquired"
 
         contender.start()
         contender_started.set()
@@ -118,11 +123,13 @@ def test_lock_excludes_opposite_mode(
         assert not contender_acquired.is_set(), f"{contender_mode} lock should not be acquired while {holder_mode} held"
 
         release_holder.set()
-        holder.join(timeout=2)
+        holder.join(timeout=_PROCESS_DEADLINE)
 
-        assert contender_acquired.wait(timeout=2), f"{contender_mode} lock not acquired after {holder_mode} released"
+        assert contender_acquired.wait(timeout=_PROCESS_DEADLINE), (
+            f"{contender_mode} lock not acquired after {holder_mode} released"
+        )
 
-        contender.join(timeout=2)
+        contender.join(timeout=_PROCESS_DEADLINE)
         assert not contender.is_alive(), "Contender did not exit cleanly"
 
 
@@ -180,7 +187,7 @@ def test_write_non_starvation(lock_file: str) -> None:
 
         assert read_releases < 3, f"Writer acquired after {read_releases} readers released - this indicates starvation"
 
-        writer.join(timeout=2)
+        writer.join(timeout=_PROCESS_DEADLINE)
         assert not writer.is_alive(), "Writer did not exit cleanly"
 
         for event in chain_backward:
@@ -220,7 +227,7 @@ def test_timeout_behavior(lock_file: str) -> None:
 
     with cleanup_processes([writer, reader]):
         writer.start()
-        assert write_acquired.wait(timeout=2), "Write lock not acquired"
+        assert write_acquired.wait(timeout=_PROCESS_DEADLINE), "Write lock not acquired"
 
         start_time = time.time()
         reader.start()
@@ -232,7 +239,7 @@ def test_timeout_behavior(lock_file: str) -> None:
         assert 0.4 <= elapsed <= 10.0, f"Timeout was not respected: {elapsed}s"
 
         release_write.set()
-        writer.join(timeout=2)
+        writer.join(timeout=_PROCESS_DEADLINE)
 
 
 @pytest.mark.timeout(10)
@@ -244,7 +251,7 @@ def test_non_blocking_behavior(lock_file: str) -> None:
 
     with cleanup_processes([writer]):
         writer.start()
-        assert write_acquired.wait(timeout=2), "Write lock not acquired"
+        assert write_acquired.wait(timeout=_PROCESS_DEADLINE), "Write lock not acquired"
 
         start_time = time.time()
 
@@ -256,7 +263,7 @@ def test_non_blocking_behavior(lock_file: str) -> None:
         assert elapsed < 0.1, f"Non-blocking took too long: {elapsed}s"
 
         release_write.set()
-        writer.join(timeout=2)
+        writer.join(timeout=_PROCESS_DEADLINE)
 
 
 @pytest.mark.parametrize(
@@ -286,7 +293,7 @@ def test_lock_release_on_process_termination(lock_file: str, mode: Literal["read
     crashing = Process(target=acquire_lock_and_crash, args=(lock_file, mode, lock_acquired))
     crashing.start()
 
-    assert lock_acquired.wait(timeout=2), "Lock not acquired by first process"
+    assert lock_acquired.wait(timeout=_PROCESS_DEADLINE), "Lock not acquired by first process"
 
     write_acquired = Event()
     successor = Process(target=acquire_lock, args=(lock_file, "write", write_acquired))
@@ -294,13 +301,13 @@ def test_lock_release_on_process_termination(lock_file: str, mode: Literal["read
     with cleanup_processes([crashing, successor]):
         time.sleep(0.5)  # let the lock settle before killing the holder
         crashing.terminate()
-        crashing.join(timeout=2)
+        crashing.join(timeout=_PROCESS_DEADLINE)
 
         successor.start()
 
         assert write_acquired.wait(timeout=5), "Lock not acquired after process termination"
 
-        successor.join(timeout=2)
+        successor.join(timeout=_PROCESS_DEADLINE)
         assert not successor.is_alive(), "Successor did not exit cleanly"
 
 

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -47,11 +47,11 @@ def test_read_locks_are_shared(lock_file: str) -> None:
         time.sleep(0.5)  # let reader1 acquire before reader2 starts
         reader2.start()
 
-        assert read1_acquired.wait(timeout=10), f"First read lock not acquired on {lock_file}"
-        assert read2_acquired.wait(timeout=10), f"Second read lock not acquired on {lock_file}"
+        assert read1_acquired.wait(timeout=_PROCESS_DEADLINE), f"First read lock not acquired on {lock_file}"
+        assert read2_acquired.wait(timeout=_PROCESS_DEADLINE), f"Second read lock not acquired on {lock_file}"
 
-        reader1.join(timeout=10)
-        reader2.join(timeout=10)
+        reader1.join(timeout=_PROCESS_DEADLINE)
+        reader2.join(timeout=_PROCESS_DEADLINE)
         assert not reader1.is_alive(), "Reader 1 did not exit cleanly"
         assert not reader2.is_alive(), "Reader 2 did not exit cleanly"
 
@@ -96,7 +96,7 @@ def test_write_lock_excludes_other_write_locks(lock_file: str) -> None:
         pytest.param("read", "write", id="read-blocks-write"),
     ],
 )
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 5)
 def test_lock_excludes_opposite_mode(
     lock_file: str,
     holder_mode: Literal["read", "write"],
@@ -161,9 +161,11 @@ def test_write_non_starvation(lock_file: str) -> None:
         )
         readers.append(reader)
 
+    # The last reader holds until its own wait expires, since the test only releases the chain once the writer is in,
+    # so the writer has to outwait that hold rather than time out first.
     writer = Process(
         target=acquire_lock,
-        args=(lock_file, "write", writer_acquired, None, 20, True, writer_ready, writer_contending),
+        args=(lock_file, "write", writer_acquired, None, _PROCESS_DEADLINE * 2, True, writer_ready, writer_contending),
     )
 
     with cleanup_processes([*readers, writer]):
@@ -181,7 +183,7 @@ def test_write_non_starvation(lock_file: str) -> None:
         with release_count.get_lock():
             releases_before_contending = release_count.value
 
-        assert writer_acquired.wait(timeout=_PROCESS_DEADLINE), "Writer couldn't acquire lock - possible starvation"
+        assert writer_acquired.wait(timeout=_PROCESS_DEADLINE * 2), "Writer couldn't acquire lock - possible starvation"
 
         with release_count.get_lock():
             read_releases = release_count.value - releases_before_contending
@@ -195,7 +197,7 @@ def test_write_non_starvation(lock_file: str) -> None:
             event.set()
 
         for idx, reader in enumerate(readers):
-            reader.join(timeout=10)
+            reader.join(timeout=_PROCESS_DEADLINE)
             assert not reader.is_alive(), f"Reader {idx} did not exit cleanly"
 
 
@@ -243,7 +245,7 @@ def test_timeout_behavior(lock_file: str) -> None:
         writer.join(timeout=_PROCESS_DEADLINE)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_non_blocking_behavior(lock_file: str) -> None:
     write_acquired = Event()
     release_write = Event()
@@ -271,7 +273,7 @@ def test_non_blocking_behavior(lock_file: str) -> None:
     "mode",
     [pytest.param("read", id="read"), pytest.param("write", id="write")],
 )
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_recursive_lock_acquisition(lock_file: str, mode: Literal["read", "write"]) -> None:
     success = Value("i", 0)
     worker = Process(target=recursive_lock, args=(lock_file, mode, success))
@@ -503,7 +505,7 @@ def acquire_lock(
     contending_event: EventType | None = None,
 ) -> None:
     if ready_event:
-        ready_event.wait(timeout=10)
+        ready_event.wait(timeout=_PROCESS_DEADLINE)
 
     lock = ReadWriteLock(lock_file, timeout=timeout, blocking=blocking)
     if contending_event:
@@ -511,7 +513,7 @@ def acquire_lock(
     with lock.read_lock() if mode == "read" else lock.write_lock():
         acquired_event.set()
         if release_event:
-            release_event.wait(timeout=10)
+            release_event.wait(timeout=_PROCESS_DEADLINE)
         else:
             time.sleep(0.5)  # hold briefly to simulate work
 
@@ -551,7 +553,7 @@ def chain_reader(
     next_reader_signal: EventType | None,
     writer_or_prev_signal: EventType,
 ) -> None:
-    start_signal.wait(timeout=10)
+    start_signal.wait(timeout=_PROCESS_DEADLINE)
 
     lock = ReadWriteLock(lock_file)
     with lock.read_lock():
@@ -566,7 +568,7 @@ def chain_reader(
 
         writer_or_prev_signal.set()
 
-        release_signal.wait(timeout=10)
+        release_signal.wait(timeout=_PROCESS_DEADLINE)
 
         with release_count.get_lock():
             release_count.value += 1

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -19,6 +19,9 @@ from tests.read_write_helpers import assert_read_write_lock_state
 # slowly under a loaded suite is not a locking failure. Only a genuine hang waits this out. Each test's own timeout
 # has to outlast the waits it makes, so those are multiples of this rather than bare seconds.
 _PROCESS_DEADLINE: Final[int] = 30
+# Reaping a process that has already been signaled is not a startup wait, and it has to stay under the suite's own
+# per-test timeout so the guard still reports the hang it was put there for.
+_REAP_DEADLINE: Final[int] = 5
 
 if sys.implementation.name == "pypy":
     set_start_method(
@@ -213,7 +216,7 @@ def test_lock_mode_transition_prohibited(lock_file: str, hold_mode: Literal["rea
 
     with cleanup_processes([worker]):
         worker.start()
-        worker.join(timeout=5)
+        worker.join(timeout=_PROCESS_DEADLINE)
         assert not worker.is_alive(), "Process did not exit cleanly"
 
     assert result.value == 0, f"Illegal {hold_mode} transition was permitted"
@@ -236,7 +239,7 @@ def test_timeout_behavior(lock_file: str) -> None:
         reader.start()
 
         assert not read_acquired.wait(timeout=1), "Read lock should not be acquired"
-        reader.join(timeout=5)
+        reader.join(timeout=_PROCESS_DEADLINE)
 
         elapsed = time.time() - start_time
         assert 0.4 <= elapsed <= 10.0, f"Timeout was not respected: {elapsed}s"
@@ -280,7 +283,7 @@ def test_recursive_lock_acquisition(lock_file: str, mode: Literal["read", "write
 
     with cleanup_processes([worker]):
         worker.start()
-        worker.join(timeout=5)
+        worker.join(timeout=_PROCESS_DEADLINE)
 
     assert success.value == 1, "Recursive lock acquisition failed"
 
@@ -304,11 +307,11 @@ def test_lock_release_on_process_termination(lock_file: str, mode: Literal["read
     with cleanup_processes([crashing, successor]):
         time.sleep(0.5)  # let the lock settle before killing the holder
         crashing.terminate()
-        crashing.join(timeout=_PROCESS_DEADLINE)
+        crashing.join(timeout=_REAP_DEADLINE)
 
         successor.start()
 
-        assert write_acquired.wait(timeout=5), "Lock not acquired after process termination"
+        assert write_acquired.wait(timeout=_PROCESS_DEADLINE), "Lock not acquired after process termination"
 
         successor.join(timeout=_PROCESS_DEADLINE)
         assert not successor.is_alive(), "Successor did not exit cleanly"
@@ -540,7 +543,7 @@ def cleanup_processes(processes: list[Process]) -> Generator[None]:
             # failure that caused it, hiding the real error.
             if proc.pid is not None:
                 proc.terminate()
-                proc.join(timeout=1)
+                proc.join(timeout=_REAP_DEADLINE)
             proc.close()
 
 

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -9,10 +9,15 @@ import textwrap
 from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
-from capability_marks import NEEDS_AUDIT_EVENTS, NEEDS_COLLECTED_FINALIZATION, NEEDS_FORK, NEEDS_FORK1
 from coverage_pragmas import CAPABILITIES
 
 from filelock import ReadWriteLock
+from tests.capability_marks import (
+    NEEDS_AUDIT_EVENTS,
+    NEEDS_COLLECTED_FINALIZATION,
+    NEEDS_FORK,
+    NEEDS_FORK1,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -6,13 +6,20 @@ import signal
 import subprocess  # ruff:ignore[suspicious-subprocess-import]  # isolates process-global audit hooks and fork exits
 import sys
 import textwrap
-from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
-from capability_marks import NEEDS_AUDIT_EVENTS, NEEDS_COLLECTED_FINALIZATION
+from capability_marks import NEEDS_AUDIT_EVENTS, NEEDS_COLLECTED_FINALIZATION, NEEDS_FORK, NEEDS_FORK1
+from coverage_pragmas import CAPABILITIES
 
 from filelock import ReadWriteLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_NEEDS_FD_DIRECTORY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["fd-directory"], reason="counting open descriptors needs a /dev/fd or /proc/self/fd view"
+)
 
 
 @NEEDS_AUDIT_EVENTS
@@ -43,10 +50,7 @@ def test_read_write_lock_closes_idle_connections(tmp_path: Path) -> None:
     assert connection_events == 3
 
 
-@pytest.mark.skipif(
-    not Path("/dev/fd").is_dir() and not Path("/proc/self/fd").is_dir(),
-    reason="no descriptor view",
-)
+@_NEEDS_FD_DIRECTORY
 @NEEDS_COLLECTED_FINALIZATION
 def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) -> None:  # pragma: needs fd-directory
     result = _run_fork_script(_dropped_instances_script(), [str(tmp_path)], timeout=10)
@@ -54,7 +58,7 @@ def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) 
     assert result == (0, "", "")
 
 
-@pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="requires fork transitions")  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @NEEDS_COLLECTED_FINALIZATION
 def test_async_read_write_lock_allows_finalizer_reentry(tmp_path: Path) -> None:
     result = _run_fork_script(
@@ -164,7 +168,7 @@ def test_read_write_lock_serializes_other_thread_operation_during_acquisition(
     assert (result.returncode, result.stderr) == (0, "")
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @pytest.mark.parametrize(
     ("mode", "fork_name", "reject_audit_hook"),
     [
@@ -175,14 +179,14 @@ def test_read_write_lock_serializes_other_thread_operation_during_acquisition(
             "read",
             "fork1",
             False,
-            marks=pytest.mark.skipif(not hasattr(os, "fork1"), reason="requires os.fork1"),
+            marks=NEEDS_FORK1,
             id="read-fork1",
         ),
         pytest.param(
             "write",
             "fork1",
             False,
-            marks=pytest.mark.skipif(not hasattr(os, "fork1"), reason="requires os.fork1"),
+            marks=NEEDS_FORK1,
             id="write-fork1",
         ),
     ],
@@ -207,7 +211,7 @@ def test_read_write_lock_survives_normal_fork_child_exit(
     assert result == (0, "", "")
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_read_write_lock_fork_waits_for_sqlite_operation(tmp_path: Path) -> None:
     result = _run_fork_script(_fork_during_sqlite_script(), [str(tmp_path / "fork-gate.db")], timeout=15)
 
@@ -239,7 +243,7 @@ def test_read_write_lock_fork_at_sqlite_boundary_exits_child(  # pragma: needs f
     assert result == (0, "", "")
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_read_write_lock_idle_fork_handles_fresh_child_lock(tmp_path: Path) -> None:
     result = _run_fork_script(_idle_fork_script(), [str(tmp_path / "idle-fork.db")], timeout=10)
 
@@ -273,14 +277,14 @@ def test_fork_script_terminates_timed_out_process_group() -> None:
         _run_fork_script("import time; time.sleep(10)", [], timeout=0.01)
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 def test_read_write_lock_subclass_cache_resets_after_fork(tmp_path: Path) -> None:
     result = _run_fork_script(_subclass_fork_script(), [str(tmp_path / "subclass-fork.db")], timeout=10)
 
     assert result == (0, "", "")
 
 
-@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")  # pragma: needs fork
+@NEEDS_FORK  # pragma: needs fork
 @pytest.mark.parametrize("held", [pytest.param(False, id="idle"), pytest.param(True, id="held")])
 def test_async_read_write_lock_fork_behavior(tmp_path: Path, held: bool) -> None:
     result = _run_fork_script(

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -10,10 +10,12 @@ from pathlib import Path
 from typing import Literal
 
 import pytest
+from capability_marks import NEEDS_AUDIT_EVENTS, NEEDS_COLLECTED_FINALIZATION
 
 from filelock import ReadWriteLock
 
 
+@NEEDS_AUDIT_EVENTS
 def test_read_write_lock_closes_idle_connections(tmp_path: Path) -> None:
     lock_path = tmp_path / "idle.db"
     connection_events = 0
@@ -45,6 +47,7 @@ def test_read_write_lock_closes_idle_connections(tmp_path: Path) -> None:
     not Path("/dev/fd").is_dir() and not Path("/proc/self/fd").is_dir(),
     reason="no descriptor view",
 )
+@NEEDS_COLLECTED_FINALIZATION
 def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) -> None:  # pragma: needs fd-directory
     result = _run_fork_script(_dropped_instances_script(), [str(tmp_path)], timeout=10)
 
@@ -52,6 +55,7 @@ def test_read_write_lock_dropped_instances_leave_no_descriptors(tmp_path: Path) 
 
 
 @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="requires fork transitions")  # pragma: needs fork
+@NEEDS_COLLECTED_FINALIZATION
 def test_async_read_write_lock_allows_finalizer_reentry(tmp_path: Path) -> None:
     result = _run_fork_script(
         _reentrant_finalizer_script(),
@@ -76,7 +80,7 @@ def test_read_write_lock_subclass_has_independent_singletons(tmp_path: Path) -> 
 @pytest.mark.parametrize(
     "audit_event",
     [
-        pytest.param("sqlite3.connect", id="sqlite-connect"),
+        pytest.param("sqlite3.connect", marks=NEEDS_AUDIT_EVENTS, id="sqlite-connect"),
         pytest.param(
             "ctypes.dlsym",
             marks=pytest.mark.skipif(
@@ -123,6 +127,7 @@ def test_read_write_lock_escrow_ignores_shared_ctypes_signatures(tmp_path: Path)
         pytest.param("close", id="close"),
     ],
 )
+@NEEDS_AUDIT_EVENTS
 def test_read_write_lock_rejects_same_thread_operation_during_acquisition(
     tmp_path: Path, operation: Literal["acquire", "release", "close"]
 ) -> None:
@@ -144,6 +149,7 @@ def test_read_write_lock_rejects_same_thread_operation_during_acquisition(
         pytest.param("close", id="close"),
     ],
 )
+@NEEDS_AUDIT_EVENTS
 def test_read_write_lock_serializes_other_thread_operation_during_acquisition(
     tmp_path: Path, operation: Literal["release", "close"]
 ) -> None:

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -5,6 +5,7 @@ import threading
 from typing import TYPE_CHECKING, Literal
 
 import pytest
+from capability_marks import NEEDS_GENERATOR_EXCEPTION_CONTEXT
 
 pytest.importorskip("sqlite3")
 
@@ -618,6 +619,7 @@ def test_meta_raises_when_pid_changes_during_singleton_construction(lock_file: s
         _Sub(lock_file)
 
 
+@NEEDS_GENERATOR_EXCEPTION_CONTEXT
 def test_finish_connection_chains_rollback_then_close_error(lock_file: str, mocker: MockerFixture) -> None:
     lock = ReadWriteLock(lock_file, is_singleton=False)
     con = mocker.MagicMock()

--- a/tests/test_read_write_unit.py
+++ b/tests/test_read_write_unit.py
@@ -5,7 +5,8 @@ import threading
 from typing import TYPE_CHECKING, Literal
 
 import pytest
-from capability_marks import NEEDS_GENERATOR_EXCEPTION_CONTEXT
+
+from tests.capability_marks import NEEDS_GENERATOR_EXCEPTION_CONTEXT
 
 pytest.importorskip("sqlite3")
 

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -11,7 +11,6 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
 import pytest
-from capability_marks import NEEDS_UNLINK_OPEN_FILE
 
 from filelock import (
     FileLock,
@@ -21,6 +20,7 @@ from filelock import (
     StrictSoftFileLock,
     Timeout,
 )
+from tests.capability_marks import NEEDS_UNLINK_OPEN_FILE
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -8,10 +8,10 @@ from contextlib import suppress
 from errno import EIO, ENOENT
 from threading import Thread
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Final, cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capability_marks import NEEDS_UNLINK_OPEN_FILE
 
 from filelock import (
     FileLock,
@@ -34,10 +34,6 @@ _HEARTBEAT: float = 0.1
 
 #: Taking a claim from a live holder means removing its marker while the holder still has it open. Where that is
 #: refused, a lease only reclaims once the holder exits and its handle closes.
-_NEEDS_UNLINK_OPEN_FILE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["unlink-open-file"],
-    reason="this runtime keeps an open marker undeletable, so no peer can take it from a live holder",
-)
 
 
 @pytest.fixture
@@ -95,7 +91,7 @@ def test_lease_heartbeat_keeps_a_live_claim_past_its_duration(marker: Path) -> N
             _lease(marker).acquire()
 
 
-@_NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
+@NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
 def test_lease_peer_takes_an_expired_claim(marker: Path, mocker: MockerFixture) -> None:
     # A wedged holder: its marker stays on disk, but no refresh ever lands on it again, so the claim ages out.
     mocker.patch("filelock._lease.touch")
@@ -131,7 +127,7 @@ def test_lease_reclaims_a_dead_same_host_holder(marker: Path) -> None:
         assert lease.is_lock_held_by_us
 
 
-@_NEEDS_UNLINK_OPEN_FILE
+@NEEDS_UNLINK_OPEN_FILE
 def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None:  # pragma: needs unlink-open-file
     seen: list[LeaseCompromise] = []
     lease = _lease(marker, on_compromise=seen.append)
@@ -144,7 +140,7 @@ def test_lease_reports_compromise_when_the_marker_vanishes(marker: Path) -> None
     assert [(c.reason, c.token, c.lock_file) for c in seen] == [("marker-missing", token, str(marker))]
 
 
-@_NEEDS_UNLINK_OPEN_FILE
+@NEEDS_UNLINK_OPEN_FILE
 def test_lease_reports_compromise_when_a_peer_takes_over(marker: Path) -> None:  # pragma: needs unlink-open-file
     seen: list[LeaseCompromise] = []
     holder = _lease(marker, on_compromise=seen.append)
@@ -198,7 +194,7 @@ def test_lease_tolerates_a_transient_refresh_error(marker: Path, mocker: MockerF
         assert lease.compromise is None
 
 
-@_NEEDS_UNLINK_OPEN_FILE
+@NEEDS_UNLINK_OPEN_FILE
 def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:  # pragma: needs unlink-open-file
     seen: list[LeaseCompromise] = []
     lease = _lease(marker, on_compromise=seen.append)
@@ -210,7 +206,7 @@ def test_lease_reports_one_compromise_per_claim(marker: Path) -> None:  # pragma
     assert len(seen) == 1
 
 
-@_NEEDS_UNLINK_OPEN_FILE
+@NEEDS_UNLINK_OPEN_FILE
 def test_lease_records_the_compromise_without_a_callback(marker: Path) -> None:  # pragma: needs unlink-open-file
     lease = _lease(marker)
 
@@ -231,7 +227,7 @@ def test_lease_holds_an_uncompromised_claim(marker: Path) -> None:
         assert lease.compromise is None
 
 
-@_NEEDS_UNLINK_OPEN_FILE
+@NEEDS_UNLINK_OPEN_FILE
 def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> None:  # pragma: needs unlink-open-file
     # The callback runs on the heartbeat thread, so releasing from it needs a context that thread can see, and it must
     # not deadlock joining itself.
@@ -257,7 +253,7 @@ def test_lease_can_be_released_from_the_compromise_callback(marker: Path) -> Non
     assert not lease.is_locked
 
 
-@_NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
+@NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
 def test_lease_release_from_the_callback_needs_a_shared_context(marker: Path) -> None:
     # With the default thread-local context the heartbeat thread sees no claim of its own, so its release() does
     # nothing. Pin the trap the docstring warns about.

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -11,12 +11,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 import pytest
-from capability_marks import NEEDS_POSIX_SIGNALS, NEEDS_SYMLINK, NEEDS_UNLINK_OPEN_FILE
 from coverage_pragmas import CAPABILITIES
 
 from filelock import CloseErrorPolicy, SoftFileLock
 from filelock._identity import process_start_token
 from filelock._soft import _MAX_LOCK_FILE_SIZE
+from tests.capability_marks import NEEDS_POSIX_SIGNALS, NEEDS_SYMLINK, NEEDS_UNLINK_OPEN_FILE
 
 if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
     from builtins import ExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gc
 import os
-import signal
 import socket
 import sys
 import threading
@@ -12,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 import pytest
+from capability_marks import NEEDS_POSIX_SIGNALS, NEEDS_SYMLINK, NEEDS_UNLINK_OPEN_FILE
 from coverage_pragmas import CAPABILITIES
 
 from filelock import CloseErrorPolicy, SoftFileLock
@@ -29,15 +29,6 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_NEEDS_POSIX_SIGNALS: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not hasattr(signal, "SIGKILL"), reason="liveness is probed with os.kill only where POSIX signals exist"
-)
-_NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["symlink"], reason="creating a symlink needs a privilege this runtime does not grant"
-)
-_NEEDS_UNLINK_OPEN_FILE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["unlink-open-file"], reason="a successor cannot replace a marker this runtime keeps undeletable"
-)
 _WINDOWS_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform != "win32", reason="windows-only")
 
 _HOST: Final[str] = socket.gethostname()
@@ -118,7 +109,7 @@ def test_live_process_without_start_token_falls_back_to_pid(lock_path: Path) -> 
     _assert_times_out(lock_path)
 
 
-@_NEEDS_POSIX_SIGNALS  # pragma: needs posix-signals
+@NEEDS_POSIX_SIGNALS  # pragma: needs posix-signals
 @pytest.mark.parametrize(
     "errno",
     [pytest.param(EPERM, id="eperm"), pytest.param(ENODEV, id="unexpected_device")],
@@ -191,7 +182,7 @@ def test_stale_lock_rename_race(lock_path: Path, mocker: MockerFixture) -> None:
     _assert_times_out(lock_path)
 
 
-@_NEEDS_SYMLINK
+@NEEDS_SYMLINK
 def test_symlinked_lock_file_is_not_followed(tmp_path: Path, lock_path: Path) -> None:  # pragma: needs symlink
     target = tmp_path / "target"
     target.write_text(_holder(99999), encoding="utf-8")
@@ -477,7 +468,7 @@ def test_del_suppresses_a_release_error(lock_path: Path, mocker: MockerFixture) 
     gc.collect()
 
 
-@_NEEDS_UNLINK_OPEN_FILE
+@NEEDS_UNLINK_OPEN_FILE
 def test_stale_release_spares_a_successor(lock_path: Path) -> None:  # pragma: needs unlink-open-file
     holder = SoftFileLock(lock_path)
     holder.acquire()
@@ -588,7 +579,7 @@ def test_second_release_does_not_close_reused_descriptor(
         os.close(reused_fd)
 
 
-@_NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
+@NEEDS_UNLINK_OPEN_FILE  # pragma: needs unlink-open-file
 def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixture) -> None:
     holder = SoftFileLock(lock_path)
     holder.acquire()

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -203,16 +203,16 @@ def test_symlinked_lock_file_is_not_followed(tmp_path: Path, lock_path: Path) ->
 
 
 def test_fifo_lock_file_does_not_block(lock_path: Path) -> None:
-    if sys.platform == "win32":  # pragma: win32 cover
-        pytest.skip("os.mkfifo is unix-only")
+    if sys.platform == "win32" or not CAPABILITIES["fifo"]:  # pragma: win32 cover
+        pytest.skip("os.mkfifo is unavailable")  # the platform arm also narrows so ty resolves os.mkfifo below
     # An attacker-placed FIFO must not stall the open; O_NONBLOCK makes the read bail instead of hang.
     os.mkfifo(lock_path)  # pragma: win32 no cover
     assert SoftFileLock(lock_path).pid is None  # pragma: win32 no cover
 
 
 def test_fifo_lock_file_with_attached_writer_self_heals(lock_path: Path) -> None:
-    if sys.platform == "win32":  # pragma: win32 cover
-        pytest.skip("os.mkfifo is unix-only")
+    if sys.platform == "win32" or not CAPABILITIES["fifo"]:  # pragma: win32 cover
+        pytest.skip("os.mkfifo is unavailable")  # the platform arm also narrows so ty resolves os.mkfifo below
     # A same-UID peer can plant a FIFO with a writer attached so a non-blocking read would raise EAGAIN. The lstat
     # guard classifies it as a malformed lock before any open, so an aged FIFO self-heals like any other node.
     os.mkfifo(lock_path)  # pragma: win32 no cover

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 import pytest
+from capability_marks import NEEDS_FILE_MODE
 
 if sys.version_info >= (3, 11):
     from builtins import ExceptionGroup  # pragma: >=3.11 cover
@@ -34,10 +35,6 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 _SENTINEL: Final[bytes] = b"1\nfilelock-strict-v1\x00\n0\n"
-
-_NEEDS_FILE_MODE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["file-mode"], reason="an unreadable claim needs POSIX permission bits"
-)
 
 
 pytestmark = pytest.mark.requires_hard_links
@@ -286,7 +283,7 @@ def test_strict_soft_rejects_non_directory_coordination_path(tmp_path: Path) -> 
         StrictSoftFileLock(lock_path).acquire()
 
 
-@_NEEDS_FILE_MODE  # pragma: needs file-mode
+@NEEDS_FILE_MODE  # pragma: needs file-mode
 def test_strict_soft_unreadable_claim_fails_closed(tmp_path: Path) -> None:
     lock_path = tmp_path / "resource.lock"
     lock = StrictSoftFileLock(lock_path)

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import os
 import socket
 import sys
@@ -27,7 +28,7 @@ from filelock import (
     Timeout,
 )
 from filelock._identity import process_start_token
-from filelock._strict import _PRIVATE_RECORD_MARKER
+from filelock._strict import _PRIVATE_RECORD_MARKER, _probe_hard_link_unsupported_errnos
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -329,6 +330,25 @@ def test_strict_soft_hard_link_failure_names_filesystem_contract(
 
     with pytest.raises(SoftFileLockProtocolError, match="atomic no-replace hard-link"):
         StrictSoftFileLock(tmp_path / "resource.lock").acquire()
+
+
+@pytest.mark.parametrize(
+    ("defined", "expected"),
+    [
+        pytest.param({"ENOTSUP": 4242, "EOPNOTSUPP": 4343}, {ENOSYS, EXDEV, 4242}, id="enotsup"),
+        pytest.param({"EOPNOTSUPP": 4343}, {ENOSYS, EXDEV, 4343}, id="eopnotsupp"),
+        pytest.param({}, {ENOSYS, EXDEV}, id="neither"),
+    ],
+)
+def test_strict_soft_hard_link_unsupported_errnos(
+    monkeypatch: pytest.MonkeyPatch, defined: dict[str, int], expected: set[int]
+) -> None:
+    for name in ("ENOTSUP", "EOPNOTSUPP"):
+        monkeypatch.delattr(errno, name, raising=False)
+    for name, code in defined.items():
+        monkeypatch.setattr(errno, name, code, raising=False)
+
+    assert _probe_hard_link_unsupported_errnos() == expected
 
 
 def test_strict_soft_write_failure_leaves_no_public_claim(tmp_path: Path, mocker: MockerFixture) -> None:

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 import pytest
-from capability_marks import NEEDS_FILE_MODE
+
+from tests.capability_marks import NEEDS_FILE_MODE
 
 if sys.version_info >= (3, 11):
     from builtins import ExceptionGroup  # pragma: >=3.11 cover

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -31,6 +31,13 @@ _NEEDS_DIR_FD: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     reason="injects a fault into the dir_fd cleanup path, which a runtime without dir_fd never executes",
 )
 
+# Narrower still: GraalPy takes os.open relative to a directory descriptor but not os.link, so the backend never opens
+# the directory these two faults are counted against.
+_NEEDS_LINK_DIR_FD: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    not CAPABILITIES["link-dir-fd"],
+    reason="counts the directory the dir_fd link path opens, which a runtime without link dir_fd never opens",
+)
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -375,6 +382,7 @@ def test_strict_soft_link_and_directory_close_failures_preserve_both(tmp_path: P
 
 
 @_NEEDS_DIR_FD  # pragma: needs dir-fd
+@_NEEDS_LINK_DIR_FD  # pragma: needs link-dir-fd
 def test_strict_soft_held_directory_close_failure_leaves_both_claims(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)
@@ -1315,6 +1323,7 @@ def test_strict_soft_acquires_without_dir_fd(tmp_path: Path, mocker: MockerFixtu
 
 
 @_NEEDS_DIR_FD  # pragma: needs dir-fd
+@_NEEDS_LINK_DIR_FD  # pragma: needs link-dir-fd
 def test_strict_soft_held_link_and_directory_close_failure(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)

--- a/tests/test_strict_soft_paths.py
+++ b/tests/test_strict_soft_paths.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
@@ -10,7 +9,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Final
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capability_marks import NEEDS_PARENT_SYMLINK_COLLAPSE, NEEDS_SYMLINK
 
 from filelock import AsyncStrictSoftFileLock, StrictSoftFileLock, Timeout
 
@@ -19,15 +18,8 @@ if TYPE_CHECKING:
 
 _STRICT_SENTINEL: Final[bytes] = b"1\nfilelock-strict-v1\x00\n0\n"
 
-_NEEDS_SYMLINK: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["symlink"], reason="creating a symlink needs Developer Mode or SeCreateSymbolicLinkPrivilege"
-)
 
 # Windows resolves a lock's parent with abspath, so a symlinked parent stays a distinct key and never collapses.
-_NEEDS_PARENT_SYMLINK_COLLAPSE: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    not CAPABILITIES["symlink"] or sys.platform == "win32",
-    reason="a symlinked parent collapses into one key only where the parent is resolved with realpath",
-)
 
 
 pytestmark = pytest.mark.requires_hard_links
@@ -123,7 +115,7 @@ async def test_async_strict_soft_waiter_keeps_acquisition_directory(
         await contender.release(force=True)
 
 
-@_NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
+@NEEDS_PARENT_SYMLINK_COLLAPSE  # pragma: win32 no cover
 def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> None:
     original = tmp_path / "original"
     replacement = tmp_path / "replacement"
@@ -149,7 +141,7 @@ def test_strict_soft_release_uses_original_symlink_parent(tmp_path: Path) -> Non
         replacement_holder.release(force=True)
 
 
-@_NEEDS_SYMLINK  # pragma: needs symlink
+@NEEDS_SYMLINK  # pragma: needs symlink
 def test_strict_soft_final_symlink_fails_closed_without_touching_target(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.write_bytes(_STRICT_SENTINEL)

--- a/tests/test_strict_soft_paths.py
+++ b/tests/test_strict_soft_paths.py
@@ -9,9 +9,9 @@ from functools import partial
 from typing import TYPE_CHECKING, Final
 
 import pytest
-from capability_marks import NEEDS_PARENT_SYMLINK_COLLAPSE, NEEDS_SYMLINK
 
 from filelock import AsyncStrictSoftFileLock, StrictSoftFileLock, Timeout
+from tests.capability_marks import NEEDS_PARENT_SYMLINK_COLLAPSE, NEEDS_SYMLINK
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/test_strict_soft_stress.py
+++ b/tests/test_strict_soft_stress.py
@@ -14,6 +14,11 @@ if TYPE_CHECKING:
 
 _PROCESS_COUNT: Final[int] = 8
 _ACQUISITIONS_PER_PROCESS: Final[int] = 500
+# A guard against a deadlock, not a throughput assertion: overlap fails immediately through the markers below, so this
+# budget only bounds a hang. The four thousand contended acquisitions cost CPython about three seconds and GraalPy about
+# twenty-eight on a ten-core machine, and the CI runners have far fewer, so it is sized for the slowest interpreter on
+# the smallest runner rather than for the fastest, which is what a seventy-five second guard encoded.
+_WORKER_DEADLINE: Final[int] = 300
 # Catch overlap two independent ways. An occupancy marker fails immediately the instant a second holder enters the
 # critical section, and a counter read-modify-write fails afterwards when two holders read the same value and one
 # increment vanishes. Both beat an O_EXCL create/unlink pair, which tripped over Windows' delete-pending lag where the
@@ -44,7 +49,7 @@ for _ in range(int(sys.argv[5])):
 pytestmark = pytest.mark.requires_hard_links
 
 
-@pytest.mark.timeout(90)
+@pytest.mark.timeout(_WORKER_DEADLINE + 60)
 def test_strict_soft_eight_process_contention_has_no_overlap(tmp_path: Path) -> None:
     lock_path = tmp_path / "resource.lock"
     start_path = tmp_path / "start"
@@ -71,13 +76,13 @@ def test_strict_soft_eight_process_contention_has_no_overlap(tmp_path: Path) -> 
         for _ in range(_PROCESS_COUNT)
     ]
     start_path.touch()
-    deadline = time.monotonic() + 75
+    deadline = time.monotonic() + _WORKER_DEADLINE
     outputs: list[tuple[str, str]] = []
     try:
         outputs.extend(process.communicate(timeout=max(0.1, deadline - time.monotonic())) for process in processes)
     except subprocess.TimeoutExpired:  # pragma: no cover - test failure cleanup
         _kill_processes(processes)
-        pytest.fail("strict soft-lock stress workers exceeded 75 seconds")
+        pytest.fail(f"strict soft-lock stress workers exceeded {_WORKER_DEADLINE} seconds")
 
     recorded = int(counter_path.read_text()) if counter_path.exists() else 0
     assert ([process.returncode for process in processes], recorded) == (

--- a/tests/test_subclass_options.py
+++ b/tests/test_subclass_options.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING, Literal, Protocol, TypedDict, cast
 from weakref import ref
 
 import pytest
-from capability_marks import NEEDS_CLASS_COLLECTION
 
 from filelock import BaseAsyncFileLock, BaseFileLock, CloseErrorPolicy, ContextErrorPolicy
+from tests.capability_marks import NEEDS_CLASS_COLLECTION
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/tests/test_subclass_options.py
+++ b/tests/test_subclass_options.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Literal, Protocol, TypedDict, cast
 from weakref import ref
 
 import pytest
+from capability_marks import NEEDS_CLASS_COLLECTION
 
 from filelock import BaseAsyncFileLock, BaseFileLock, CloseErrorPolicy, ContextErrorPolicy
 
@@ -217,6 +218,7 @@ def test_forwarding_subclass_singleton_rejects_changed_option(
     assert first.on_acquired is hook
 
 
+@NEEDS_CLASS_COLLECTION
 def test_constructor_model_does_not_retain_dynamic_subclass(tmp_path: Path) -> None:
     lock_type = _dynamic_constructor()
     class_ref = ref(lock_type)

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -5,11 +5,11 @@ import socket
 import subprocess  # ruff:ignore[suspicious-subprocess-import]  # a clean interpreter isolates the blocked fcntl import
 import sys
 from errno import EIO, ENOSYS
-from importlib.util import find_spec
 from textwrap import dedent
 from typing import TYPE_CHECKING, Final
 
 import pytest
+from capability_marks import NEEDS_FCNTL
 
 from filelock import SoftFileLock, UnixFileLock
 from filelock._identity import process_start_token
@@ -20,12 +20,8 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-_NEEDS_FCNTL: Final[pytest.MarkDecorator] = pytest.mark.skipif(
-    find_spec("fcntl") is None, reason="the flock fallback path is driven through the fcntl module"
-)
 
-
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:  # pragma: needs fcntl
     script: Final[str] = dedent(
         """
@@ -70,7 +66,7 @@ def test_import_without_fcntl_uses_soft_aliases_and_descriptor_errors() -> None:
     )
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.usefixtures("unsupported_flock")
 def test_fallback_emits_warning(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock = UnixFileLock(tmp_path / "test.lock")
@@ -80,7 +76,7 @@ def test_fallback_emits_warning(tmp_path: Path) -> None:  # pragma: needs fcntl
     lock.release()
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
 def test_fallback_swaps_to_soft(tmp_path: Path) -> None:  # pragma: needs fcntl
@@ -91,7 +87,7 @@ def test_fallback_swaps_to_soft(tmp_path: Path) -> None:  # pragma: needs fcntl
         assert isinstance(lock, SoftFileLock)
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
 def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:  # pragma: needs fcntl
@@ -105,7 +101,7 @@ def test_fallback_writes_pid_and_hostname(tmp_path: Path) -> None:  # pragma: ne
     assert lines == expected
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
 def test_fallback_release_unlinks_file(tmp_path: Path) -> None:  # pragma: needs fcntl
@@ -118,7 +114,7 @@ def test_fallback_release_unlinks_file(tmp_path: Path) -> None:  # pragma: needs
     assert not lock_path.exists()
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")  # pragma: needs fcntl
 def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, unsupported_flock: MagicMock) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
@@ -132,7 +128,7 @@ def test_fallback_subsequent_acquire_skips_flock(tmp_path: Path, unsupported_flo
     unsupported_flock.assert_not_called()
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 @pytest.mark.filterwarnings("ignore:flock not supported on this filesystem:UserWarning")
 @pytest.mark.usefixtures("unsupported_flock")
 def test_fallback_reentrant_locking(tmp_path: Path) -> None:  # pragma: needs fcntl
@@ -145,7 +141,7 @@ def test_fallback_reentrant_locking(tmp_path: Path) -> None:  # pragma: needs fc
     assert not lock.is_locked
 
 
-@_NEEDS_FCNTL
+@NEEDS_FCNTL
 def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) -> None:  # pragma: needs fcntl
     lock = UnixFileLock(tmp_path / "test.lock")
     lock.acquire()
@@ -163,7 +159,7 @@ def test_release_suppresses_eio_on_close(tmp_path: Path, mocker: MockerFixture) 
     assert not lock.is_locked
 
 
-@_NEEDS_FCNTL  # pragma: needs fcntl
+@NEEDS_FCNTL  # pragma: needs fcntl
 def test_acquire_flock_error_clears_pending_descriptor(tmp_path: Path, mocker: MockerFixture) -> None:
     lock = UnixFileLock(tmp_path / "test.lock")
     mocker.patch(

--- a/tests/test_unix_fallback.py
+++ b/tests/test_unix_fallback.py
@@ -9,10 +9,10 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Final
 
 import pytest
-from capability_marks import NEEDS_FCNTL
 
 from filelock import SoftFileLock, UnixFileLock
 from filelock._identity import process_start_token
+from tests.capability_marks import NEEDS_FCNTL
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tox.toml
+++ b/tox.toml
@@ -182,3 +182,9 @@ commands_pre = [
     "filelock==3.20.0",
   ],
 ]
+
+# tox invents an env on the fly only for a py or pypy factor, so GraalPy has to be declared to be selectable at all. It
+# stays out of env_list because, like PyPy, it is a CI-only check that runs unmeasured and feeds no coverage data: the
+# 100% gate remains CPython's. Its job is to keep the capability probes the suite gates on honest on a second runtime.
+[env."graalpy3.11"]
+description = "run the tests with pytest under {env_name}, unmeasured"

--- a/tox.toml
+++ b/tox.toml
@@ -12,6 +12,9 @@ set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{w
 # tasks holds the coverage_pragmas plugin, which coverage imports by name in this process and in the subprocesses it
 # patches, so it has to resolve from the environment rather than from pytest's sys.path.
 set_env.PYTHONPATH = "{tox_root}{/}tasks"
+# No --cov-context: coverage refuses its sys.monitoring core when contexts are configured, because that core does not
+# implement them, but pytest-cov switches contexts behind that guard. The unsupported pair silently drops lines the
+# suite ran, and it cost BaseAsyncFileLock.__del__'s no-loop path a flaky 99.98% on the 3.14 jobs.
 commands = [
   [
     "pytest",
@@ -27,8 +30,6 @@ commands = [
       "{tox_root}{/}tests",
       "--cov-config",
       "{tox_root}{/}pyproject.toml",
-      "--cov-context",
-      "test",
       "--cov-report",
       "term-missing:skip-covered",
       "--cov-report",


### PR DESCRIPTION
`_strict.py` imports `ENOTSUP` from `errno` at module scope. GraalPy's `errno` does not define it, so importing `filelock` on that runtime raises:

```
ImportError: cannot import name 'ENOTSUP' from 'errno'
```

This breaks every consumer on GraalPy at import, before anyone takes a lock. pypa/virtualenv's GraalPy jobs die at conftest import on its `main`: [ubuntu-24.04](https://github.com/pypa/virtualenv/actions/runs/29730396773/job/88313263808) and [macos-15](https://github.com/pypa/virtualenv/actions/runs/29730396773/job/88313263782). virtualenv requires `filelock>=3.24.2,<4`, so it resolves to a release carrying the import. `ENOTSUP` arrived with the claim protocol in #659 and shipped first in 3.30.0. GraalPy 24.1, 24.2 and 25.1 all omit the name, so this is not a single bad release.

## The fix

`_strict.py` now probes the code instead of importing it.

- `ENOTSUP` wins wherever it exists, so no platform that defines the name changes behavior.
- `EOPNOTSUPP` stands in only for runtimes that lack `ENOTSUP`. It approximates rather than matches: the two agree on Linux and differ on macOS/BSD (45 against 102) and on Windows (129 against 130).
- Where neither exists, the code drops out and `ENOSYS`/`EXDEV` still classify the link failures such a runtime can raise.

The probe follows the module's existing convention (`_probe_link_follow_symlinks`) and runs once at import.

## Four changes ride along

**A coverage measurement bug.** `BaseAsyncFileLock.__del__`'s no-loop path reported its `except RuntimeError` and the following `return` as missing while the handler body between them reported covered, which no execution can produce. coverage refuses its `sys.monitoring` core when a config sets contexts, since that core does not implement them. pytest-cov's `--cov-context` switches contexts through another path, behind that guard. Every 3.14 job had been running the combination coverage rules out, and the seed decided which lines went missing. Dropping `--cov-context` fixes it. Pinning the C tracer does not: Termux ships coverage without the extension.

**A GraalPy CI job.** Linux only, and unmeasured like PyPy, so the 100% gate stays CPython's. Nothing else checks the capability probes against a second runtime.

**Capability gating.** GraalPy ran the suite with 55 failures, none of them filelock defects. Each now gates on a probe of the behavior it needs. Three turned out to be real test bugs, so I fixed those rather than gating them. Twenty cancellation tests carry a non-strict xfail against a GraalPy `contextlib` that answers `athrow()` with `RuntimeError`.

**One gate registry.** Seven marks had been redefined per module, `fcntl` in six and `fork` in five, and three re-derived their answer inline instead of reading the probe. That last one hid a bug: GraalPy registers fork handlers without being able to fork, so a capability asking for both skipped four tests needing only the registration.

## Verification

| Runtime | Result |
| --- | --- |
| CPython 3.14 | 1239 passed, 52 skipped, 100% total and diff coverage |
| GraalPy 24.2.2 | 1105 passed, 153 skipped, 28 xfailed, 5 xpassed |
| PyPy 3.11 | 1226 passed, 65 skipped |

`ty` and `pre-commit` clean. `src/filelock` gains only the probe, and no pre-existing capability value changes on CPython, so it measures the lines it measured before.
