### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -23,6 +24,7 @@ now = datetime.now(tz=timezone.utc)
 version, release = ".".join(__version__.split(".")[:2]), __version__
 copyright = f"2014-{now.date().year}, {company}"  # ruff:ignore[builtin-variable-shadowing]
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.viewcode",
@@ -117,3 +119,6 @@ def setup(app: Sphinx) -> None:
             return super().resolve_xref(env, fromdocname, builder, type, target, node, contnode)
 
     app.add_domain(PatchedPythonDomain, override=True)
+
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ docs = [
   "sphinx-autodoc-typehints>=3.9.11",
   "sphinx-copybutton>=0.5.2",
   "sphinx-design>=0.7",
+  "sphinx-llm>=0.4.1",
   "sphinx-sitemap>=2.9",
   "sphinxcontrib-mermaid>=2.0.1",
   "sphinxcontrib-towncrier>=0.5.0a0",


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
