### PR TITLE
🐛 fix(packaging): let an unpacked sdist run the test suite

### DIFF
--- a/docs/changelog/685.bugfix.rst
+++ b/docs/changelog/685.bugfix.rst
@@ -1,0 +1,2 @@
+``SoftReadWriteLock`` closes the directory handle it opens to scan for readers as soon as a scan stops early, rather
+than holding it until the generator is collected.

--- a/docs/changelog/685.packaging.rst
+++ b/docs/changelog/685.packaging.rst
@@ -1,0 +1,2 @@
+The source distribution ships the capability probes the tests import, and reading one no longer needs ``coverage``
+installed, so the suite runs from an unpacked sdist instead of failing on a missing ``coverage_pragmas``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,10 +198,6 @@ ini_options.markers = [
 ]
 ini_options.filterwarnings = [
   "error",
-  # multiprocessing's leaked Finalize objects clean up descriptors from their own finalizer; that is a CPython
-  # behavior, not a filelock bug, and pytest-randomly can collect one during any test. A filelock finalizer issue
-  # would not carry "Finalize" in the message and still errors.
-  "ignore:Exception ignored in.*Finalize:pytest.PytestUnraisableExceptionWarning",
   "ignore:unclosed database in <sqlite3.Connection object at:ResourceWarning",
   "ignore:unclosed file <_io.TextIOWrapper:ResourceWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,10 @@ ini_options.markers = [
 ]
 ini_options.filterwarnings = [
   "error",
+  # CPython's resource tracker refuses to unregister a semaphore while it is already cleaning up, and warns instead.
+  # multiprocessing.Event and Value expose no close, so only the collector frees them, and it picks the moment. Seen
+  # on 3.12 alone. Filtering the tracker's own warning keeps the finalizer from raising rather than hiding the raise.
+  "ignore:ResourceTracker called reentrantly for resource cleanup:UserWarning",
 ]
 ini_options.verbosity_assertions = 2
 ini_options.asyncio_default_fixture_loop_scope = "session"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ version.source = "vcs"
 build.hooks.vcs.version-file = "src/filelock/version.py"
 build.targets.sdist.include = [
   "/src",
+  "/tasks",
   "/tests",
   "/tox.toml",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,8 +198,6 @@ ini_options.markers = [
 ]
 ini_options.filterwarnings = [
   "error",
-  "ignore:unclosed database in <sqlite3.Connection object at:ResourceWarning",
-  "ignore:unclosed file <_io.TextIOWrapper:ResourceWarning",
 ]
 ini_options.verbosity_assertions = 2
 ini_options.asyncio_default_fixture_loop_scope = "session"

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -656,9 +656,8 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         ``dirfd_relative`` is ``True`` when *name* should be passed to ``dir_fd=``-aware syscalls; ``False``
         when *name* is a full path because dirfd-relative I/O is unavailable on this platform.
 
-        A consumer that stops early must close this generator (``contextlib.closing``); while it is suspended the
-        ``scandir`` handle below stays open, and leaving it to the collector surfaces as an unraisable exception
-        inside whatever runs next.
+        A consumer that stops early must close this generator: while suspended it holds the ``scandir`` handle open,
+        and leaving that to the collector surfaces as an unraisable exception inside whatever runs next.
         """
         if self._readers_dir_fd is not None:  # pragma: needs dir-fd
             with os.scandir(self._readers_dir_fd) as it:

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import time
 import uuid
-from contextlib import contextmanager, suppress
+from contextlib import closing, contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal
@@ -644,8 +644,9 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
                 self._readers_dir_fd_token = token
 
     def _any_readers(self) -> bool:
-        for _ in self._iter_reader_entries():
-            return True
+        with closing(self._iter_reader_entries()) as entries:
+            for _ in entries:
+                return True
         return False
 
     def _iter_reader_entries(self) -> Generator[tuple[str, bool]]:
@@ -654,6 +655,10 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
 
         ``dirfd_relative`` is ``True`` when *name* should be passed to ``dir_fd=``-aware syscalls; ``False``
         when *name* is a full path because dirfd-relative I/O is unavailable on this platform.
+
+        A consumer that stops early must close this generator (``contextlib.closing``); while it is suspended the
+        ``scandir`` handle below stays open, and leaving it to the collector surfaces as an unraisable exception
+        inside whatever runs next.
         """
         if self._readers_dir_fd is not None:  # pragma: needs dir-fd
             with os.scandir(self._readers_dir_fd) as it:
@@ -670,8 +675,9 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
     def _break_stale_readers(self, now: float) -> None:
         names: list[tuple[str, int | None]] = []
         try:
-            for name, dirfd_relative in self._iter_reader_entries():
-                names.append((name, self._readers_dir_fd if dirfd_relative else None))
+            with closing(self._iter_reader_entries()) as entries:
+                for name, dirfd_relative in entries:
+                    names.append((name, self._readers_dir_fd if dirfd_relative else None))
         except OSError:  # pragma: no cover - transient NFS scandir hiccup
             return
         for name, fd in names:

--- a/tasks/capabilities.py
+++ b/tasks/capabilities.py
@@ -1,0 +1,233 @@
+"""What the runtime this suite is running on can actually do.
+
+Probed rather than inferred from a platform or interpreter name: a name answers who is running, and every question
+here is about what the runtime can do. The coverage pragmas and the tests' skipif gates both read these, so a test
+cannot skip while coverage still demands its lines.
+
+Kept apart from the pragma plugin so reading a capability never requires coverage to be installed.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import signal
+import socket
+import sys
+import tempfile
+import weakref
+from asyncio import CancelledError
+from contextlib import asynccontextmanager, contextmanager
+from importlib.util import find_spec
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Generator, Iterator
+
+
+def _supports_symlink() -> bool:
+    # Windows grants this per privilege, not per platform, so ask the filesystem.
+    with tempfile.TemporaryDirectory() as directory:
+        target = Path(directory, "target")
+        target.touch()
+        try:
+            Path(directory, "link").symlink_to(target)
+        except (OSError, NotImplementedError, AttributeError):
+            return False
+        return True
+
+
+def _supports_unlinking_an_open_file() -> bool:
+    # Where this is refused, a peer can never take a live holder's marker.
+    with tempfile.TemporaryDirectory() as directory:
+        victim = Path(directory, "victim")
+        victim.touch()
+        with victim.open("rb"):
+            try:
+                victim.unlink()
+            except OSError:
+                return False
+        return True
+
+
+def _honors_link_follow_symlinks() -> bool:
+    # PyPy advertises the option then rejects it with EINVAL, so trust a real link over os.supports_follow_symlinks.
+    if not hasattr(os, "link"):
+        return False
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory, "source")
+        source.touch()
+        try:
+            os.link(source, Path(directory, "link"), follow_symlinks=False)
+        except (OSError, NotImplementedError, ValueError):
+            return False
+        return True
+
+
+def _finalizes_on_last_reference() -> bool:
+    # Only a refcounting collector runs __del__ the moment the last reference goes; a tracing one defers it.
+    finalized: list[bool] = []
+
+    class Probe:
+        def __del__(self) -> None:
+            finalized.append(True)
+
+    Probe()
+    return bool(finalized)
+
+
+def _finalizes_on_collection() -> bool:
+    # GraalPy queues finalizers on the host collector, so even a forced collection does not run __del__.
+    finalized: list[bool] = []
+
+    class Probe:
+        def __del__(self) -> None:
+            finalized.append(True)
+
+    Probe()
+    gc.collect()
+    return bool(finalized)
+
+
+def _collects_classes() -> bool:
+    # A dynamically built lock subclass must not outlive its last reference, or the registries keyed on it leak.
+    def build() -> type:
+        class Probe:
+            pass
+
+        return Probe
+
+    reference = weakref.ref(build())
+    gc.collect()
+    return reference() is None
+
+
+def _preserves_context_thrown_into_a_generator() -> bool:
+    # GraalPy resets __context__ when contextlib throws into the suspended generator, losing the chained cause.
+    @contextmanager
+    def probe() -> Iterator[None]:
+        yield
+
+    error = KeyError("thrown")
+    error.__context__ = ValueError("context")
+    try:
+        with probe():
+            raise error
+    except KeyError as caught:
+        return caught.__context__ is not None
+    return False  # pragma: no cover  # the raise above always propagates
+
+
+class _Suspend:
+    """An awaitable that parks its coroutine once, so a probe can throw into a suspended frame without a loop."""
+
+    def __await__(self) -> Generator[None, None, None]:
+        yield
+
+
+def _propagates_a_cancellation_thrown_into_a_coroutine() -> bool:
+    # Driven by hand so the probe needs no event loop: GraalPy answers athrow with RuntimeError instead of the
+    # CancelledError, so every cancellation crossing an async context manager surfaces as the wrong exception.
+    @asynccontextmanager
+    async def gate() -> AsyncIterator[None]:
+        await _Suspend()
+        yield
+
+    async def body() -> None:
+        async with gate():
+            pass
+
+    coroutine = body()
+    coroutine.send(None)
+    try:
+        coroutine.throw(CancelledError())
+    except CancelledError:
+        return True
+    except BaseException:  # ruff:ignore[blind-except]  # whatever else a runtime substitutes counts as the deviation
+        return False
+    return False  # pragma: no cover  # throwing into the suspended coroutine always raises
+
+
+_AUDIT_PROBE_EVENT: Final[str] = "filelock.capability-probe"
+
+
+def _delivers_audit_events() -> bool:
+    # GraalPy accepts a hook and never calls it. The hook is a permanent no-op; tests install their own anyway.
+    delivered: list[bool] = []
+    sys.addaudithook(lambda event, _args: delivered.append(True) if event == _AUDIT_PROBE_EVENT else None)
+    sys.audit(_AUDIT_PROBE_EVENT)
+    return bool(delivered)
+
+
+def _refuses_to_open_a_symlink() -> bool:
+    # GraalPy accepts O_NOFOLLOW then follows the link anyway, so ask for the refusal rather than the constant.
+    if not hasattr(os, "O_NOFOLLOW"):
+        return False
+    if not _supports_symlink():
+        # Nothing to point the probe at, so keep the constant's answer rather than reporting a gap we cannot see.
+        return True
+    with tempfile.TemporaryDirectory() as directory:
+        target = Path(directory, "target")
+        target.touch()
+        link = Path(directory, "link")
+        link.symlink_to(target)
+        try:
+            descriptor = os.open(link, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError:
+            return True
+        os.close(descriptor)
+        return False
+
+
+def _enforces_file_mode() -> bool:
+    # Without POSIX permission bits a chmod does not read back.
+    with tempfile.TemporaryDirectory() as directory:
+        probe = Path(directory, "probe")
+        probe.touch()
+        probe.chmod(_OWNER_READ_WRITE)
+        return probe.stat().st_mode & 0o777 == _OWNER_READ_WRITE
+
+
+_OWNER_READ_WRITE: Final[int] = 0o600
+
+#: Capability -> whether this runtime provides it. Tests gate their skipif on this same mapping.
+CAPABILITIES: Final[dict[str, bool]] = {
+    "fork": hasattr(os, "fork") and hasattr(os, "register_at_fork"),
+    # Narrower than "fork": GraalPy registers fork handlers but cannot fork.
+    "register-at-fork": hasattr(os, "register_at_fork"),
+    "dir-fd": os.open in os.supports_dir_fd,
+    # Narrower than "dir-fd": GraalPy takes os.open relative to a directory descriptor but not os.link.
+    "link-dir-fd": hasattr(os, "link") and os.link in os.supports_dir_fd,
+    "fork1": hasattr(os, "fork1"),
+    "hard-link": hasattr(os, "link"),
+    "symlink": _supports_symlink(),
+    "fcntl": find_spec("fcntl") is not None,
+    "unlink-open-file": _supports_unlinking_an_open_file(),
+    "posix-signals": hasattr(signal, "SIGKILL"),
+    "file-mode": _enforces_file_mode(),
+    "prompt-finalization": _finalizes_on_last_reference(),
+    "collected-finalization": _finalizes_on_collection(),
+    "class-collection": _collects_classes(),
+    "generator-exception-context": _preserves_context_thrown_into_a_generator(),
+    "coroutine-cancellation": _propagates_a_cancellation_thrown_into_a_coroutine(),
+    "audit-events": _delivers_audit_events(),
+    "fd-directory": any(Path(view).is_dir() for view in ("/dev/fd", "/proc/self/fd")),
+    "fifo": hasattr(os, "mkfifo"),
+    "af-unix": hasattr(socket, "AF_UNIX"),
+    # Distinct from "symlink": a runtime can create them yet still not refuse to follow one.
+    "o-nofollow": _refuses_to_open_a_symlink(),
+    "utime-nofollow": os.utime in os.supports_follow_symlinks,
+    "utime-fd": os.utime in os.supports_fd,
+    "sqlite3": find_spec("sqlite3") is not None,
+    # A source consumer may run the suite unmeasured, and a forked child then has nothing to flush.
+    "coverage": find_spec("coverage") is not None,
+    "link-follow-symlinks": _honors_link_follow_symlinks(),
+    # Only the tox env that installs a released filelock sets this.
+    "old-client": bool(os.environ.get("FILELOCK_OLD_CLIENT_PATH")),
+}
+
+
+__all__ = [
+    "CAPABILITIES",
+]

--- a/tasks/coverage_pragmas.py
+++ b/tasks/coverage_pragmas.py
@@ -6,31 +6,21 @@ for a capability reason has to name a platform as a stand-in. The stand-in goes 
 Windows gaps behind platform-agnostic code.
 
 ``# pragma: needs <capability>`` drops out only where the capability is absent, and ``# pragma: lacks <capability>``
-only where it is present. Both read the probes below, as do the tests' skipif gates, so a test cannot skip while
-coverage still demands its lines.
+only where it is present. Both read the probes in :mod:`capabilities`, as do the tests' skipif gates, so a test cannot
+skip while coverage still demands its lines.
 
 List this after covdefaults in ``[tool.coverage] run.plugins``; both merge into the same options.
 """
 
 from __future__ import annotations
 
-import gc
-import os
-import signal
-import socket
-import sys
-import tempfile
-import weakref
-from asyncio import CancelledError
-from contextlib import asynccontextmanager, contextmanager
-from importlib.util import find_spec
-from pathlib import Path
 from typing import TYPE_CHECKING, Final, cast
 
+from capabilities import CAPABILITIES
 from coverage import CoveragePlugin
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Generator, Iterable, Iterator
+    from collections.abc import Iterable
 
     from coverage.plugin_support import Plugins
     from coverage.types import TConfigurable
@@ -67,205 +57,6 @@ class CapabilityPragmas(CoveragePlugin):
         merged.update(patterns)
         config.set_option(option, sorted(merged))
 
-
-def _supports_symlink() -> bool:
-    # Windows grants this per privilege, not per platform, so ask the filesystem.
-    with tempfile.TemporaryDirectory() as directory:
-        target = Path(directory, "target")
-        target.touch()
-        try:
-            Path(directory, "link").symlink_to(target)
-        except (OSError, NotImplementedError, AttributeError):
-            return False
-        return True
-
-
-def _supports_unlinking_an_open_file() -> bool:
-    # Where this is refused, a peer can never take a live holder's marker.
-    with tempfile.TemporaryDirectory() as directory:
-        victim = Path(directory, "victim")
-        victim.touch()
-        with victim.open("rb"):
-            try:
-                victim.unlink()
-            except OSError:
-                return False
-        return True
-
-
-def _honors_link_follow_symlinks() -> bool:
-    # PyPy advertises the option then rejects it with EINVAL, so trust a real link over os.supports_follow_symlinks.
-    if not hasattr(os, "link"):
-        return False
-    with tempfile.TemporaryDirectory() as directory:
-        source = Path(directory, "source")
-        source.touch()
-        try:
-            os.link(source, Path(directory, "link"), follow_symlinks=False)
-        except (OSError, NotImplementedError, ValueError):
-            return False
-        return True
-
-
-def _finalizes_on_last_reference() -> bool:
-    # Only a refcounting collector runs __del__ the moment the last reference goes; a tracing one defers it.
-    finalized: list[bool] = []
-
-    class Probe:
-        def __del__(self) -> None:
-            finalized.append(True)
-
-    Probe()
-    return bool(finalized)
-
-
-def _finalizes_on_collection() -> bool:
-    # GraalPy queues finalizers on the host collector, so even a forced collection does not run __del__.
-    finalized: list[bool] = []
-
-    class Probe:
-        def __del__(self) -> None:
-            finalized.append(True)
-
-    Probe()
-    gc.collect()
-    return bool(finalized)
-
-
-def _collects_classes() -> bool:
-    # A dynamically built lock subclass must not outlive its last reference, or the registries keyed on it leak.
-    def build() -> type:
-        class Probe:
-            pass
-
-        return Probe
-
-    reference = weakref.ref(build())
-    gc.collect()
-    return reference() is None
-
-
-def _preserves_context_thrown_into_a_generator() -> bool:
-    # GraalPy resets __context__ when contextlib throws into the suspended generator, losing the chained cause.
-    @contextmanager
-    def probe() -> Iterator[None]:
-        yield
-
-    error = KeyError("thrown")
-    error.__context__ = ValueError("context")
-    try:
-        with probe():
-            raise error
-    except KeyError as caught:
-        return caught.__context__ is not None
-    return False  # pragma: no cover  # the raise above always propagates
-
-
-class _Suspend:
-    """An awaitable that parks its coroutine once, so a probe can throw into a suspended frame without a loop."""
-
-    def __await__(self) -> Generator[None, None, None]:
-        yield
-
-
-def _propagates_a_cancellation_thrown_into_a_coroutine() -> bool:
-    # Driven by hand so the probe needs no event loop: GraalPy answers athrow with RuntimeError instead of the
-    # CancelledError, so every cancellation crossing an async context manager surfaces as the wrong exception.
-    @asynccontextmanager
-    async def gate() -> AsyncIterator[None]:
-        await _Suspend()
-        yield
-
-    async def body() -> None:
-        async with gate():
-            pass
-
-    coroutine = body()
-    coroutine.send(None)
-    try:
-        coroutine.throw(CancelledError())
-    except CancelledError:
-        return True
-    except BaseException:  # ruff:ignore[blind-except]  # whatever else a runtime substitutes counts as the deviation
-        return False
-    return False  # pragma: no cover  # throwing into the suspended coroutine always raises
-
-
-_AUDIT_PROBE_EVENT: Final[str] = "filelock.capability-probe"
-
-
-def _delivers_audit_events() -> bool:
-    # GraalPy accepts a hook and never calls it. The hook is a permanent no-op; tests install their own anyway.
-    delivered: list[bool] = []
-    sys.addaudithook(lambda event, _args: delivered.append(True) if event == _AUDIT_PROBE_EVENT else None)
-    sys.audit(_AUDIT_PROBE_EVENT)
-    return bool(delivered)
-
-
-def _refuses_to_open_a_symlink() -> bool:
-    # GraalPy accepts O_NOFOLLOW then follows the link anyway, so ask for the refusal rather than the constant.
-    if not hasattr(os, "O_NOFOLLOW"):
-        return False
-    if not _supports_symlink():
-        # Nothing to point the probe at, so keep the constant's answer rather than reporting a gap we cannot see.
-        return True
-    with tempfile.TemporaryDirectory() as directory:
-        target = Path(directory, "target")
-        target.touch()
-        link = Path(directory, "link")
-        link.symlink_to(target)
-        try:
-            descriptor = os.open(link, os.O_RDONLY | os.O_NOFOLLOW)
-        except OSError:
-            return True
-        os.close(descriptor)
-        return False
-
-
-def _enforces_file_mode() -> bool:
-    # Without POSIX permission bits a chmod does not read back.
-    with tempfile.TemporaryDirectory() as directory:
-        probe = Path(directory, "probe")
-        probe.touch()
-        probe.chmod(_OWNER_READ_WRITE)
-        return probe.stat().st_mode & 0o777 == _OWNER_READ_WRITE
-
-
-_OWNER_READ_WRITE: Final[int] = 0o600
-
-#: Capability -> whether this runtime provides it. Tests gate their skipif on this same mapping.
-CAPABILITIES: Final[dict[str, bool]] = {
-    "fork": hasattr(os, "fork") and hasattr(os, "register_at_fork"),
-    # Narrower than "fork": GraalPy registers fork handlers but cannot fork.
-    "register-at-fork": hasattr(os, "register_at_fork"),
-    "dir-fd": os.open in os.supports_dir_fd,
-    # Narrower than "dir-fd": GraalPy takes os.open relative to a directory descriptor but not os.link.
-    "link-dir-fd": hasattr(os, "link") and os.link in os.supports_dir_fd,
-    "fork1": hasattr(os, "fork1"),
-    "hard-link": hasattr(os, "link"),
-    "symlink": _supports_symlink(),
-    "fcntl": find_spec("fcntl") is not None,
-    "unlink-open-file": _supports_unlinking_an_open_file(),
-    "posix-signals": hasattr(signal, "SIGKILL"),
-    "file-mode": _enforces_file_mode(),
-    "prompt-finalization": _finalizes_on_last_reference(),
-    "collected-finalization": _finalizes_on_collection(),
-    "class-collection": _collects_classes(),
-    "generator-exception-context": _preserves_context_thrown_into_a_generator(),
-    "coroutine-cancellation": _propagates_a_cancellation_thrown_into_a_coroutine(),
-    "audit-events": _delivers_audit_events(),
-    "fd-directory": any(Path(view).is_dir() for view in ("/dev/fd", "/proc/self/fd")),
-    "fifo": hasattr(os, "mkfifo"),
-    "af-unix": hasattr(socket, "AF_UNIX"),
-    # Distinct from "symlink": a runtime can create them yet still not refuse to follow one.
-    "o-nofollow": _refuses_to_open_a_symlink(),
-    "utime-nofollow": os.utime in os.supports_follow_symlinks,
-    "utime-fd": os.utime in os.supports_fd,
-    "sqlite3": find_spec("sqlite3") is not None,
-    "link-follow-symlinks": _honors_link_follow_symlinks(),
-    # Only the tox env that installs a released filelock sets this.
-    "old-client": bool(os.environ.get("FILELOCK_OLD_CLIENT_PATH")),
-}
 
 #: Modules a missing capability makes unrunnable in full; marking every line would restate one module-level gate.
 _CAPABILITY_MODULES: Final[dict[str, tuple[str, ...]]] = {

--- a/tests/async_filelock_cancellation_helpers.py
+++ b/tests/async_filelock_cancellation_helpers.py
@@ -37,11 +37,12 @@ def assert_file_lock_state(lock_file: str, *, available: bool) -> None:
     try:
         probe.join(timeout=5)
         assert not probe.is_alive(), "lock probe did not exit"
+        assert (probe.exitcode, acquired.value) == (0, available)
     finally:
         if probe.is_alive():  # pragma: no cover - cleanup for a hung child after the assertion fails
             probe.terminate()
             probe.join(timeout=5)
-    assert (probe.exitcode, acquired.value) == (0, available)
+        probe.close()
 
 
 def start_file_lock_holder(lock_file: str) -> tuple[threading.Thread, threading.Event, threading.Event]:

--- a/tests/capability_marks.py
+++ b/tests/capability_marks.py
@@ -12,7 +12,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capabilities import CAPABILITIES
 
 if TYPE_CHECKING:
     from typing import Final

--- a/tests/fork_helpers.py
+++ b/tests/fork_helpers.py
@@ -51,7 +51,8 @@ def _flush_coverage() -> None:
         return
     from coverage import Coverage
 
-    if (coverage := Coverage.current()) is not None:
+    # Reaching the other side needs coverage inactive, which is when nothing gets recorded anyway.
+    if (coverage := Coverage.current()) is not None:  # pragma: no branch
         coverage.save()
 
 

--- a/tests/fork_helpers.py
+++ b/tests/fork_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, Final, NoReturn, cast
 
-from coverage import Coverage, process_startup
+from capabilities import CAPABILITIES
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,20 +39,31 @@ def fork_process(child: Callable[[], NoReturn] | None = None) -> int:  # pragma:
 
 def exit_child(status: int) -> NoReturn:
     try:
-        if (coverage := Coverage.current()) is not None:
-            coverage.save()
+        _flush_coverage()
     finally:
         # A coverage write failure must not return the fork child to pytest.
         os._exit(status)
 
 
+def _flush_coverage() -> None:
+    # An unmeasured run has nothing to write, and importing coverage there would stop the suite from running at all.
+    if not CAPABILITIES["coverage"]:  # pragma: lacks coverage
+        return
+    from coverage import Coverage
+
+    if (coverage := Coverage.current()) is not None:
+        coverage.save()
+
+
 def _restart_coverage_after_fork() -> None:  # pragma: win32 no cover
+    from coverage import Coverage, process_startup
+
     if (coverage := Coverage.current()) is not None:  # pragma: win32 no cover
         coverage.stop()
     process_startup(force=True, slug="fork")  # pragma: no cover - coverage is stopped until this call returns
 
 
-if _REGISTER_AT_FORK is not None:  # pragma: win32 no cover
+if _REGISTER_AT_FORK is not None and CAPABILITIES["coverage"]:  # pragma: win32 no cover
     _REGISTER_AT_FORK(after_in_child=_restart_coverage_after_fork)
 
 

--- a/tests/fork_helpers.py
+++ b/tests/fork_helpers.py
@@ -45,7 +45,7 @@ def exit_child(status: int) -> NoReturn:
         os._exit(status)
 
 
-def _flush_coverage() -> None:
+def _flush_coverage() -> None:  # pragma: win32 no cover - a spawned child inherits no coverage to flush
     # An unmeasured run has nothing to write, and importing coverage there would stop the suite from running at all.
     if not CAPABILITIES["coverage"]:  # pragma: lacks coverage
         return

--- a/tests/process_helpers.py
+++ b/tests/process_helpers.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from multiprocessing import Process
+
+#: Reaping a process that has already been signaled is not a startup wait, and it has to stay under the suite's own
+#: per-test timeout so the guard still reports the hang it was put there for.
+_REAP_DEADLINE: Final[int] = 5
+
+
+@contextmanager
+def cleanup_processes(processes: list[Process]) -> Generator[None]:
+    """Reap every process on the way out, whatever the block did."""
+    try:
+        yield
+    finally:
+        for process in processes:
+            # An assertion can escape before every process starts, and terminating an unstarted one raises over the
+            # failure that caused it, hiding the real error.
+            if process.pid is not None:
+                process.terminate()
+                process.join(timeout=_REAP_DEADLINE)
+                # A worker that outlives its test wedges the next one, and SIGTERM can be slow on a loaded runner.
+                if process.is_alive():  # pragma: no cover  # terminate lands first unless the runner is saturated
+                    process.kill()
+                    process.join(timeout=_REAP_DEADLINE)
+            # Release the multiprocessing finalizer here rather than leave it for a collection that lands in whichever
+            # test is running by then, where it surfaces as an unraisable exception from a dead weakref callback.
+            process.close()
+
+
+__all__ = ["cleanup_processes"]

--- a/tests/process_helpers.py
+++ b/tests/process_helpers.py
@@ -7,8 +7,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
     from multiprocessing import Process
 
-#: Reaping a process that has already been signaled is not a startup wait, and it has to stay under the suite's own
-#: per-test timeout so the guard still reports the hang it was put there for.
+#: Stays under the suite's per-test timeout so a wedged worker still surfaces as the hang it is.
 _REAP_DEADLINE: Final[int] = 5
 
 
@@ -19,17 +18,14 @@ def cleanup_processes(processes: list[Process]) -> Generator[None]:
         yield
     finally:
         for process in processes:
-            # An assertion can escape before every process starts, and terminating an unstarted one raises over the
-            # failure that caused it, hiding the real error.
+            # Terminating an unstarted process raises over the assertion that escaped before it started.
             if process.pid is not None:
                 process.terminate()
                 process.join(timeout=_REAP_DEADLINE)
-                # A worker that outlives its test wedges the next one, and SIGTERM can be slow on a loaded runner.
-                if process.is_alive():  # pragma: no cover  # terminate lands first unless the runner is saturated
+                if process.is_alive():  # pragma: no cover  # SIGTERM only loses this race on a saturated runner
                     process.kill()
                     process.join(timeout=_REAP_DEADLINE)
-            # Release the multiprocessing finalizer here rather than leave it for a collection that lands in whichever
-            # test is running by then, where it surfaces as an unraisable exception from a dead weakref callback.
+            # Left open, the finalizer runs during whichever test the collector lands in, as an unraisable exception.
             process.close()
 
 

--- a/tests/process_helpers.py
+++ b/tests/process_helpers.py
@@ -5,14 +5,14 @@ from typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from multiprocessing import Process
+    from multiprocessing.process import BaseProcess
 
 #: Stays under the suite's per-test timeout so a wedged worker still surfaces as the hang it is.
 _REAP_DEADLINE: Final[int] = 5
 
 
 @contextmanager
-def cleanup_processes(processes: list[Process]) -> Generator[None]:
+def cleanup_processes(processes: list[BaseProcess]) -> Generator[None]:
     """Reap every process on the way out, whatever the block did."""
     try:
         yield

--- a/tests/read_write_helpers.py
+++ b/tests/read_write_helpers.py
@@ -17,11 +17,12 @@ def assert_read_write_lock_state(lock_file: str, mode: Literal["read", "write"],
     try:
         probe.join(timeout=5)
         assert not probe.is_alive(), "read-write lock probe did not exit"
+        assert (probe.exitcode, acquired.value) == (0, available)
     finally:
         if probe.is_alive():  # pragma: no cover - cleanup for a hung child after the assertion fails
             probe.terminate()
             probe.join(timeout=5)
-    assert (probe.exitcode, acquired.value) == (0, available)
+        probe.close()
 
 
 def _probe_read_write_lock(lock_file: str, mode: Literal["read", "write"], acquired: Synchronized[bool]) -> None:

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -1184,8 +1184,6 @@ def test_cleanup_closes_the_process() -> None:
     with cleanup_processes([proc]):
         assert proc.is_alive()
 
-    # Reading liveness back is how a closed process is observable; leaving it open defers its finalizer to whichever
-    # test the collector happens to land in.
     with pytest.raises(ValueError, match="process object is closed"):
         proc.is_alive()
 

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capabilities import CAPABILITIES
 
 from filelock import Timeout
 from filelock import _util as util_mod

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -8,7 +8,7 @@ import stat
 import sys
 import threading
 import time
-from contextlib import contextmanager, suppress
+from contextlib import suppress
 from errno import EIO, ENOENT
 from multiprocessing import Event, Process
 from pathlib import Path
@@ -22,6 +22,7 @@ from filelock import _util as util_mod
 from filelock._soft_rw import SoftReadWriteLock
 from filelock._soft_rw import _sync as sync_mod
 from tests.capability_marks import NEEDS_FILE_MODE, NEEDS_FORK, NEEDS_POSIX_SIGNALS, SKIP_ON_UNRELIABLE_PROCESS_SYNC
+from tests.process_helpers import cleanup_processes
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -278,7 +279,7 @@ def test_multiple_readers_can_hold_simultaneously(lock_file: str) -> None:
     r1, r2, release = Event(), Event(), Event()
     p1 = Process(target=_worker, args=(lock_file, "read", r1, release))
     p2 = Process(target=_worker, args=(lock_file, "read", r2, release))
-    with _cleanup([p1, p2]):
+    with cleanup_processes([p1, p2]):
         p1.start()
         p2.start()
         assert r1.wait(timeout=_PROCESS_DEADLINE)
@@ -295,7 +296,7 @@ def test_write_lock_excludes_writers(lock_file: str) -> None:
     second = Event()
     holder = Process(target=_worker, args=(lock_file, "write", held, release))
     contender = Process(target=_worker, args=(lock_file, "write", second, None, 0.3, True))
-    with _cleanup([holder, contender]):
+    with cleanup_processes([holder, contender]):
         holder.start()
         assert held.wait(timeout=_PROCESS_DEADLINE)
         contender.start()
@@ -312,7 +313,7 @@ def test_write_lock_excludes_readers(lock_file: str) -> None:
     reader_acquired = Event()
     writer = Process(target=_worker, args=(lock_file, "write", held, release))
     reader = Process(target=_worker, args=(lock_file, "read", reader_acquired, None, 0.3, True))
-    with _cleanup([writer, reader]):
+    with cleanup_processes([writer, reader]):
         writer.start()
         assert held.wait(timeout=_PROCESS_DEADLINE)
         reader.start()
@@ -329,7 +330,7 @@ def test_writer_drains_existing_readers(lock_file: str) -> None:
     w_held = Event()
     reader = Process(target=_worker, args=(lock_file, "read", r_held, r_release))
     writer = Process(target=_worker, args=(lock_file, "write", w_held))
-    with _cleanup([reader, writer]):
+    with cleanup_processes([reader, writer]):
         reader.start()
         assert r_held.wait(timeout=_PROCESS_DEADLINE)
         writer.start()
@@ -349,7 +350,7 @@ def test_writer_preference_blocks_new_readers(lock_file: str) -> None:
     reader1 = Process(target=_worker, args=(lock_file, "read", r1_held, r1_release))
     writer = Process(target=_worker, args=(lock_file, "write", w_held, w_release))
     reader2 = Process(target=_worker, args=(lock_file, "read", r2_held, None, 10, True))
-    with _cleanup([reader1, writer, reader2]):
+    with cleanup_processes([reader1, writer, reader2]):
         reader1.start()
         assert r1_held.wait(timeout=_PROCESS_DEADLINE)
         writer.start()
@@ -447,7 +448,7 @@ def test_two_readers_in_same_process_share_slot(lock_file: str) -> None:
 def test_timeout_raises(lock_file: str) -> None:
     held, release = Event(), Event()
     holder = Process(target=_worker, args=(lock_file, "write", held, release))
-    with _cleanup([holder]):
+    with cleanup_processes([holder]):
         holder.start()
         assert held.wait(timeout=_PROCESS_DEADLINE)
         lock = _make_lock(lock_file)
@@ -465,7 +466,7 @@ def test_timeout_raises(lock_file: str) -> None:
 def test_non_blocking_writer_contended_raises(lock_file: str) -> None:
     held, release = Event(), Event()
     holder = Process(target=_worker, args=(lock_file, "write", held, release))
-    with _cleanup([holder]):
+    with cleanup_processes([holder]):
         holder.start()
         assert held.wait(timeout=_PROCESS_DEADLINE)
         lock = _make_lock(lock_file)
@@ -505,7 +506,7 @@ def test_writer_phase2_timeout_releases_marker(lock_file: str) -> None:
 def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs posix-signals
     held = Event()
     holder = Process(target=_sigkill_worker, args=(lock_file, "write", held, 0.1, 0.5))
-    with _cleanup([holder]):
+    with cleanup_processes([holder]):
         holder.start()
         assert held.wait(timeout=_PROCESS_DEADLINE)
         pid = holder.pid
@@ -528,7 +529,7 @@ def test_dead_writer_evicted_by_reader(lock_file: str) -> None:  # pragma: needs
 def test_dead_reader_evicted_by_writer(lock_file: str) -> None:  # pragma: needs posix-signals
     held = Event()
     holder = Process(target=_sigkill_worker, args=(lock_file, "read", held, 0.1, 0.5))
-    with _cleanup([holder]):
+    with cleanup_processes([holder]):
         holder.start()
         assert held.wait(timeout=_PROCESS_DEADLINE)
         pid = holder.pid
@@ -701,7 +702,7 @@ def test_live_heartbeat_keeps_lock_alive_past_stale_threshold(lock_file: str) ->
         target=_worker,
         args=(lock_file, "write", held, release, -1, True, heartbeat, stale, 0.05),
     )
-    with _cleanup([holder]):
+    with cleanup_processes([holder]):
         holder.start()
         assert held.wait(timeout=_PROCESS_DEADLINE)
         time.sleep(stale * 2)
@@ -1040,21 +1041,6 @@ def _worker(
         lock.close()
 
 
-@contextmanager
-def _cleanup(processes: list[Process]) -> Generator[None]:
-    try:
-        yield
-    finally:
-        for proc in processes:
-            if proc.is_alive():
-                proc.terminate()
-                proc.join(timeout=_REAP_DEADLINE)
-            # A worker that outlives its test wedges the next one, and SIGTERM can be slow on a loaded runner.
-            if proc.is_alive():  # pragma: no cover  # the terminate lands first whenever the runner is not saturated
-                proc.kill()
-                proc.join(timeout=_REAP_DEADLINE)
-
-
 def _sigkill_worker(  # pragma: forked child
     lock_file: str,
     mode: Literal["read", "write"],
@@ -1181,9 +1167,27 @@ def _fork_event() -> EventType:  # pragma: needs fork
 def test_cleanup_terminates_a_still_running_process() -> None:
     proc = Process(target=time.sleep, args=(30,))
     proc.start()
-    with _cleanup([proc]):
+    started = time.monotonic()
+
+    with cleanup_processes([proc]):
         assert proc.is_alive()
-    assert not proc.is_alive()
+
+    # A helper that only joined would sit here for the child's whole sleep instead of signaling it first.
+    assert time.monotonic() - started < 10
+
+
+@SKIP_ON_UNRELIABLE_PROCESS_SYNC
+def test_cleanup_closes_the_process() -> None:
+    proc = Process(target=time.sleep, args=(30,))
+    proc.start()
+
+    with cleanup_processes([proc]):
+        assert proc.is_alive()
+
+    # Reading liveness back is how a closed process is observable; leaving it open defers its finalizer to whichever
+    # test the collector happens to land in.
+    with pytest.raises(ValueError, match="process object is closed"):
+        proc.is_alive()
 
 
 def test_write_marker_zero_write_rolls_back(lock_file: str, mocker: MockerFixture) -> None:

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -37,9 +37,6 @@ _OWNER_READ_WRITE: Final[int] = 0o600
 # that starts slowly under a loaded suite is not a locking failure. The short negative waits below are deliberate,
 # since those assert a contender stays blocked and have to stay brief.
 _PROCESS_DEADLINE: Final[int] = 30
-# Reaping a process that has already been signaled is not a startup wait, and it has to stay under the suite's own
-# per-test timeout so the guard still reports the hang it was put there for.
-_REAP_DEADLINE: Final[int] = 5
 
 
 @pytest.fixture(autouse=True)
@@ -924,10 +921,11 @@ def test_child_cannot_reuse_parents_lock_instance(tmp_path: Path) -> None:  # pr
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(target=_reuse_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
-    proc.start()
-    proc.join(timeout=_PROCESS_DEADLINE)
-    assert not failure.is_set()
-    assert result.is_set()
+    with cleanup_processes([proc]):
+        proc.start()
+        proc.join(timeout=_PROCESS_DEADLINE)
+        assert not failure.is_set()
+        assert result.is_set()
 
 
 @SKIP_ON_UNRELIABLE_PROCESS_SYNC
@@ -937,10 +935,11 @@ def test_child_release_on_inherited_lock_is_silent(tmp_path: Path) -> None:  # p
     ctx = mp.get_context("spawn")
     result, failure = ctx.Event(), ctx.Event()
     proc = ctx.Process(target=_release_inherited_lock, args=(str(tmp_path / "foo.lock"), result, failure))
-    proc.start()
-    proc.join(timeout=_PROCESS_DEADLINE)
-    assert not failure.is_set()
-    assert result.is_set()
+    with cleanup_processes([proc]):
+        proc.start()
+        proc.join(timeout=_PROCESS_DEADLINE)
+        assert not failure.is_set()
+        assert result.is_set()
 
 
 @SKIP_ON_UNRELIABLE_PROCESS_SYNC
@@ -953,10 +952,11 @@ def test_child_can_acquire_a_different_lock_after_fork(tmp_path: Path) -> None: 
         target=_reacquire_fresh_lock_in_child,
         args=(str(tmp_path / "parent.lock"), str(tmp_path / "child.lock"), result, failure),
     )
-    proc.start()
-    proc.join(timeout=_PROCESS_DEADLINE)
-    assert not failure.is_set()
-    assert result.is_set()
+    with cleanup_processes([proc]):
+        proc.start()
+        proc.join(timeout=_PROCESS_DEADLINE)
+        assert not failure.is_set()
+        assert result.is_set()
 
 
 @NEEDS_FORK

--- a/tests/test_async_read_write_cancellation.py
+++ b/tests/test_async_read_write_cancellation.py
@@ -75,12 +75,14 @@ def test_executor_cancels_queued_acquire_without_compensation(lock_file: str, *,
     canceled = context.Value("b", False)
     process = context.Process(target=_cancel_queued_read_write_acquire, args=(lock_file, cancel_caller, canceled))
     process.start()
-    process.join(timeout=10)
-    if process.is_alive():  # pragma: no cover - cleanup for a hung child after the assertion fails
-        process.terminate()
-        process.join(timeout=5)
-
-    assert (process.exitcode, canceled.value) == (0, True)
+    try:
+        process.join(timeout=10)
+        assert (process.exitcode, canceled.value) == (0, True)
+    finally:
+        if process.is_alive():  # pragma: no cover - cleanup for a hung child after the assertion fails
+            process.terminate()
+            process.join(timeout=5)
+        process.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 from weakref import WeakValueDictionary
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capabilities import CAPABILITIES
 
 from filelock import (
     BaseFileLock,

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 import time
-from contextlib import contextmanager
 from multiprocessing import Event, Process, Value, set_start_method
 from typing import TYPE_CHECKING, Final, Literal, cast
 
@@ -14,6 +13,7 @@ import sqlite3
 
 from filelock import ReadWriteLock, Timeout
 from tests.capability_marks import SKIP_ON_UNRELIABLE_PROCESS_SYNC
+from tests.process_helpers import cleanup_processes
 from tests.read_write_helpers import assert_read_write_lock_state
 
 # Bounds how long a spawned process may take to reach the lock, not how fast it must be: an interpreter that starts
@@ -32,7 +32,6 @@ if sys.implementation.name == "pypy":
     )  # pragma: no cover  # exercised only under the pypy fork backend, which runs without coverage
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
     from multiprocessing.sharedctypes import Synchronized
     from multiprocessing.synchronize import Event as EventType
     from pathlib import Path
@@ -548,20 +547,6 @@ def test_cleanup_reports_the_failure_that_escaped_before_a_start() -> None:
 
     with pytest.raises(AssertionError, match="the real failure"):
         fail_before_start()
-
-
-@contextmanager
-def cleanup_processes(processes: list[Process]) -> Generator[None]:
-    try:
-        yield
-    finally:
-        for proc in processes:
-            # An assertion can escape before every process starts, and terminating an unstarted one raises over the
-            # failure that caused it, hiding the real error.
-            if proc.pid is not None:
-                proc.terminate()
-                proc.join(timeout=_REAP_DEADLINE)
-            proc.close()
 
 
 def _write_intent_pending(prober: ReadWriteLock, deadline: float) -> bool:

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -9,7 +9,7 @@ import textwrap
 from typing import TYPE_CHECKING, Final, Literal
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capabilities import CAPABILITIES
 
 from filelock import ReadWriteLock
 from tests.capability_marks import (

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capabilities import CAPABILITIES
 
 from filelock import CloseErrorPolicy, SoftFileLock
 from filelock._identity import process_start_token

--- a/tests/test_strict_soft.py
+++ b/tests/test_strict_soft.py
@@ -18,7 +18,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: <3.11 cover
     from exceptiongroup import ExceptionGroup
 
-from coverage_pragmas import CAPABILITIES
+from capabilities import CAPABILITIES
 
 from filelock import (
     AsyncStrictSoftFileLock,

--- a/tests/test_strict_soft_compat.py
+++ b/tests/test_strict_soft_compat.py
@@ -6,7 +6,7 @@ import sys
 from typing import TYPE_CHECKING, Final, TextIO, cast
 
 import pytest
-from coverage_pragmas import CAPABILITIES
+from capabilities import CAPABILITIES
 
 from filelock import StrictSoftFileLock, Timeout
 

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -17,7 +17,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: <3.11 cover
     from exceptiongroup import BaseExceptionGroup
 
-from coverage_pragmas import CAPABILITIES
+from capabilities import CAPABILITIES
 
 import filelock._strict
 from filelock import SoftFileLock, SoftFileLockProtocolError, StrictSoftFileLock, Timeout


### PR DESCRIPTION
Building `filelock` from source hits the problem reported in [#684](https://github.com/tox-dev/filelock/issues/684): the sdist ships `tests/` but not `tasks/`, so collection dies importing `coverage_pragmas`. Shipping that directory alone would not fix it, because the capability probes the tests gate on live inside a `CoveragePlugin` module and drag in `coverage`. A downstream packager running the suite to validate a build should not have to install the coverage tooling first.

A standalone `capabilities` module now holds those probes and imports nothing beyond the standard library, while `coverage_pragmas` consumes the table rather than owning it. One table feeds both the coverage exclusions and the `skipif` gates, so coverage cannot demand lines for a test its platform skips. Adding `tasks/` to the sdist makes extract, build wheel, install, add the test group, run work end to end.

Restoring the suite's remaining warning suppressions to errors exposed two resource leaks. The suite terminated and joined its test workers but never closed them, so each kept its `multiprocessing` finalizer alive until the collector fired it inside whatever test happened to be running, appearing as an unraisable exception from a dead weakref callback under `pytest-randomly`. The suppression that hid this blamed CPython. The cause was ours, so both it and the ignore are gone, replaced by one helper that terminates, joins, escalates to `kill`, and closes. The second leak lives in `_iter_reader_entries`, which yields from inside an `os.scandir` context, so the two callers that stop early left the directory handle open until the collector reclaimed the generator. CPython's refcounting hides that; a traceback cycle or a runtime without refcounting does not.

The library change touches only `_soft_rw/_sync.py` and shifts cleanup timing rather than locking semantics. The rest is packaging and test plumbing.

Closes #684 