### PR TITLE
🧪 test(unix): deflake sticky-bit concurrent-unlink on graalpy

### DIFF
--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1119,14 +1119,19 @@ def test_sticky_bit_fallback_handles_concurrent_unlink(tmp_path: Path, mocker: M
     lock = FileLock(str(lock_path), is_singleton=False)
 
     real_open = os.open
-    call_count = 0
+    denied_create = False
+    unlinked_open = False
 
+    # Key the injections off each open's signature rather than a global call count: GraalPy opens unrelated paths
+    # mid-acquire, which would shift a counter and land the errors on the wrong opens. Deny the first create, then
+    # unlink under the first no-create open, so the sticky-bit fallback must retry once more to succeed.
     def open_permission_then_unlink(path: str, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1 and flags & os.O_CREAT and "test.lock" in path:
+        nonlocal denied_create, unlinked_open
+        if not denied_create and flags & os.O_CREAT and "test.lock" in path:
+            denied_create = True
             raise PermissionError(13, "Permission denied", path)
-        if call_count == 2 and not (flags & os.O_CREAT) and "test.lock" in path:
+        if not unlinked_open and not flags & os.O_CREAT and "test.lock" in path:
+            unlinked_open = True
             lock_path.unlink(missing_ok=True)
             raise FileNotFoundError(2, "No such file or directory", path)
         return real_open(path, flags, mode) if dir_fd is None else real_open(path, flags, mode, dir_fd=dir_fd)
@@ -1134,7 +1139,7 @@ def test_sticky_bit_fallback_handles_concurrent_unlink(tmp_path: Path, mocker: M
     mocker.patch("os.open", side_effect=open_permission_then_unlink)
     lock.acquire()
     assert lock.is_locked
-    assert call_count == 3
+    assert (denied_create, unlinked_open) == (True, True)
     lock.release()
 
 


### PR DESCRIPTION
`test_sticky_bit_fallback_handles_concurrent_unlink` flaked on graalpy3.11 with `assert 5 == 3`. The test patches `os.open` to reproduce a sticky-bit directory: the first create is denied, the follow-up open without `O_CREAT` finds the file unlinked, and a retry then succeeds. It counts every `os.open` call and asserts the total is 3. GraalPy opens unrelated paths partway through acquire, so the counter climbed past 3, and because the injected errors keyed off that same global counter they landed on the wrong opens, sending the acquire down a different path.

The mock now counts and injects only on opens of the lock file. The fallback logic drives three lock-file opens on every interpreter regardless of how many other files the runtime touches, so the count and the injected errors stay put.

Showed up on the CI run for #691.
