### PR TITLE
🧪 test: deflake six scheduled-run failures

### DIFF
--- a/tasks/capabilities.py
+++ b/tasks/capabilities.py
@@ -15,10 +15,10 @@ import signal
 import socket
 import sys
 import tempfile
-import tracemalloc
 import weakref
 from asyncio import CancelledError
 from contextlib import asynccontextmanager, contextmanager
+from importlib import import_module
 from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
@@ -182,10 +182,15 @@ def _refuses_to_open_a_symlink() -> bool:
 
 
 def _reports_object_tracebacks() -> bool:
-    # GraalPy raises NotImplementedError from the lookup pytest's thread and unraisable exception hooks make; CPython
-    # answers None while tracemalloc is not tracing.
+    # pytest's thread and unraisable exception hooks ask tracemalloc where the offending object was allocated. GraalPy
+    # raises NotImplementedError from that lookup; CPython answers None while not tracing, and PyPy, which ships no
+    # tracemalloc, is never asked.
     try:
-        tracemalloc.get_object_traceback(object())
+        get_object_traceback = import_module("tracemalloc").get_object_traceback
+    except ImportError:
+        return True
+    try:
+        get_object_traceback(object())
     except NotImplementedError:
         return False
     return True

--- a/tasks/capabilities.py
+++ b/tasks/capabilities.py
@@ -15,6 +15,7 @@ import signal
 import socket
 import sys
 import tempfile
+import tracemalloc
 import weakref
 from asyncio import CancelledError
 from contextlib import asynccontextmanager, contextmanager
@@ -180,6 +181,16 @@ def _refuses_to_open_a_symlink() -> bool:
         return False
 
 
+def _reports_object_tracebacks() -> bool:
+    # GraalPy raises NotImplementedError from the lookup pytest's thread and unraisable exception hooks make; CPython
+    # answers None while tracemalloc is not tracing.
+    try:
+        tracemalloc.get_object_traceback(object())
+    except NotImplementedError:
+        return False
+    return True
+
+
 def _enforces_file_mode() -> bool:
     # Without POSIX permission bits a chmod does not read back.
     with tempfile.TemporaryDirectory() as directory:
@@ -223,6 +234,7 @@ CAPABILITIES: Final[dict[str, bool]] = {
     # A source consumer may run the suite unmeasured, and a forked child then has nothing to flush.
     "coverage": find_spec("coverage") is not None,
     "link-follow-symlinks": _honors_link_follow_symlinks(),
+    "tracemalloc-object-traceback": _reports_object_tracebacks(),
     # Only the tox env that installs a released filelock sets this.
     "old-client": bool(os.environ.get("FILELOCK_OLD_CLIENT_PATH")),
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import gc
 import os
+import tracemalloc
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from capabilities import CAPABILITIES
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -27,6 +30,28 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         for item in items:
             if item.get_closest_marker("requires_hard_links") is not None:
                 item.add_marker(skip)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _tracemalloc_lookup_without_support() -> Iterator[None]:
+    # pytest's thread and unraisable exception hooks ask tracemalloc where the offending object was allocated. Where
+    # that lookup raises (GraalPy), the hook reports "Failed to process thread exception" in place of the thread's real
+    # error, so hand it the answer tracemalloc gives while it is not tracing.
+    with pytest.MonkeyPatch.context() as patch:
+        if not CAPABILITIES["tracemalloc-object-traceback"]:  # pragma: lacks tracemalloc-object-traceback
+            patch.setattr(tracemalloc, "get_object_traceback", lambda _source: None)
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _collect_garbage() -> Iterator[None]:
+    # Multiprocessing objects register finalizers that close pipes, unlink semaphores and write to the resource
+    # tracker; when cyclic garbage from one test is collected during a later one, those run against whatever that
+    # later test has patched onto os.close or os.write. Collect after every test so finalizers fire in the test that
+    # created the objects, before any such patch is in place. This runs after mocker's undo, since autouse fixtures
+    # set up first and tear down last.
+    yield
+    gc.collect()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gc
 import os
-import tracemalloc
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -39,7 +38,7 @@ def _tracemalloc_lookup_without_support() -> Iterator[None]:
     # error, so hand it the answer tracemalloc gives while it is not tracing.
     with pytest.MonkeyPatch.context() as patch:
         if not CAPABILITIES["tracemalloc-object-traceback"]:  # pragma: lacks tracemalloc-object-traceback
-            patch.setattr(tracemalloc, "get_object_traceback", lambda _source: None)
+            patch.setattr("tracemalloc.get_object_traceback", lambda _source: None)
         yield
 
 

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -351,7 +351,12 @@ def test_writer_preference_blocks_new_readers(lock_file: str) -> None:
         reader1.start()
         assert r1_held.wait(timeout=_PROCESS_DEADLINE)
         writer.start()
-        time.sleep(0.3)
+        # Start reader2 only once the writer's marker is on disk: a fixed sleep undershoots on a Windows runner still
+        # spawning the writer's interpreter, and reader2 then slips in ahead of the writer's intent.
+        deadline = time.monotonic() + _PROCESS_DEADLINE
+        while not Path(f"{lock_file}.write").exists():
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
         reader2.start()
         assert not r2_held.wait(timeout=0.5)
         r1_release.set()
@@ -369,11 +374,13 @@ def test_transaction_lock_timeout_across_threads(lock_file: str) -> None:
     # Two threads share one lock instance. Thread A holds the transaction lock while spinning on a peer
     # writer; thread B times out on the transaction lock, exercising the in-process Timeout path rather
     # than cross-process contention.
+    # Staleness is not under test: a peer heartbeat that stalls past a short threshold on a loaded runner would let
+    # thread A evict the peer and take the lock, turning thread B's Timeout into a same-instance ownership error.
     peer = SoftReadWriteLock(
         lock_file,
         is_singleton=False,
         heartbeat_interval=0.1,
-        stale_threshold=0.5,
+        stale_threshold=_PROCESS_DEADLINE,
         poll_interval=0.02,
     )
     peer.acquire_write(timeout=2)
@@ -382,7 +389,7 @@ def test_transaction_lock_timeout_across_threads(lock_file: str) -> None:
             lock_file,
             is_singleton=False,
             heartbeat_interval=0.1,
-            stale_threshold=0.5,
+            stale_threshold=_PROCESS_DEADLINE,
             poll_interval=0.02,
         )
         try:

--- a/tests/test_async_filelock.py
+++ b/tests/test_async_filelock.py
@@ -686,7 +686,7 @@ async def test_soft_close_error_policy_cleans_marker(
     lock_path = tmp_path / "a"
     lock = AsyncSoftFileLock(lock_path, close_error_policy=policy, run_in_executor=False)
     await lock.acquire()
-    with _close_after_commit(mocker) as (close_error, attempts):
+    with _close_after_commit(mocker, lock) as (close_error, attempts):
         if surfaces:
             with pytest.raises(OSError, match="close failed") as info:
                 await lock.release()
@@ -712,7 +712,7 @@ async def test_soft_close_error_suppression_releases_once(
     lock = AsyncSoftFileLock(lock_path, close_error_policy="suppress", run_in_executor=False)
     for _acquisition in range(depth):
         await lock.acquire()
-    with _close_after_commit(mocker) as (_, attempts):
+    with _close_after_commit(mocker, lock) as (_, attempts):
         if force:
             await lock.release(force=True)
         else:
@@ -734,7 +734,10 @@ async def test_soft_context_surfaces_close_error_after_cleanup(
 ) -> None:
     lock_path = tmp_path / "a"
     lock = AsyncSoftFileLock(lock_path, run_in_executor=False)
-    with _close_after_commit(mocker) as (close_error, attempts), pytest.raises(OSError, match="close failed") as info:
+    with (
+        _close_after_commit(mocker, lock) as (close_error, attempts),
+        pytest.raises(OSError, match="close failed") as info,
+    ):
         async with await lock.acquire() if use_proxy else lock:
             pass
     assert (info.value, len(attempts), lock.is_locked, lock_path.exists()) == (close_error, 1, False, False)
@@ -747,7 +750,10 @@ async def test_soft_second_release_does_not_close_reused_descriptor(
 ) -> None:
     lock = AsyncSoftFileLock(tmp_path / "a", run_in_executor=False)
     await lock.acquire()
-    with _close_after_commit(mocker) as (close_error, attempts), pytest.raises(OSError, match="close failed") as info:
+    with (
+        _close_after_commit(mocker, lock) as (close_error, attempts),
+        pytest.raises(OSError, match="close failed") as info,
+    ):
         await lock.release()
     assert info.value is close_error
     reused_fd = os.open(tmp_path / "reused", os.O_CREAT | os.O_WRONLY)
@@ -760,23 +766,29 @@ async def test_soft_second_release_does_not_close_reused_descriptor(
 
 
 @contextmanager
-def _close_after_commit(mocker: MockerFixture) -> Iterator[tuple[OSError, list[int]]]:
+def _close_after_commit(mocker: MockerFixture, lock: AsyncSoftFileLock) -> Iterator[tuple[OSError, list[int]]]:
     real_close = os.close
     close_error = OSError(EINTR, "close failed")
     attempts: list[int] = []
-    # close is an attribute of the shared os module, so this patch binds for every thread rather than just this one.
-    # Leave another thread's close alone: counting it would inflate attempts, and failing it would break whatever
-    # unrelated work happens to be closing a descriptor while this window is open. Every lock here runs with
-    # run_in_executor=False, so the closes under test stay on this thread.
-    caller = threading.get_ident()
+    # close is an attribute of the shared os module, so this patch binds for every close in the process while the
+    # window is open, including one a GC-run finalizer (a multiprocessing pipe from an earlier test, say) makes on this
+    # very thread. Fail only the descriptor this lock lets go of: it clears its bookkeeping right before the one close
+    # attempt, so record the descriptor as it does.
+    released: list[int | None] = []
+    real_mark_released = lock._mark_descriptor_released
+
+    def mark_released() -> None:
+        released.append(lock._context.lock_file_fd)
+        real_mark_released()
 
     def close(fd: int) -> None:
         real_close(fd)
-        if threading.get_ident() != caller:
+        if fd not in released:
             return
         attempts.append(fd)
         raise close_error
 
+    mocker.patch.object(lock, "_mark_descriptor_released", side_effect=mark_released)
     close_mock = mocker.patch("filelock._soft.os.close", side_effect=close)
     try:
         yield close_error, attempts
@@ -784,24 +796,30 @@ def _close_after_commit(mocker: MockerFixture) -> Iterator[tuple[OSError, list[i
         mocker.stop(close_mock)
 
 
-def test_close_after_commit_ignores_closes_from_other_threads(mocker: MockerFixture) -> None:
-    # The patch binds os.close process-wide, so a descriptor closed on another thread must pass through cleanly and
-    # stay out of the caller's recorded attempts rather than absorb the injected failure.
+@pytest.mark.asyncio
+async def test_close_after_commit_ignores_other_descriptors(tmp_path: Path, mocker: MockerFixture) -> None:
+    # The patch binds os.close process-wide, so a descriptor that is not the lock's, whether closed on another thread
+    # or by a finalizer the collector happens to run on this one, must pass through cleanly and stay out of the
+    # recorded attempts.
+    lock = AsyncSoftFileLock(tmp_path / "a", run_in_executor=False)
+    await lock.acquire()
     closed: list[int] = []
 
     def close_a_pipe() -> None:
         read_fd, write_fd = os.pipe()
         os.close(read_fd)
-        os.close(write_fd)  # a non-caller thread: passes through untouched rather than raising the injected error
+        os.close(write_fd)
         closed.extend((read_fd, write_fd))
 
-    with _close_after_commit(mocker) as (_close_error, attempts):
+    with _close_after_commit(mocker, lock) as (_close_error, attempts):
+        close_a_pipe()
         worker = threading.Thread(target=close_a_pipe)
         worker.start()
         worker.join()
+        with pytest.raises(OSError, match="close failed"):
+            await lock.release()
 
-    assert len(closed) == 2
-    assert attempts == []
+    assert (len(closed), len(attempts), attempts[0] in closed) == (4, 1, False)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_soft_stale.py
+++ b/tests/test_soft_stale.py
@@ -507,7 +507,7 @@ def test_close_error_policy_cleans_marker(
 ) -> None:
     lock = SoftFileLock(lock_path, close_error_policy=policy)
     lock.acquire()
-    with _close_after_commit(mocker) as (close_error, attempts):
+    with _close_after_commit(mocker, lock) as (close_error, attempts):
         if surfaces:
             with pytest.raises(OSError, match="close failed") as info:
                 lock.release()
@@ -531,7 +531,7 @@ def test_close_error_suppression_releases_once(
     lock = SoftFileLock(lock_path, close_error_policy="suppress")
     for _acquisition in range(depth):
         lock.acquire()
-    with _close_after_commit(mocker) as (_, attempts):
+    with _close_after_commit(mocker, lock) as (_, attempts):
         if force:
             lock.release(force=True)
         else:
@@ -552,7 +552,7 @@ def test_context_surfaces_close_error_after_cleanup(
 ) -> None:
     lock = SoftFileLock(lock_path)
     with (
-        _close_after_commit(mocker) as (close_error, attempts),
+        _close_after_commit(mocker, lock) as (close_error, attempts),
         pytest.raises(OSError, match="close failed") as info,
         lock.acquire() if use_proxy else lock,
     ):
@@ -567,7 +567,10 @@ def test_second_release_does_not_close_reused_descriptor(
 ) -> None:
     lock = SoftFileLock(lock_path)
     lock.acquire()
-    with _close_after_commit(mocker) as (close_error, attempts), pytest.raises(OSError, match="close failed") as info:
+    with (
+        _close_after_commit(mocker, lock) as (close_error, attempts),
+        pytest.raises(OSError, match="close failed") as info,
+    ):
         lock.release()
     assert info.value is close_error
     reused_fd = os.open(tmp_path / "reused", os.O_CREAT | os.O_WRONLY)
@@ -585,7 +588,7 @@ def test_close_error_spares_successor_marker(lock_path: Path, mocker: MockerFixt
     holder.acquire()
     lock_path.unlink()
     lock_path.write_text(_holder(_DEAD_PID), encoding="utf-8")
-    with _close_after_commit(mocker) as (_, _attempts), pytest.raises(OSError, match="close failed"):
+    with _close_after_commit(mocker, holder) as (_, _attempts), pytest.raises(OSError, match="close failed"):
         holder.release()
     assert lock_path.read_text(encoding="utf-8") == _holder(_DEAD_PID)
 
@@ -595,7 +598,7 @@ def test_close_and_marker_cleanup_failures_are_grouped(lock_path: Path, mocker: 
     lock.acquire()
     cleanup_error = RuntimeError("cleanup failed")
     unlink_mock = mocker.patch("filelock._soft.Path.unlink", side_effect=cleanup_error)
-    with _close_after_commit(mocker) as (close_error, _attempts), pytest.raises(ExceptionGroup) as info:
+    with _close_after_commit(mocker, lock) as (close_error, _attempts), pytest.raises(ExceptionGroup) as info:
         lock.release()
     mocker.stop(unlink_mock)
     assert (
@@ -613,43 +616,55 @@ def test_close_and_marker_cleanup_failures_are_grouped(lock_path: Path, mocker: 
     )
 
 
-def test_close_after_commit_ignores_closes_from_other_threads(mocker: MockerFixture) -> None:
-    # The patch binds os.close process-wide, so a descriptor closed on another thread must pass through cleanly and
-    # stay out of the caller's recorded attempts rather than absorb the injected failure.
+def test_close_after_commit_ignores_other_descriptors(lock_path: Path, mocker: MockerFixture) -> None:
+    # The patch binds os.close process-wide, so a descriptor that is not the lock's, whether closed on another thread
+    # or by a finalizer the collector happens to run on this one, must pass through cleanly and stay out of the
+    # recorded attempts.
+    lock = SoftFileLock(lock_path)
+    lock.acquire()
     closed: list[int] = []
 
     def close_a_pipe() -> None:
         read_fd, write_fd = os.pipe()
         os.close(read_fd)
-        os.close(write_fd)  # a non-caller thread: passes through untouched rather than raising the injected error
+        os.close(write_fd)
         closed.extend((read_fd, write_fd))
 
-    with _close_after_commit(mocker) as (_close_error, attempts):
+    with _close_after_commit(mocker, lock) as (_close_error, attempts):
+        close_a_pipe()
         worker = threading.Thread(target=close_a_pipe)
         worker.start()
         worker.join()
+        with pytest.raises(OSError, match="close failed"):
+            lock.release()
 
-    assert len(closed) == 2
-    assert attempts == []
+    assert (len(closed), len(attempts), attempts[0] in closed) == (4, 1, False)
 
 
 @contextmanager
-def _close_after_commit(mocker: MockerFixture) -> Iterator[tuple[OSError, list[int]]]:
+def _close_after_commit(mocker: MockerFixture, lock: SoftFileLock) -> Iterator[tuple[OSError, list[int]]]:
     real_close = os.close
     close_error = OSError(EINTR, "close failed")
     attempts: list[int] = []
-    # close is an attribute of the shared os module, so this patch binds for every thread rather than just this one.
-    # Leave another thread's close alone: counting it would inflate attempts, and failing it would break whatever
-    # unrelated work happens to be closing a descriptor while this window is open.
-    caller = threading.get_ident()
+    # close is an attribute of the shared os module, so this patch binds for every close in the process while the
+    # window is open, including one a GC-run finalizer (a multiprocessing pipe from an earlier test, say) makes on this
+    # very thread. Fail only the descriptor this lock lets go of: it clears its bookkeeping right before the one close
+    # attempt, so record the descriptor as it does.
+    released: list[int | None] = []
+    real_mark_released = lock._mark_descriptor_released
+
+    def mark_released() -> None:
+        released.append(lock._context.lock_file_fd)
+        real_mark_released()
 
     def close(fd: int) -> None:
         real_close(fd)
-        if threading.get_ident() != caller:
+        if fd not in released:
             return
         attempts.append(fd)
         raise close_error
 
+    mocker.patch.object(lock, "_mark_descriptor_released", side_effect=mark_released)
     close_mock = mocker.patch("filelock._soft.os.close", side_effect=close)
     try:
         yield close_error, attempts

--- a/tests/test_strict_soft_races.py
+++ b/tests/test_strict_soft_races.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal
 import pytest
 
 from filelock import StrictSoftFileLock, Timeout
+from filelock._strict import _CLAIM_MAGIC
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -144,9 +145,12 @@ def test_strict_soft_private_partial_record_is_not_a_claim(tmp_path: Path, mocke
     real_write = os.write
     paused = False
 
+    # The patch binds os.write process-wide, so key the pause to the claim record itself: a finalizer the collector
+    # runs on the "partial" thread may write to the resource tracker's pipe meanwhile, and truncating that command
+    # breaks the tracker rather than this test.
     def paused_write(fd: int, data: bytes | bytearray | memoryview) -> int:
         nonlocal paused
-        if threading.current_thread().name != "partial" or paused:
+        if threading.current_thread().name != "partial" or paused or not bytes(data).startswith(_CLAIM_MAGIC.encode()):
             return real_write(fd, data)
         paused = True
         written = real_write(fd, data[:1])


### PR DESCRIPTION
Every scheduled run on `main` fails a different test, and most of them share one cause: a test patches `os.close` or `os.write` process-wide, and a `multiprocessing` finalizer that the collector happens to run on the test thread takes the injected fault first. `_close_after_commit` now fails only the descriptor the lock relinquishes ([3.12 macos](https://github.com/tox-dev/filelock/actions/runs/31372766126/job/93405207348) `assert 22 == 35`, [graalpy](https://github.com/tox-dev/filelock/actions/runs/30900433000/job/91963199080), [graalpy](https://github.com/tox-dev/filelock/actions/runs/30694389911/job/91354605697)); the partial-record write pause keys on the strict claim magic so the resource tracker's `UNREGISTER` command is never truncated ([3.14 ubuntu](https://github.com/tox-dev/filelock/actions/runs/31372766126/job/93405207311) `unrecognized command 'UUNREGISTER'`); and an autouse `gc.collect()` after every test makes finalizers fire in the test that created their objects, before a later test patches anything ([3.10 ubuntu](https://github.com/tox-dev/filelock/actions/runs/31092921026/job/92587941637) `sem_unlink` `FileNotFoundError` x10, [3.12 macos](https://github.com/tox-dev/filelock/actions/runs/31015852373/job/92339568415) `nbytes 0 but len(msg) 34` x10) (no measurable change to the suite's wall time locally). Two soft-rw timing assumptions go too: `test_writer_preference_blocks_new_readers` waits for the writer's marker instead of sleeping 0.3s, which a Windows spawn undershoots ([3.12 windows](https://github.com/tox-dev/filelock/actions/runs/31639638774/job/94258608106)), and `test_transaction_lock_timeout_across_threads` stops using a 0.5s stale threshold that let thread A evict the peer on a loaded runner and turn thread B's `Timeout` into an ownership error ([3.14t macos](https://github.com/tox-dev/filelock/actions/runs/31580638361/job/94062634925)). Finally, pytest's thread and unraisable exception hooks call `tracemalloc.get_object_traceback`, which GraalPy does not implement, so every background-thread error there surfaced as `RuntimeError: Failed to process thread exception` ([1](https://github.com/tox-dev/filelock/actions/runs/31303510919/job/93220017536), [2](https://github.com/tox-dev/filelock/actions/runs/30623424984/job/91133020003), [3](https://github.com/tox-dev/filelock/actions/runs/30497248451/job/90728814320)); a probed `tracemalloc-object-traceback` capability stubs the lookup where it raises so the real error shows.

