### PR TITLE
hand back the claim when a heartbeat thread fails to start

### DIFF
--- a/docs/changelog/691.bugfix.rst
+++ b/docs/changelog/691.bugfix.rst
@@ -1,0 +1,3 @@
+A ``SoftReadWriteLock`` or ``SoftFileLease`` acquire whose heartbeat thread fails to start now hands the claim back
+and unlinks its marker, instead of leaving a marker no heartbeat refreshes that a peer then takes while the caller
+believes it still holds the lock.

--- a/docs/changelog/691.bugfix.rst
+++ b/docs/changelog/691.bugfix.rst
@@ -1,3 +1,3 @@
-A ``SoftReadWriteLock`` or ``SoftFileLease`` acquire whose heartbeat thread fails to start now hands the claim back
-and unlinks its marker, instead of leaving a marker no heartbeat refreshes that a peer then takes while the caller
-believes it still holds the lock.
+A ``SoftReadWriteLock`` or ``SoftFileLease`` acquire whose heartbeat thread fails to start now unlinks its marker and
+hands the claim back, instead of leaving an unrefreshed marker a peer takes while the caller believes it still holds
+the lock.

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -246,8 +246,12 @@ class SoftFileLease(MarkerSoftFileLock):
             name=f"filelock-lease-{os.getpid()}",
             daemon=True,
         )
-        claim.heartbeat = _Heartbeat(thread, stop)
+        # Record the heartbeat only once it is actually running. If the OS refuses a new thread, recording it first
+        # would leave a never-started thread on the claim, so the acquire rollback's _stop_heartbeat would raise
+        # joining it and the marker would never be unlinked; leaving it unset lets the rollback release the claim
+        # cleanly. The thread reads its arguments, not claim.heartbeat, so starting before the assignment is safe.
         thread.start()
+        claim.heartbeat = _Heartbeat(thread, stop)
 
     def _stop_heartbeat(self) -> None:
         claim = self._claim

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -246,10 +246,9 @@ class SoftFileLease(MarkerSoftFileLock):
             name=f"filelock-lease-{os.getpid()}",
             daemon=True,
         )
-        # Record the heartbeat only once it is actually running. If the OS refuses a new thread, recording it first
-        # would leave a never-started thread on the claim, so the acquire rollback's _stop_heartbeat would raise
-        # joining it and the marker would never be unlinked; leaving it unset lets the rollback release the claim
-        # cleanly. The thread reads its arguments, not claim.heartbeat, so starting before the assignment is safe.
+        # Record the heartbeat only after the thread starts; recording first would leave a never-started thread on the
+        # claim, so the acquire rollback's _stop_heartbeat raises joining it and the marker is never unlinked. The
+        # thread reads its arguments, not claim.heartbeat, so starting before the record is safe.
         thread.start()
         claim.heartbeat = _Heartbeat(thread, stop)
 

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -246,11 +246,11 @@ class SoftFileLease(MarkerSoftFileLock):
             name=f"filelock-lease-{os.getpid()}",
             daemon=True,
         )
-        # Record the heartbeat only after the thread starts; recording first would leave a never-started thread on the
-        # claim, so the acquire rollback's _stop_heartbeat raises joining it and the marker is never unlinked. The
-        # thread reads its arguments, not claim.heartbeat, so starting before the record is safe.
-        thread.start()
+        # Record the heartbeat before starting the thread so a release racing this acquire on a shared,
+        # non-thread-local claim always sees it and sets the stop event; the thread then exits at its first wait
+        # instead of outliving the release. A start that raises leaves the unstarted thread for _stop_heartbeat.
         claim.heartbeat = _Heartbeat(thread, stop)
+        thread.start()
 
     def _stop_heartbeat(self) -> None:
         claim = self._claim
@@ -258,8 +258,10 @@ class SoftFileLease(MarkerSoftFileLock):
             return
         heartbeat.stop.set()
         claim.heartbeat = None
-        # on_compromise runs on the heartbeat thread and may release the lease, which lands back here.
-        if heartbeat.thread is not current_thread():
+        # thread.ident is None until start() runs: a heartbeat recorded before its thread started (a start that
+        # raised, or a release racing acquire on a shared claim) has nothing to join, and the stop above makes it
+        # exit at once. on_compromise runs on the heartbeat thread and may release the lease, landing back here.
+        if heartbeat.thread.ident is not None and heartbeat.thread is not current_thread():
             heartbeat.thread.join(timeout=self._heartbeat_interval)
 
     def _refresh_until_stopped(

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -467,11 +467,10 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             stop_event=stop_event,
             name=f"filelock-heartbeat-{id(self):x}",
         )
-        # Publish the hold and start its heartbeat under one critical section. The marker is already on disk, so if
-        # the OS refuses a new thread (an rlimit reached) the hold must not be left standing over a marker nothing
-        # refreshes: a peer would evict it as stale and acquire while this instance still believes it holds, and a
-        # later release() would raise joining a thread that never started. On a start failure clear the hold and
-        # drop the marker we just claimed, so the acquire fails cleanly with the slot handed back.
+        # Publish the hold and start its heartbeat under one internal-lock section, so a concurrent release() never
+        # observes a hold whose thread has not started and joins it. If the OS refuses the thread, clear the hold and
+        # unlink the marker we claimed: left in place, a peer evicts it as stale and acquires while this instance still
+        # believes it holds the lock.
         start_error: BaseException | None = None
         with self._locks.internal:
             self._hold = _Hold(
@@ -486,9 +485,8 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             )
             try:
                 heartbeat.start()
-            except BaseException as error:  # ruff:ignore[blind-except]  # unwind the just-claimed slot below and re-raise
+            except BaseException as error:  # ruff:ignore[blind-except]  # clear the slot below and re-raise
                 self._hold = None
-                stop_event.set()
                 start_error = error
         if start_error is not None:
             if is_reader:

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -467,6 +467,12 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
             stop_event=stop_event,
             name=f"filelock-heartbeat-{id(self):x}",
         )
+        # Publish the hold and start its heartbeat under one critical section. The marker is already on disk, so if
+        # the OS refuses a new thread (an rlimit reached) the hold must not be left standing over a marker nothing
+        # refreshes: a peer would evict it as stale and acquire while this instance still believes it holds, and a
+        # later release() would raise joining a thread that never started. On a start failure clear the hold and
+        # drop the marker we just claimed, so the acquire fails cleanly with the slot handed back.
+        start_error: BaseException | None = None
         with self._locks.internal:
             self._hold = _Hold(
                 level=1,
@@ -478,7 +484,18 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
                 heartbeat_thread=heartbeat,
                 heartbeat_stop=stop_event,
             )
-        heartbeat.start()
+            try:
+                heartbeat.start()
+            except BaseException as error:  # ruff:ignore[blind-except]  # unwind the just-claimed slot below and re-raise
+                self._hold = None
+                stop_event.set()
+                start_error = error
+        if start_error is not None:
+            if is_reader:
+                _unlink(marker_name, dir_fd=self._readers_dir_fd)
+            else:
+                self._unlink_writer_marker_if_ours(token)
+            raise start_error
         return AcquireReturnProxy(lock=self)
 
     def _validate_reentrant(self, mode: _Mode) -> AcquireReturnProxy:

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -689,16 +689,12 @@ def test_heartbeat_stops_when_marker_evicted(lock_file: str, monkeypatch: pytest
 
 @pytest.mark.parametrize("mode", [pytest.param("write", id="write"), pytest.param("read", id="read")])
 def test_acquire_hands_back_the_slot_when_the_heartbeat_cannot_start(
-    lock_file: str, monkeypatch: pytest.MonkeyPatch, mode: Literal["read", "write"]
+    lock_file: str, mocker: MockerFixture, mode: Literal["read", "write"]
 ) -> None:
-    # If the OS refuses a new thread (an rlimit reached) while acquiring, the hold must not be left standing over a
-    # marker no heartbeat refreshes: a peer would evict it as stale and acquire while we still believed we held it,
-    # and release() would then raise joining a thread that never started. The acquire must fail cleanly instead.
-    def boom(self: sync_mod._HeartbeatThread) -> None:  # ruff:ignore[unused-function-argument]  # matches Thread.start and always raises
-        msg = "can't start new thread"
-        raise RuntimeError(msg)
-
-    monkeypatch.setattr(sync_mod._HeartbeatThread, "start", boom)
+    # A heartbeat thread the OS refuses (an rlimit reached) must not leave a hold behind: a peer would evict the
+    # unrefreshed marker and acquire while this instance still believed it held the lock, and release() would raise
+    # joining a thread that never started.
+    mocker.patch.object(sync_mod._HeartbeatThread, "start", side_effect=RuntimeError("can't start new thread"))
     lock = _make_lock(lock_file)
     acquire = lock.acquire_write if mode == "write" else lock.acquire_read
     with pytest.raises(RuntimeError, match="can't start new thread"):

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -687,6 +687,30 @@ def test_heartbeat_stops_when_marker_evicted(lock_file: str, monkeypatch: pytest
         lock.close()
 
 
+@pytest.mark.parametrize("mode", [pytest.param("write", id="write"), pytest.param("read", id="read")])
+def test_acquire_hands_back_the_slot_when_the_heartbeat_cannot_start(
+    lock_file: str, monkeypatch: pytest.MonkeyPatch, mode: Literal["read", "write"]
+) -> None:
+    # If the OS refuses a new thread (an rlimit reached) while acquiring, the hold must not be left standing over a
+    # marker no heartbeat refreshes: a peer would evict it as stale and acquire while we still believed we held it,
+    # and release() would then raise joining a thread that never started. The acquire must fail cleanly instead.
+    def boom(self: sync_mod._HeartbeatThread) -> None:  # ruff:ignore[unused-function-argument]  # matches Thread.start and always raises
+        msg = "can't start new thread"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(sync_mod._HeartbeatThread, "start", boom)
+    lock = _make_lock(lock_file)
+    acquire = lock.acquire_write if mode == "write" else lock.acquire_read
+    with pytest.raises(RuntimeError, match="can't start new thread"):
+        acquire(timeout=2)
+
+    assert lock._hold is None
+    assert not Path(lock._paths.write).exists()
+    assert not lock._any_readers()
+    lock.release(force=True)  # a handed-back slot leaves nothing to release, so this must not raise
+    lock.close()
+
+
 @SKIP_ON_UNRELIABLE_PROCESS_SYNC
 @pytest.mark.timeout(_PROCESS_DEADLINE * 3)
 def test_live_heartbeat_keeps_lock_alive_past_stale_threshold(lock_file: str) -> None:

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -338,16 +338,10 @@ def test_lease_keeps_its_claim_when_another_thread_fails_to_acquire(marker: Path
 
 
 def test_lease_hands_back_the_claim_when_the_heartbeat_cannot_start(marker: Path, mocker: MockerFixture) -> None:
-    # If the OS refuses a new thread while acquiring, the claim must not be left standing over a marker no heartbeat
-    # refreshes: a peer would evict it as stale and acquire while we still believed we held it, and the acquire
-    # rollback would raise joining a thread that never started. The acquire must fail cleanly and release the claim.
-    import filelock._lease as lease_mod
-
-    def failing_start(self: Thread) -> None:  # ruff:ignore[unused-function-argument]  # matches Thread.start and always raises
-        msg = "can't start new thread"
-        raise RuntimeError(msg)
-
-    mocker.patch.object(lease_mod.Thread, "start", failing_start)
+    # A heartbeat thread the OS refuses (an rlimit reached) must not leave the claim behind: a peer would evict the
+    # unrefreshed marker and acquire while this instance still believed it held the lease, and the acquire rollback
+    # would raise joining a thread that never started.
+    mocker.patch.object(Thread, "start", side_effect=RuntimeError("can't start new thread"))
     lease = _lease(marker)
     with pytest.raises(RuntimeError, match="can't start new thread"):
         lease.acquire()

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -337,6 +337,26 @@ def test_lease_keeps_its_claim_when_another_thread_fails_to_acquire(marker: Path
             _lease(marker).acquire()
 
 
+def test_lease_hands_back_the_claim_when_the_heartbeat_cannot_start(marker: Path, mocker: MockerFixture) -> None:
+    # If the OS refuses a new thread while acquiring, the claim must not be left standing over a marker no heartbeat
+    # refreshes: a peer would evict it as stale and acquire while we still believed we held it, and the acquire
+    # rollback would raise joining a thread that never started. The acquire must fail cleanly and release the claim.
+    import filelock._lease as lease_mod
+
+    def failing_start(self: Thread) -> None:  # ruff:ignore[unused-function-argument]  # matches Thread.start and always raises
+        msg = "can't start new thread"
+        raise RuntimeError(msg)
+
+    mocker.patch.object(lease_mod.Thread, "start", failing_start)
+    lease = _lease(marker)
+    with pytest.raises(RuntimeError, match="can't start new thread"):
+        lease.acquire()
+
+    assert not lease.is_locked
+    assert not marker.exists()
+    lease.release(force=True)  # nothing was left to release, so this must not raise
+
+
 def test_lease_rejects_a_peer_configured_with_another_duration(marker: Path) -> None:
     holder = _lease(marker)
 

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -351,6 +351,24 @@ def test_lease_hands_back_the_claim_when_the_heartbeat_cannot_start(marker: Path
     lease.release(force=True)  # nothing was left to release, so this must not raise
 
 
+def test_lease_release_stops_a_heartbeat_recorded_before_its_thread_starts(marker: Path, mocker: MockerFixture) -> None:
+    # A shared, non-thread-local claim lets a release() run while an acquire has recorded its heartbeat but not yet
+    # started the thread. Stubbing start() as a no-op freezes that window: release() must stop the heartbeat without
+    # raising on a join of the unstarted thread, and must still unlink the marker so a peer cannot take a claim we
+    # let go.
+    mocker.patch.object(Thread, "start")
+    lease = SoftFileLease(
+        str(marker), timeout=0.3, lease_duration=_DURATION, heartbeat_interval=_HEARTBEAT, thread_local=False
+    )
+    lease.acquire()
+    assert lease.is_locked
+
+    lease.release()  # must not raise joining a thread that never started
+
+    assert not lease.is_locked
+    assert not marker.exists()
+
+
 def test_lease_rejects_a_peer_configured_with_another_duration(marker: Path) -> None:
     holder = _lease(marker)
 


### PR DESCRIPTION
SoftReadWriteLock and SoftFileLease both commit the hold and its on-disk marker before their heartbeat thread has started, so if the OS refuses a new thread the marker is left with nothing refreshing it: a peer evicts it as stale and acquires while this instance still believes it holds the lock, and a later release then raises trying to join a thread that never started, so the marker is not even unlinked. Start the heartbeat under the same critical section that publishes the hold and, on a start failure, clear the hold and drop the marker we just claimed; the lease records its heartbeat only once the thread is running so the acquire rollback releases the claim cleanly. Both paths come with a regression test that fails on the current code.