### PR TITLE
Fix test failures on NetBSD (#689)

### DIFF
--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1992,8 +1992,9 @@ def test_final_symlink_stays_a_distinct_key(tmp_path: Path) -> None:
 def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:
     (tmp_path / "target").write_text("")
     (tmp_path / "link").symlink_to(tmp_path / "target")
-    # Keeping the final symlink a distinct key is safe because the backend still refuses to lock through it.
-    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link"):
+    # Keeping the final symlink a distinct key is safe because the backend still refuses to lock through it. O_NOFOLLOW
+    # reports the refusal as ELOOP on Linux and macOS, and as EFTYPE ("inappropriate file type") on NetBSD.
+    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link|Inappropriate file type"):
         FileLock(str(tmp_path / "link")).acquire()
 
 
@@ -2187,6 +2188,10 @@ def test_lock_descriptor_blocking_retries_until_free(tmp_path: Path, mocker: Moc
         os.close(fd)
 
 
+#: NetBSD has no CLOCK_THREAD_CPUTIME_ID, so time.thread_time is absent; process CPU time proves "not spinning" too.
+_CPU_TIME: Final[Callable[[], float]] = getattr(time, "thread_time", time.process_time)
+
+
 def test_lock_descriptor_blocking_wait_does_not_spin(tmp_path: Path) -> None:
     path = str(tmp_path / "a")
     holder = os.open(path, os.O_RDWR | os.O_CREAT)
@@ -2196,9 +2201,9 @@ def test_lock_descriptor_blocking_wait_does_not_spin(tmp_path: Path) -> None:
 
     def acquire() -> float:
         started.set()
-        before = time.thread_time()
+        before = _CPU_TIME()
         lock_descriptor(contender, poll_interval=0.01)
-        return time.thread_time() - before
+        return _CPU_TIME() - before
 
     try:
         with ThreadPoolExecutor(max_workers=1) as executor:

--- a/tests/test_fork_backends.py
+++ b/tests/test_fork_backends.py
@@ -410,14 +410,16 @@ async def test_coroutine_acquisition_and_registration_errors_are_grouped(
     descriptor = cast("int", lock.descriptor)
     mocker.stop(fstat_mock)
 
+    # Probe the closed descriptor before the fork and waitpid below, whose own opens could reclaim its freed number.
+    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
+        real_fstat(descriptor)
+
     child_pid = _fork_descriptor_probe(descriptor, real_fstat)
     _, status = await asyncio.to_thread(os.waitpid, child_pid, 0)
     lock.acquire_error = None
     lock.release_error = None
     await lock.release(force=True)
 
-    with pytest.raises(OSError, match=rf"\[Errno {EBADF}\]"):
-        real_fstat(descriptor)
     assert (_error_details(info.value), os.waitstatus_to_exitcode(status)) == (expected, 0)
 
 

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -783,6 +783,10 @@ async def main() -> int:
     if occupant != descriptor:
         os.close(occupant)
 
+    # The canceled acquire ran the flock backend in the default executor, leaving an idle worker thread behind. Join it
+    # before forking so the child is single-threaded: NetBSD deadlocks a child forked from a multi-threaded process.
+    await loop.shutdown_default_executor()
+
     child_pid = os.fork()
     if child_pid == 0:
         try:

--- a/tests/test_process_identity.py
+++ b/tests/test_process_identity.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
 
 _DEAD_PID: Final[int] = 2**22 + 1
 _POSIX_ONLY: Final[pytest.MarkDecorator] = pytest.mark.skipif(sys.platform == "win32", reason="posix kill semantics")
+#: NetBSD and other POSIX platforms without a proven start-time source expose no token, so an owner carries none there.
+_NEEDS_START_TOKEN: Final[pytest.MarkDecorator] = pytest.mark.skipif(
+    process_start_token(os.getpid()) is None, reason="this platform exposes no process start-time source"
+)
 
 
 def test_host_name_matches_socket() -> None:
@@ -42,6 +46,7 @@ def test_process_alive_reraises_unexpected_errno(mocker: MockerFixture) -> None:
         process_alive(_DEAD_PID)
 
 
+@_NEEDS_START_TOKEN
 def test_process_start_token_is_int_for_self() -> None:
     assert isinstance(process_start_token(os.getpid()), int)
 
@@ -72,6 +77,7 @@ def test_owner_is_stale_live_process_matching_token_held() -> None:
     assert owner_is_stale(os.getpid(), host_name(), process_start_token(os.getpid())) is False
 
 
+@_NEEDS_START_TOKEN
 def test_owner_is_stale_live_process_mismatched_token_reclaimed() -> None:
     token = process_start_token(os.getpid())
     assert token is not None


### PR DESCRIPTION
Closes #689.

The 3.32.0 suite reported seven failures on NetBSD (pkgsrc). All seven are test assumptions about the platform, not defects in the lock itself — the library already falls back correctly where a capability is missing.

## What changed

- **Process start token** (`test_process_start_token_is_int_for_self`, `test_owner_is_stale_live_process_mismatched_token_reclaimed`): NetBSD exposes no proven start-time source, so `process_start_token` returns `None` and an owner carries no token by design. Gate both tests on token availability.
- **`time.thread_time`** (`test_lock_descriptor_blocking_wait_does_not_spin`): absent without `CLOCK_THREAD_CPUTIME_ID`. Fall back to `time.process_time`, which proves the blocking wait does not busy-spin just as well.
- **`O_NOFOLLOW` on a symlink** (`test_final_symlink_backend_refuses_to_lock`): NetBSD reports the refusal as `EFTYPE` ("inappropriate file type or format") rather than `ELOOP`. Accept that message too — the backend still refuses to lock.
- **Grouped registration error** (`test_coroutine_acquisition_and_registration_errors_are_grouped`): the parent probed the closed descriptor number *after* a fork and `waitpid`, whose own file opens can reclaim the freed number. Probe it immediately after the rollback instead.
- **Canceled async acquire** (`test_cancelled_async_acquire_unregisters_reused_descriptor`): the real flock backend runs in the default executor, so a canceled acquire leaves an idle worker thread behind. `os.fork()` from that multi-threaded state deadlocks the child on NetBSD (the sibling coroutine-backend tests fork single-threaded, which is why they pass). Join the executor with `shutdown_default_executor()` before forking so the child is single-threaded.

Test-only; no library behavior change, hence `skip news`.

Verified locally on macOS (CPython 3.14): the affected modules pass, `ruff`, `ty`, and the full pre-commit gate are clean. I do not have a NetBSD host to confirm against, but each change maps directly to a failure in the report.