### PR TITLE
🧪 test(fork): report where a stalled fork stops

### DIFF
--- a/tests/test_fork_coordination.py
+++ b/tests/test_fork_coordination.py
@@ -777,7 +777,9 @@ def test_cancelled_async_acquire_unregisters_reused_descriptor(tmp_path: Path) -
 from __future__ import annotations
 
 import asyncio
+import faulthandler
 import os
+import signal
 import sys
 import threading
 import time
@@ -786,6 +788,21 @@ import warnings
 from filelock import AsyncFileLock
 
 warnings.filterwarnings("ignore", message=".*multi-threaded, use of fork.*", category=DeprecationWarning)
+
+child_pid = 0
+
+def report_stall(_signum: int, _frame: object) -> None:
+    # Every wait below is bounded, so reaching this means something wedged: the NetBSD fork deadlock (#707, #689)
+    # arrived as a bare SIGKILL naming nothing. Print every stack, then kill the child, which holds the captured
+    # pipes: subprocess.run() waits for those to close even after it has killed this process.
+    faulthandler.dump_traceback(all_threads=True)
+    if child_pid:
+        os.kill(child_pid, signal.SIGKILL)
+    os._exit(7)
+
+faulthandler.enable()
+signal.signal(signal.SIGALRM, report_stall)
+signal.alarm(15)
 
 async def main() -> tuple[int, tuple[int, int]]:
     callback_started = asyncio.Event()
@@ -853,6 +870,7 @@ if child_pid == 0:
         os._exit(1)
     os._exit(0 if (replacement_stat.st_dev, replacement_stat.st_ino) == identity else 2)
 _, status = os.waitpid(child_pid, 0)
+signal.alarm(0)
 os.close(descriptor)
 raise SystemExit(os.waitstatus_to_exitcode(status))
 """


### PR DESCRIPTION
NetBSD has wedged `test_cancelled_async_acquire_unregisters_reused_descriptor` twice, in #689 and again in #707. Both
reports arrived as a `subprocess.TimeoutExpired` with return code -9, naming neither side of the fork. #693 and #714
each read the surrounding code and changed what looked wrong, and no one has run either change on the platform.

Every wait in that script is bounded, so a stall means a defect rather than a slow builder. A SIGALRM watchdog now
prints each thread's stack and exits 7, which reaches the `result.stderr` the assertion already reports.

The watchdog also kills the forked child before it exits. That child inherits the captured stdout and stderr pipes, and
`subprocess.run()` waits for those to close even after it kills the process it started, so a wedged child blocks the
parent test past its own timeout.

I injected a stall on each side of the fork to check both paths. A stalled parent and a wedged child each report at 15
seconds with a stack naming the blocked line, and `subprocess.run()` returns instead of waiting on the pipes.

The change touches one test, so it carries the `skip news` label.
