### PR TITLE
🐛 fix(fork): survive audit events during interpreter shutdown

### DIFF
--- a/docs/changelog/701.bugfix.rst
+++ b/docs/changelog/701.bugfix.rst
@@ -1,0 +1,2 @@
+The fork-safety audit hook no longer prints ``Exception ignored in audit hook`` with a ``TypeError`` when an audit
+event fires during interpreter shutdown, after CPython has already cleared the module globals.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,8 @@ html_title, html_last_updated_fmt = name, now.isoformat()
 html_baseurl = "https://py-filelock.readthedocs.io/"
 pygments_style, pygments_dark_style = "sphinx", "monokai"
 autoclass_content, autodoc_member_order, autodoc_typehints = "both", "bysource", "none"
+# _typeshed exists only inside type checkers; sphinx-autodoc-typehints executes TYPE_CHECKING imports to resolve hints.
+autodoc_mock_imports = ["_typeshed"]
 autodoc_default_options = {"member-order": "bysource", "undoc-members": True, "show-inheritance": True}
 autosectionlabel_prefix_document = True
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -1779,14 +1779,20 @@ def _refresh_owner_pins() -> None:  # pragma: needs fork
 
 
 # Audit events carry unrelated interpreter-owned values; object is the sole accurate common element type.
+# The defaults capture the module globals: the hook outlives them at interpreter shutdown, where CPython wipes the
+# module dict to None before the final audit events fire.
 def _audit_fork_safety(  # pragma: no cover - CPython disables tracing while Python audit hooks run
-    event: str, _args: tuple[object, ...]
+    event: str,
+    _args: tuple[object, ...],
+    *,
+    _fork_events: frozenset[str] = _FORK_AUDIT_EVENTS,
+    _state: _ForkState = _FORK_STATE,
 ) -> None:
-    if event in _FORK_AUDIT_EVENTS:
-        if _FORK_STATE.transition_context.depth or _FORK_STATE.fork_owner_depths:
+    if event in _fork_events:
+        if _state.transition_context.depth or _state.fork_owner_depths:
             msg = f"{event} is unsafe while filelock is changing descriptor ownership"
             raise RuntimeError(msg)
-    elif event == "_posixsubprocess.fork_exec" and _FORK_STATE.transition_context.depth:
+    elif event == "_posixsubprocess.fork_exec" and _state.transition_context.depth:
         msg = "fork_exec is unsafe while filelock is changing descriptor ownership"
         raise RuntimeError(msg)
 

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
     from types import TracebackType
     from typing import Protocol
 
+    from _typeshed import Unused
+
     from ._read_write import ReadWriteLock
     from ._soft_rw import SoftReadWriteLock
 
@@ -1778,12 +1780,11 @@ def _refresh_owner_pins() -> None:  # pragma: needs fork
             _FORK_STATE.pinned_classes[thread_id][:] = [classes] * len(object_snapshots)
 
 
-# Audit events carry unrelated interpreter-owned values; object is the sole accurate common element type.
 # The defaults capture the module globals: the hook outlives them at interpreter shutdown, where CPython wipes the
 # module dict to None before the final audit events fire.
 def _audit_fork_safety(  # pragma: no cover - CPython disables tracing while Python audit hooks run
     event: str,
-    _args: tuple[object, ...],
+    _args: Unused,
     *,
     _fork_events: frozenset[str] = _FORK_AUDIT_EVENTS,
     _state: _ForkState = _FORK_STATE,

--- a/src/filelock/_read_write.py
+++ b/src/filelock/_read_write.py
@@ -24,6 +24,8 @@ from ._error import Timeout
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
+    from _typeshed import Unused
+
     if sys.version_info >= (3, 11):
         from typing import Self
     else:
@@ -744,7 +746,7 @@ def _abort_forked_sqlite_transition() -> None:  # pragma: forked child
         os._exit(_UNSAFE_FORK_EXIT_STATUS)  # inherited SQLite handles cannot be used or closed safely
 
 
-def _track_sqlite_use(event: str, _args: tuple[object, ...]) -> None:  # audit payloads are heterogeneous
+def _track_sqlite_use(event: str, _args: Unused) -> None:
     if event == "sqlite3.connect":
         _FORKED_DATABASES.note_sqlite_use()
 

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -784,6 +784,26 @@ def _close_after_commit(mocker: MockerFixture) -> Iterator[tuple[OSError, list[i
         mocker.stop(close_mock)
 
 
+def test_close_after_commit_ignores_closes_from_other_threads(mocker: MockerFixture) -> None:
+    # The patch binds os.close process-wide, so a descriptor closed on another thread must pass through cleanly and
+    # stay out of the caller's recorded attempts rather than absorb the injected failure.
+    closed: list[int] = []
+
+    def close_a_pipe() -> None:
+        read_fd, write_fd = os.pipe()
+        os.close(read_fd)
+        os.close(write_fd)  # a non-caller thread: passes through untouched rather than raising the injected error
+        closed.extend((read_fd, write_fd))
+
+    with _close_after_commit(mocker) as (_close_error, attempts):
+        worker = threading.Thread(target=close_a_pipe)
+        worker.start()
+        worker.join()
+
+    assert len(closed) == 2
+    assert attempts == []
+
+
 @pytest.mark.parametrize(
     "use_proxy",
     [pytest.param(False, id="direct"), pytest.param(True, id="proxy")],

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -764,9 +764,16 @@ def _close_after_commit(mocker: MockerFixture) -> Iterator[tuple[OSError, list[i
     real_close = os.close
     close_error = OSError(EINTR, "close failed")
     attempts: list[int] = []
+    # close is an attribute of the shared os module, so this patch binds for every thread rather than just this one.
+    # Leave another thread's close alone: counting it would inflate attempts, and failing it would break whatever
+    # unrelated work happens to be closing a descriptor while this window is open. Every lock here runs with
+    # run_in_executor=False, so the closes under test stay on this thread.
+    caller = threading.get_ident()
 
     def close(fd: int) -> None:
         real_close(fd)
+        if threading.get_ident() != caller:
+            return
         attempts.append(fd)
         raise close_error
 

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -162,6 +162,32 @@ if second_status != 0 or owner.is_alive() or statuses.get(timeout=1) != 0:
 
 
 @NEEDS_FORK  # pragma: needs fork
+def test_audit_hook_survives_interpreter_shutdown() -> None:
+    script = """
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import filelock._api as api
+
+class LateAudit:
+    def __del__(self, object_id: Callable[[LateAudit], int] = id) -> None:
+        object_id(self)
+
+api.__dict__["_late_shutdown_audit"] = LateAudit()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert (result.returncode, result.stderr) == (0, "")
+
+
+@NEEDS_FORK  # pragma: needs fork
 @pytest.mark.parametrize(
     "event",
     [

--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -114,8 +114,12 @@ def block_before_fork() -> None:
 os.register_at_fork(before=block_before_fork)
 
 if sys.argv[2] == "rejected":
-    # Audit arguments mix interpreter-owned types; object is their only accurate common type.
-    def reject_add_hook(event: str, _args: tuple[object, ...]) -> None:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from _typeshed import Unused
+
+    def reject_add_hook(event: str, _args: Unused) -> None:
         if event == "sys.addaudithook":
             raise RuntimeError
 
@@ -238,8 +242,12 @@ import sys
 from errno import EBADF
 
 if sys.argv[1] == "rejected-audit":
-    # Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
-    def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from _typeshed import Unused
+
+    def reject_filelock_hook(event: str, _args: Unused) -> None:
         if event == "sys.addaudithook":
             raise RuntimeError
 
@@ -312,8 +320,8 @@ from errno import EBADF
 child_status = -1
 forked = False
 
-# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
-def audit_hook(event: str, args: tuple[object, ...]) -> None:
+# Typed for the fcntl.flock payload (fd, cmd); every other event returns before touching args.
+def audit_hook(event: str, args: tuple[int, int]) -> None:
     global child_status, forked
     if event == "sys.addaudithook" and sys.argv[1] == "rejected-audit":
         raise RuntimeError
@@ -361,8 +369,12 @@ import os
 import sys
 from errno import EBADF
 
-# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
-def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _typeshed import Unused
+
+def reject_filelock_hook(event: str, _args: Unused) -> None:
     if event == "sys.addaudithook":
         raise RuntimeError
 
@@ -444,8 +456,12 @@ import os
 import sys
 from errno import EBADF
 
-# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
-def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _typeshed import Unused
+
+def reject_filelock_hook(event: str, _args: Unused) -> None:
     if event == "sys.addaudithook":
         raise RuntimeError
 
@@ -516,8 +532,12 @@ from __future__ import annotations
 import os
 import sys
 
-# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
-def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _typeshed import Unused
+
+def reject_filelock_hook(event: str, _args: Unused) -> None:
     if event == "sys.addaudithook":
         raise RuntimeError
 
@@ -588,8 +608,12 @@ from queue import Queue
 
 warnings.filterwarnings("ignore", message=".*multi-threaded, use of fork.*", category=DeprecationWarning)
 
-# Audit arguments are heterogeneous interpreter-owned values, so object is their only accurate common type.
-def reject_filelock_hook(event: str, _args: tuple[object, ...]) -> None:
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _typeshed import Unused
+
+def reject_filelock_hook(event: str, _args: Unused) -> None:
     if event == "sys.addaudithook":
         raise RuntimeError
 

--- a/tests/test_read_write_fork.py
+++ b/tests/test_read_write_fork.py
@@ -22,6 +22,8 @@ from tests.capability_marks import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from _typeshed import StrOrBytesPath
+
 _NEEDS_FD_DIRECTORY: Final[pytest.MarkDecorator] = pytest.mark.skipif(
     not CAPABILITIES["fd-directory"], reason="counting open descriptors needs a /dev/fd or /proc/self/fd view"
 )
@@ -32,8 +34,9 @@ def test_read_write_lock_closes_idle_connections(tmp_path: Path) -> None:
     lock_path = tmp_path / "idle.db"
     connection_events = 0
 
+    # Typed for the sqlite3.connect payload the hook reads; every other event returns before touching args.
     def audit_hook(  # pragma: no cover - interpreter audit hooks run with tracing disabled
-        event: str, args: tuple[object, ...]
+        event: str, args: tuple[StrOrBytesPath, ...]
     ) -> None:
         nonlocal connection_events
         if event != "sqlite3.connect":
@@ -410,8 +413,12 @@ def _recursive_construction_script() -> str:
         lock_path, audit_event = sys.argv[1:]
         armed = True
 
-        def audit_hook(event: str, _args: tuple[object, ...]) -> None:
-            # CPython supplies heterogeneous values for process-wide audit events.
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from _typeshed import Unused
+
+        def audit_hook(event: str, _args: Unused) -> None:
             if armed and event == audit_event:
                 ReadWriteLock(lock_path)
 
@@ -443,8 +450,12 @@ def _recursive_acquisition_script() -> str:
         lock = ReadWriteLock(lock_path)
         armed = True
 
-        def audit_hook(event: str, _args: tuple[object, ...]) -> None:
-            # CPython supplies heterogeneous values for process-wide audit events.
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from _typeshed import Unused
+
+        def audit_hook(event: str, _args: Unused) -> None:
             if armed and event == "sqlite3.connect":
                 if operation == "acquire":
                     lock.acquire_read()
@@ -511,8 +522,12 @@ def _concurrent_operation_script() -> str:
         operation_errors: queue.SimpleQueue[BaseException] = queue.SimpleQueue()
         armed = True
 
-        def audit_hook(event: str, _args: tuple[object, ...]) -> None:
-            # CPython supplies heterogeneous values for process-wide audit events.
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from _typeshed import Unused
+
+        def audit_hook(event: str, _args: Unused) -> None:
             if armed and event == "sqlite3.connect":
                 acquisition_inside_connect.set()
                 assert continue_acquisition.wait(5)
@@ -568,11 +583,14 @@ def _fork_script() -> str:
         import os
         import sqlite3
         import sys
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from _typeshed import Unused
 
         lock_path, mode, fork_name, audit_hook_mode = sys.argv[1:]
         if audit_hook_mode == "reject":
-            def reject_filelock_audit_hook(event: str, _args: tuple[object, ...]) -> None:
-                # CPython supplies heterogeneous values for process-wide audit events.
+            def reject_filelock_audit_hook(event: str, _args: Unused) -> None:
                 if event == "sys.addaudithook":
                     raise RuntimeError("audit hook registration rejected")
 
@@ -606,8 +624,7 @@ def _fork_script() -> str:
                 gc.collect()
                 sqlite_connects = 0
 
-                def count_sqlite_connects(event: str, _args: tuple[object, ...]) -> None:
-                    # CPython supplies heterogeneous values for process-wide audit events.
+                def count_sqlite_connects(event: str, _args: Unused) -> None:
                     global sqlite_connects
                     if event == "sqlite3.connect":
                         sqlite_connects += 1
@@ -667,6 +684,10 @@ def _fork_during_sqlite_script() -> str:  # pragma: needs fork
         import threading
         import time
         import warnings
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from _typeshed import StrOrBytesPath
 
         from filelock import ReadWriteLock
 
@@ -681,8 +702,8 @@ def _fork_during_sqlite_script() -> str:  # pragma: needs fork
         acquisition_errors: queue.SimpleQueue[BaseException] = queue.SimpleQueue()
         armed = True
 
-        def audit_hook(event: str, args: tuple[object, ...]) -> None:
-            # CPython supplies heterogeneous values for process-wide audit events.
+        # Typed for the sqlite3.connect payload the hook reads; every other event returns before touching args.
+        def audit_hook(event: str, args: tuple[StrOrBytesPath, ...]) -> None:
             if not armed or event != "sqlite3.connect":
                 return
             database = args[0]
@@ -740,14 +761,16 @@ def _fork_at_sqlite_boundary_script() -> str:
         import sqlite3
         import sys
         from types import FrameType
-        from typing import Protocol
+        from typing import TYPE_CHECKING, Protocol
+
+        if TYPE_CHECKING:
+            from _typeshed import Unused
 
         class ProfiledCall(Protocol):
             @property
             def __name__(self) -> str: ...
 
-        def reject_filelock_audit_hook(event: str, _args: tuple[object, ...]) -> None:
-            # CPython audit events have heterogeneous interpreter-owned payloads.
+        def reject_filelock_audit_hook(event: str, _args: Unused) -> None:
             if event == "sys.addaudithook":
                 raise RuntimeError("audit hook registration rejected")
 


### PR DESCRIPTION
CPython keeps audit hooks firing through interpreter finalization, after it has wiped the underscore-named globals of `filelock._api` to `None`. A late audit event, such as `builtins.id` raised from a `__del__` that runs during module teardown, then evaluated `event in _FORK_AUDIT_EVENTS` against `None` and printed `Exception ignored in audit hook` with a `TypeError`. Fixes #701, where this surfaced during ASGI worker shutdown on Python 3.14.

`_audit_fork_safety` now takes `_FORK_AUDIT_EVENTS` and `_FORK_STATE` as keyword-only defaults, captured at definition time, so the hook no longer reads its module dict at call time. CPython invokes audit hooks with two positional arguments, so the extra parameters leave the call contract unchanged.
