### PR TITLE
fix(api): handle module teardown NoneType in _audit_fork_safety during interpreter shutdown (#701)

### DIFF
--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -1782,11 +1782,11 @@ def _refresh_owner_pins() -> None:  # pragma: needs fork
 def _audit_fork_safety(  # pragma: no cover - CPython disables tracing while Python audit hooks run
     event: str, _args: tuple[object, ...]
 ) -> None:
-    if event in _FORK_AUDIT_EVENTS:
-        if _FORK_STATE.transition_context.depth or _FORK_STATE.fork_owner_depths:
+    if _FORK_AUDIT_EVENTS is not None and event in _FORK_AUDIT_EVENTS:
+        if _FORK_STATE is not None and (_FORK_STATE.transition_context.depth or _FORK_STATE.fork_owner_depths):
             msg = f"{event} is unsafe while filelock is changing descriptor ownership"
             raise RuntimeError(msg)
-    elif event == "_posixsubprocess.fork_exec" and _FORK_STATE.transition_context.depth:
+    elif event == "_posixsubprocess.fork_exec" and _FORK_STATE is not None and _FORK_STATE.transition_context.depth:
         msg = "fork_exec is unsafe while filelock is changing descriptor ownership"
         raise RuntimeError(msg)
 

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -188,6 +188,18 @@ def test_audit_rejects_process_creation_inside_descriptor_transition(
         AuditedLock(str(tmp_path / "audit.lock"), is_singleton=False).acquire(timeout=0)
 
 
+def test_audit_fork_safety_during_interpreter_shutdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    from filelock import _api
+
+    monkeypatch.setattr(_api, "_FORK_AUDIT_EVENTS", None)
+    monkeypatch.setattr(_api, "_FORK_STATE", None)
+
+    # Calling the audit hook when globals are None should safely return without raising TypeError
+    _api._audit_fork_safety("os.fork", ())
+    _api._audit_fork_safety("_posixsubprocess.fork_exec", ())
+    _api._audit_fork_safety("unrelated_event", ())
+
+
 @NEEDS_FORK  # pragma: needs fork
 @_FORK_WARNING
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary of Changes
Fixes a `TypeError: argument of type 'NoneType' is not a container or iterable` crash in `_audit_fork_safety` during interpreter shutdown (#701).

### Root Cause
During CPython interpreter finalization/shutdown, module global variables (such as `_FORK_AUDIT_EVENTS` and `_FORK_STATE` in `filelock/_api.py`) are cleared and set to `None` before registered audit hooks are removed. When late audit events fire during teardown, calling `_audit_fork_safety` executes `if event in _FORK_AUDIT_EVENTS:`, which raises a `TypeError` because `_FORK_AUDIT_EVENTS` is `None`.

### Solution
1. Defensively check `if _FORK_AUDIT_EVENTS is not None and event in _FORK_AUDIT_EVENTS:` in `_audit_fork_safety`.
2. Check `if _FORK_STATE is not None` before accessing `transition_context` or `fork_owner_depths`.
3. Added unit test `test_audit_fork_safety_during_interpreter_shutdown` in `tests/test_fork_coordination.py`.

### Testing
- `ruff check` & `ruff format`: All checks passed.
- `pytest`: 1,301 passed.
