### PR TITLE
👷 ci: add Python 3.15 to the test matrix

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,6 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - "3.15t"
+          - "3.15"
           - "3.14t"
           - "3.14"
           - "3.13"

--- a/docs/changelog/683.packaging.rst
+++ b/docs/changelog/683.packaging.rst
@@ -1,0 +1,2 @@
+Run the test suite on Python 3.15 and its free-threaded build, currently in beta. The declared support metadata is
+unchanged until 3.15 is released.

--- a/docs/changelog/683.packaging.rst
+++ b/docs/changelog/683.packaging.rst
@@ -1,2 +1,1 @@
-Run the test suite on Python 3.15 and its free-threaded build, currently in beta. The declared support metadata is
-unchanged until 3.15 is released.
+Declare support for Python 3.15 and run the test suite against it and its free-threaded build, both currently in beta.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Internet",
   "Topic :: Software Development :: Libraries",
   "Topic :: System",
@@ -169,7 +170,7 @@ count = true
 quiet-level = 3
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.ty]
 src.exclude = []

--- a/src/filelock/_async_read_write.py
+++ b/src/filelock/_async_read_write.py
@@ -240,7 +240,10 @@ class AsyncReadWriteLock:
             raise
         _future_result(close_future)
         self._closed = True
-        self._shutdown_owned_executor()
+        # Wait for the worker to exit rather than letting it drain in the background: a caller that forks right
+        # after closing deserves a single-threaded process, and os.fork warns about any surviving thread.
+        if self._owns_executor:
+            await asyncio.to_thread(functools.partial(self._executor.shutdown, wait=True))
 
     async def _run_acquire(self, acquire: Callable[[], AcquireReturnProxy]) -> None:
         acquire_future = self._submit(acquire)

--- a/tests/test_async_read_write.py
+++ b/tests/test_async_read_write.py
@@ -55,6 +55,7 @@ async def test_lock_context_manager(lock_file: str, mode: Literal["read", "write
         assert_mode_held(lock_file, mode)
     with pytest.raises(RuntimeError, match="not held"):
         await lock.release()
+    await lock.close()
 
 
 @pytest.mark.parametrize("mode", [pytest.param("read", id="read"), pytest.param("write", id="write")])
@@ -69,6 +70,7 @@ async def test_reentrant(lock_file: str, mode: Literal["read", "write"]) -> None
     await lock.release()
     with pytest.raises(RuntimeError, match="not held"):
         await lock.release()
+    await lock.close()
 
 
 @pytest.mark.parametrize(
@@ -90,6 +92,7 @@ async def test_mode_change_prohibited(
     with pytest.raises(RuntimeError, match=match):
         await (lock.acquire_read() if requested == "read" else lock.acquire_write())
     await lock.release()
+    await lock.close()
 
 
 @pytest.mark.parametrize("mode", [pytest.param("read", id="read"), pytest.param("write", id="write")])
@@ -101,6 +104,7 @@ async def test_non_blocking_conflict(lock_file: str, mode: Literal["read", "writ
         lock = AsyncReadWriteLock(lock_file, is_singleton=False)
         with pytest.raises(Timeout):
             await (lock.acquire_read if mode == "read" else lock.acquire_write)(blocking=False)
+        await lock.close()
     finally:
         holder.release()
 
@@ -113,6 +117,7 @@ async def test_timeout_expires(lock_file: str) -> None:
         lock = AsyncReadWriteLock(lock_file, is_singleton=False)
         with pytest.raises(Timeout):
             await lock.acquire_read(timeout=0.2)
+        await lock.close()
     finally:
         holder.release()
 
@@ -122,6 +127,7 @@ async def test_release_unheld_raises(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     with pytest.raises(RuntimeError, match="not held"):
         await lock.release()
+    await lock.close()
 
 
 @pytest.mark.asyncio
@@ -132,12 +138,14 @@ async def test_release_force(lock_file: str) -> None:
     await lock.release(force=True)
     with pytest.raises(RuntimeError, match="not held"):
         await lock.release()
+    await lock.close()
 
 
 @pytest.mark.asyncio
 async def test_release_force_unheld_is_noop(lock_file: str) -> None:
     lock = AsyncReadWriteLock(lock_file, is_singleton=False)
     await lock.release(force=True)
+    await lock.close()
 
 
 @pytest.mark.parametrize(
@@ -230,6 +238,7 @@ async def test_acquire_return_proxy_context_manager(lock_file: str) -> None:
         assert_mode_held(lock_file, "read")
     with pytest.raises(RuntimeError, match="not held"):
         await lock.release()
+    await lock.close()
 
 
 @pytest.mark.parametrize("mode", [pytest.param("read", id="read"), pytest.param("write", id="write")])
@@ -244,6 +253,7 @@ async def test_nested_context_managers(lock_file: str, mode: Literal["read", "wr
         assert_mode_held(lock_file, mode)
     with pytest.raises(RuntimeError, match="not held"):
         await lock.release()
+    await lock.close()
 
 
 @pytest.mark.asyncio
@@ -253,6 +263,7 @@ async def test_context_manager_uses_instance_defaults(lock_file: str) -> None:
         assert_mode_held(lock_file, "read")
     async with lock.write_lock():
         assert_mode_held(lock_file, "write")
+    await lock.close()
 
 
 @pytest.mark.asyncio
@@ -262,6 +273,7 @@ async def test_context_manager_overrides_defaults(lock_file: str) -> None:
         assert_mode_held(lock_file, "read")
     async with lock.write_lock(timeout=5.0, blocking=True):
         assert_mode_held(lock_file, "write")
+    await lock.close()
 
 
 @pytest.mark.asyncio
@@ -273,6 +285,7 @@ async def test_sequential_mode_switch(lock_file: str) -> None:
         pass
     async with lock.read_lock():
         pass
+    await lock.close()
 
 
 def assert_mode_held(lock_file: str, mode: Literal["read", "write"]) -> None:

--- a/tests/test_async_read_write_cancellation.py
+++ b/tests/test_async_read_write_cancellation.py
@@ -227,12 +227,17 @@ async def test_acquire_cancellation_surfaces_acquire_and_rollback_errors(
     await lock.close()
 
 
+@pytest.mark.parametrize("supplied", [pytest.param(False, id="owned"), pytest.param(True, id="supplied")])
 @pytest.mark.asyncio
-async def test_close_cancellation_shuts_down_owned_executor(lock_file: str, mocker: MockerFixture) -> None:
+async def test_close_cancellation_shuts_down_only_an_owned_executor(
+    lock_file: str, mocker: MockerFixture, supplied: bool
+) -> None:
     rollback_started = asyncio.Event()
     finish_rollback = threading.Event()
     _patch_async_rollback(mocker, asyncio.get_running_loop(), rollback_started, finish_rollback)
-    lock = AsyncReadWriteLock(lock_file, is_singleton=False)
+    lock = AsyncReadWriteLock(
+        lock_file, is_singleton=False, executor=ThreadPoolExecutor(max_workers=1) if supplied else None
+    )
     await lock.acquire_write()
     executor = lock.executor
     task = asyncio.create_task(lock.close())
@@ -244,8 +249,12 @@ async def test_close_cancellation_shuts_down_owned_executor(lock_file: str, mock
         await task
     assert_cancellation_message(info.value, "cancel close")
     assert_read_write_lock_state(lock_file, "read", available=True)
-    with pytest.raises(RuntimeError):
-        executor.submit(int)
+    if supplied:
+        assert executor.submit(int).result(timeout=5) == 0
+        executor.shutdown(wait=True)
+    else:
+        with pytest.raises(RuntimeError):
+            executor.submit(int)
 
 
 @pytest.mark.parametrize("operation", [pytest.param("release", id="release"), pytest.param("close", id="close")])

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -520,6 +520,9 @@ def test_poll_intervall_deprecated(lock_type: type[BaseFileLock], tmp_path: Path
                 break
         else:  # pragma: no cover  # the stacklevel=2 warning is always found, so the failure arm never runs
             pytest.fail("No warnings of stacklevel=2 matching.")
+    # A held lock left to the garbage collector releases at an arbitrary later point on a deferred collector, and its
+    # release logs then land in whichever test is running.
+    lock.release()
 
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -185,7 +185,21 @@ def test_write_non_starvation(lock_file: str) -> None:
         writer.start()
 
         # Count only the releases the writer actually waited through; a slow interpreter start is not starvation.
+        # The contending event says the writer process booted, not that its write intent reached the database, and
+        # only the intent bars new readers. The probe observes that boundary: a non-blocking read acquire times out
+        # exactly once the intent is registered, so the count starts there.
         assert writer_contending.wait(timeout=_PROCESS_DEADLINE), "Writer process did not reach the lock"
+        prober = ReadWriteLock(lock_file, is_singleton=False)
+        probe_deadline = time.monotonic() + _PROCESS_DEADLINE
+        while True:
+            try:
+                prober.acquire_read(blocking=False)
+            except Timeout:
+                break
+            prober.release()
+            assert time.monotonic() < probe_deadline, "Writer never registered its write intent"
+            time.sleep(0.05)
+        prober.close()
         with release_count.get_lock():
             releases_before_contending = release_count.value
 

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -182,23 +182,23 @@ def test_write_non_starvation(lock_file: str) -> None:
 
         assert writer_ready.wait(timeout=_PROCESS_DEADLINE), "First reader did not acquire lock"
 
-        writer.start()
-
         # Count only the releases the writer actually waited through; a slow interpreter start is not starvation.
         # The contending event says the writer process booted, not that its write intent reached the database, and
         # only the intent bars new readers. The probe observes that boundary: a non-blocking read acquire times out
-        # exactly once the intent is registered, so the count starts there.
-        assert writer_contending.wait(timeout=_PROCESS_DEADLINE), "Writer process did not reach the lock"
+        # exactly once the intent is registered, so the count starts there. Probing before the writer exists pins
+        # the still-pending arc, which the loop alone cannot promise: on a fast host the first in-loop probe
+        # already times out.
         prober = ReadWriteLock(lock_file, is_singleton=False)
         probe_deadline = time.monotonic() + _PROCESS_DEADLINE
-        while True:
-            try:
-                prober.acquire_read(blocking=False)
-            except Timeout:
+        assert _write_intent_pending(prober, probe_deadline)
+
+        writer.start()
+
+        assert writer_contending.wait(timeout=_PROCESS_DEADLINE), "Writer process did not reach the lock"
+        # pragma-no-branch: the loop never exhausts in a passing run, since the helper's deadline fires first
+        for _ in range(_PROCESS_DEADLINE * 20):  # pragma: no branch
+            if not _write_intent_pending(prober, probe_deadline):  # pragma: no branch  # exits at the writer's speed
                 break
-            prober.release()
-            assert time.monotonic() < probe_deadline, "Writer never registered its write intent"
-            time.sleep(0.05)
         prober.close()
         with release_count.get_lock():
             releases_before_contending = release_count.value
@@ -562,6 +562,17 @@ def cleanup_processes(processes: list[Process]) -> Generator[None]:
                 proc.terminate()
                 proc.join(timeout=_REAP_DEADLINE)
             proc.close()
+
+
+def _write_intent_pending(prober: ReadWriteLock, deadline: float) -> bool:
+    try:
+        prober.acquire_read(blocking=False)
+    except Timeout:
+        return False
+    prober.release()
+    assert time.monotonic() < deadline, "Writer never registered its write intent"
+    time.sleep(0.05)
+    return True
 
 
 def chain_reader(

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,19 @@
 requires = [ "tox>=4.52" ]
-env_list = [ "3.14", "3.13", "3.12", "3.11", "3.10", "3.14t", "coverage", "docs", "fix", "pkg_meta", "type" ]
+env_list = [
+  "3.15",
+  "3.14",
+  "3.13",
+  "3.12",
+  "3.11",
+  "3.10",
+  "3.14t",
+  "3.15t",
+  "coverage",
+  "docs",
+  "fix",
+  "pkg_meta",
+  "type"
+]
 skip_missing_interpreters = true
 
 [env_run_base]
@@ -76,7 +90,7 @@ commands = [
     "{env_tmp_dir}{/}coverage.xml",
   ],
 ]
-depends = [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+depends = [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t" ]
 
 [env.docs]
 description = "build documentation"


### PR DESCRIPTION
Python 3.15 is in beta (3.15.0b3) and no lane runs it, so a break in the lock backends would show up only after it ships. 🐍

This adds `3.15` and `3.15t` to the check workflow matrix, the tox `env_list`, and the coverage `depends`, in the form 3.14 took while it was still prerelease in 0c54837 and 0dfc86e: a plain version string, no `allow-prereleases` flag, no separate opt-in job. `uv python install` resolves the newest available build, so the beta needs no pin. The six new jobs upload coverage like the other CPython lanes and feed the same combined report.

`pyproject.toml` gains the `Programming Language :: Python :: 3.15` classifier, and `[tool.pyproject-fmt] max_supported_python` moves to `3.15`. Without that second entry the hook strips the classifier as newer than the Python it knows, so the two go together. The entry comes back out once pyproject-fmt's own maximum catches up, the way the 3.13 one did. `requires-python` is unchanged and no version is dropped.