### PR TITLE
🧪 test(soft-rw): deflake writer phase-2 peer-marker test

### DIFF
--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -602,17 +602,21 @@ def test_writer_phase2_does_not_complete_on_a_peers_marker(lock_file: str, monke
     real_sleep = time.sleep
     swapped = threading.Event()
 
+    # Only the writer's phase-2 poll loop calls the patched sleep (the reader's heartbeat waits on an Event), so the
+    # swap lands on the first poll and the second poll ends the wait. Driving the timeout from the hook instead of the
+    # wall clock keeps this deterministic: a loaded runner could otherwise blow the deadline during phase-2 setup and
+    # raise Timeout before the first sleep ever ran, leaving the swap uninjected.
     def hook(seconds: float) -> None:  # ruff:ignore[unused-function-argument]  # replaces time.sleep; the duration is irrelevant to the swap
-        if not swapped.is_set():
-            swapped.set()
-            Path(write_marker).write_bytes(peer_marker)
-            reader.release()
-        real_sleep(0.005)
+        if swapped.is_set():
+            raise Timeout(lock_file)
+        swapped.set()
+        Path(write_marker).write_bytes(peer_marker)
+        reader.release()
 
     monkeypatch.setattr(sync_mod.time, "sleep", hook)
     try:
         with pytest.raises(Timeout):
-            writer.acquire_write(timeout=0.6)
+            writer.acquire_write(timeout=30)
         assert swapped.is_set()
         # We never overwrote or refreshed the peer's live marker.
         assert Path(write_marker).read_bytes() == peer_marker


### PR DESCRIPTION
`test_writer_phase2_does_not_complete_on_a_peers_marker` flaked on the free-threaded 3.15t Windows runner: `assert swapped.is_set()` failed. The test injects its peer-marker eviction from a monkeypatched `time.sleep`, so the swap fires only once the writer's phase-2 poll loop reaches its first sleep. `_wait_for` checks the wall-clock deadline before it sleeps. When phase-1 setup and the first phase-2 filesystem scan run slow under full parallel load, the 0.6s acquire deadline expired first and `_wait_for` raised `Timeout` before any sleep ran. The swap never happened, so the guard assertion failed.

The hook now drives the timeout instead of the clock. It swaps on the first poll and raises `Timeout` on the second. Only the writer touches the patched sleep, because the reader's heartbeat waits on a `threading.Event` rather than `time.sleep`, so nothing else lands in the hook and the result no longer depends on how fast the runner reaches phase 2. The `acquire_write` timeout now caps the wait; the hook ends it.

The flake showed up on the CI run for #693.
