### PR TITLE
🐛 fix: retry transient denials on open and claim read

### DIFF
--- a/docs/changelog/705.bugfix.1.rst
+++ b/docs/changelog/705.bugfix.1.rst
@@ -1,0 +1,3 @@
+``WindowsFileLock`` waits out a transient ``STATUS_ACCESS_DENIED`` from ``NtCreateFile`` for up to half a second
+before raising ``PermissionError``, since a peer unlinking the lock file as it releases can answer that for a moment; a
+real denial still fails fast.

--- a/docs/changelog/705.bugfix.2.rst
+++ b/docs/changelog/705.bugfix.2.rst
@@ -1,0 +1,2 @@
+``StrictSoftFileLock`` always retries a claim read whose first attempt reports the claim as pending, so a first read
+that itself outlasts the retry grace no longer fails closed on a claim it could have read.

--- a/src/filelock/_strict.py
+++ b/src/filelock/_strict.py
@@ -335,16 +335,16 @@ def _read_claim_record(lock_file: str, directory: Path, name: str) -> bytes | No
     # completes. On NFS, a peer that unlinks its own claim leaves this client's cached filehandle stale, so the next
     # open returns ESTALE rather than a clean ENOENT until the lookup revalidates against the server. Retrying re-runs
     # the path lookup, which turns the vanished claim into ENOENT (skip) or reads it if it still exists. A genuinely
-    # unreadable record (a locked-down file, an EIO fault) still fails closed.
-    deadline = time.monotonic() + _CLAIM_READ_GRACE
-    delaying = False
+    # unreadable record (a locked-down file, an EIO fault) still fails closed. The grace starts at the first pending
+    # result rather than before the first attempt, so a slow first read cannot use up the window and leave no retry.
+    deadline: float | None = None
     while True:
-        if delaying:
-            time.sleep(_CLAIM_READ_RETRY)
         record, pending = _attempt_claim_read(lock_file, directory, name)
         if pending is None:
             return record
-        if time.monotonic() >= deadline:
+        if deadline is None:
+            deadline = time.monotonic() + _CLAIM_READ_GRACE
+        elif time.monotonic() >= deadline:
             if pending.errno == ESTALE:
                 # A stale handle that outlives revalidation is a claim the server no longer has (RFC 1813
                 # NFS3ERR_STALE): skip it like ENOENT. Skipping a peer's vanished claim can only overcount
@@ -352,7 +352,7 @@ def _read_claim_record(lock_file: str, directory: Path, name: str) -> bytes | No
                 return None
             reason = f"cannot read claim: {pending.strerror or str(pending) or type(pending).__name__}"
             raise SoftFileLockProtocolError(lock_file, name, reason) from pending
-        delaying = True
+        time.sleep(_CLAIM_READ_RETRY)
 
 
 def _attempt_claim_read(lock_file: str, directory: Path, name: str) -> tuple[bytes | None, OSError | None]:

--- a/src/filelock/_windows.py
+++ b/src/filelock/_windows.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from contextlib import suppress
 from pathlib import Path
 from typing import Final, cast
@@ -49,6 +50,10 @@ if sys.platform == "win32":  # pragma: win32 cover
     _STATUS_ACCESS_DENIED: Final[int] = 0xC0000022
     _STATUS_SHARING_VIOLATION: Final[int] = 0xC0000043
     _STATUS_DELETE_PENDING: Final[int] = 0xC0000056
+    #: How long an open waits out a STATUS_ACCESS_DENIED before treating it as a real denial: NTFS answers it for a
+    #: moment while a peer's unlink tears the name down, so a bounded wait keeps a real denial failing fast (#604).
+    _ACCESS_DENIED_GRACE: Final[float] = 0.5
+    _ACCESS_DENIED_RETRY: Final[float] = 0.002
 
     _ntdll: Final[ctypes.WinDLL] = ctypes.WinDLL("ntdll")
     _kernel32: Final[ctypes.WinDLL] = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -235,12 +240,19 @@ if sys.platform == "win32":  # pragma: win32 cover
             name the caller should treat as contention and retry.
 
         :raises OSError: if the path resolves to a reparse point, or the open fails for any other reason, raised with
-            the Win32 error the status maps to.
+            the Win32 error the status maps to. An access denial is raised only once it outlasts a short grace, since
+            a peer unlinking the file as it releases can make the open answer ``STATUS_ACCESS_DENIED`` for a moment.
 
         """
         # Emit the audit event os.open would, so consumers watching "open" still see the path-level open and can veto.
         sys.audit("open", path, None, os.O_RDWR | os.O_CREAT)
-        handle, status = _nt_open(path, read_only=not mode & _OWNER_WRITE)
+        read_only = not mode & _OWNER_WRITE
+        handle, status = _nt_open(path, read_only=read_only)
+        if status == _STATUS_ACCESS_DENIED:
+            deadline = time.monotonic() + _ACCESS_DENIED_GRACE
+            while status == _STATUS_ACCESS_DENIED and time.monotonic() < deadline:
+                time.sleep(_ACCESS_DENIED_RETRY)
+                handle, status = _nt_open(path, read_only=read_only)
         if status != _STATUS_SUCCESS:
             if status in {_STATUS_SHARING_VIOLATION, _STATUS_DELETE_PENDING}:
                 return None

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1606,9 +1606,37 @@ def test_windows_delete_pending_is_treated_as_contention(tmp_path: Path, mocker:
 
 @_WINDOWS_ONLY  # pragma: win32 cover
 def test_windows_permanent_denial_raises_without_timeout(tmp_path: Path, mocker: MockerFixture) -> None:
-    mocker.patch("filelock._windows._nt_open", return_value=(0, 0xC0000022))  # STATUS_ACCESS_DENIED
+    mocker.patch("filelock._windows._ACCESS_DENIED_GRACE", 0.02)
+    nt_open = mocker.patch("filelock._windows._nt_open", return_value=(0, 0xC0000022))  # STATUS_ACCESS_DENIED
+    started = time.monotonic()
     with pytest.raises(PermissionError):
         FileLock(str(tmp_path / "a"), timeout=5).acquire()
+    # The denial outlasted its grace, so it surfaced after a bounded wait rather than the caller's timeout.
+    assert 0.02 <= time.monotonic() - started < 5
+    assert nt_open.call_count > 1
+
+
+@_WINDOWS_ONLY  # pragma: win32 cover
+def test_windows_transient_denial_is_retried_within_grace(tmp_path: Path, mocker: MockerFixture) -> None:
+    # A peer unlinking the lock file as it releases can make NtCreateFile answer STATUS_ACCESS_DENIED for a moment,
+    # which the open must wait out instead of raising a PermissionError. timeout=0 leaves the acquire loop one attempt,
+    # so the retry has to come from the open itself. The marker skips the run; the guard only narrows the import for
+    # ty, so it goes one way.
+    if sys.platform == "win32":  # pragma: no branch
+        from filelock._windows import _nt_open as real_nt_open
+
+        statuses = [0xC0000022]
+
+        def deny_once(path: str, *, read_only: bool) -> tuple[int, int]:
+            if statuses:
+                return 0, statuses.pop()
+            return real_nt_open(path, read_only=read_only)
+
+        nt_open = mocker.patch("filelock._windows._nt_open", side_effect=deny_once)
+        lock = FileLock(str(tmp_path / "a"), timeout=0)
+        lock.acquire()
+        assert (lock.is_locked, nt_open.call_count) == (True, 2)
+        lock.release()
 
 
 @_WINDOWS_ONLY  # pragma: win32 cover

--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -1292,6 +1292,28 @@ def test_strict_soft_permission_denied_claim_read_fails_closed(tmp_path: Path, m
         _ = StrictSoftFileLock(lock_path).claims
 
 
+def test_strict_soft_claim_read_retries_after_a_slow_denied_attempt(tmp_path: Path, mocker: MockerFixture) -> None:
+    # The grace window opens at the first pending result, so a first attempt that itself outlasts the window still
+    # gets a retry rather than failing closed on a transient denial.
+    lock_path = tmp_path / "resource.lock"
+    claim = _write_held_claim(Path(f"{lock_path}.filelock") / "claims")
+    mocker.patch("filelock._strict._CLAIM_READ_GRACE", 0.02)
+    real_open = os.open
+    denied = False
+
+    def deny_slowly_once(path: _PathValue, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        nonlocal denied
+        if not denied and os.fsdecode(path) == str(claim):
+            denied = True
+            time.sleep(0.05)
+            raise PermissionError(EACCES, "sharing violation")
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    mocker.patch("filelock._strict.os.open", side_effect=deny_slowly_once)
+
+    assert ([found.name for found in StrictSoftFileLock(lock_path).claims], denied) == ([claim.name], True)
+
+
 def test_strict_soft_ignores_malformed_private_record_name(tmp_path: Path) -> None:
     lock_path = tmp_path / "resource.lock"
     claims = Path(f"{lock_path}.filelock") / "claims"


### PR DESCRIPTION
Two bounded retry windows each had a gap a loaded runner fell through. `WindowsFileLock` opens its file through `NtCreateFile` and retried only `STATUS_SHARING_VIOLATION` and `STATUS_DELETE_PENDING`, but a peer's unlink in `_release` racing the open can answer `STATUS_ACCESS_DENIED` for a moment, which surfaced as `PermissionError: [WinError 5]` from `test_threaded_shared_lock_obj[WindowsFileLock]` under 100 free-threaded threads ([3.14t windows](https://github.com/tox-dev/filelock/actions/runs/31248322058/job/93080488826), [3.15t windows](https://github.com/tox-dev/filelock/actions/runs/31303510919/job/93220017601)); the open now waits out an access denial for up to 0.5s before raising, so a real denial still fails fast instead of spinning until the caller's timeout (#604). `_read_claim_record` computed its 0.5s grace deadline before the first read attempt, so a first attempt that itself ran slow left no retry and `test_strict_soft_claim_replaced_while_opening_fails_closed[directory]` got `cannot read claim: Permission denied` in place of `is not a regular file` ([3.14t windows](https://github.com/tox-dev/filelock/actions/runs/31785796178/job/94721289610)); the window now opens at the first pending result, which guarantees a retry. Tests cover a denial that clears within the grace, one that outlasts it, and a first claim read that outlasts the grace on its own.
