### PR TITLE
🧪 test: cover a reclaimed private record for real

### DIFF
--- a/tests/test_strict_soft_failures.py
+++ b/tests/test_strict_soft_failures.py
@@ -1180,6 +1180,33 @@ def test_strict_soft_private_inspection_failure_unlinks_vanished_record(tmp_path
     assert lock.is_locked is False
 
 
+def test_strict_soft_private_record_reclaimed_after_close_is_tolerated(tmp_path: Path, mocker: MockerFixture) -> None:
+    lock_path = tmp_path / "resource.lock"
+    _initialize_protocol(lock_path)
+    real_close = os.close
+    real_open_relative = filelock._strict._open_relative
+    private_records: dict[int, Path] = {}
+
+    def capture_private_record(directory_ref: tuple[str, int | None], name: str, flags: int, mode: int) -> int:
+        fd = real_open_relative(directory_ref, name, flags, mode)
+        private_records[fd] = Path(directory_ref[0], name)
+        return fd
+
+    def reclaim_on_close(fd: int) -> None:
+        real_close(fd)
+        if (record := private_records.pop(fd, None)) is not None:
+            record.unlink()
+
+    mocker.patch("filelock._strict._open_relative", side_effect=capture_private_record)
+    mocker.patch("filelock._strict.os.close", side_effect=reclaim_on_close)
+    lock = StrictSoftFileLock(lock_path, timeout=0)
+
+    lock.acquire()
+    assert lock.is_locked is True
+    lock.release()
+    assert lock.is_locked is False
+
+
 def test_strict_soft_record_finalization_close_and_unlink_failures_group(tmp_path: Path, mocker: MockerFixture) -> None:
     lock_path = tmp_path / "resource.lock"
     _initialize_protocol(lock_path)


### PR DESCRIPTION
The `FileNotFoundError` arm of `_relative_identity` (`_strict.py:634-635`) was only reached by races in the stress tests, so the 100% gate failed when they did not occur (https://github.com/tox-dev/filelock/actions/runs/31871461866, 3.14t Windows). Add a test that reclaims the private record right after its descriptor is closed — the post-publication cleanup then sees it missing — which is valid on Windows too, unlike unlinking it while open.