### PR TITLE
📝 docs: say that mode is read-only in the thread-local section

### DIFF
--- a/docs/changelog/716.doc.rst
+++ b/docs/changelog/716.doc.rst
@@ -1,1 +1,1 @@
-Clarify in the thread-local section that ``mode`` is read-only and fixed at construction, unlike ``poll_interval``, ``timeout``, ``blocking`` and ``lifetime``; assigning ``mode`` raises ``AttributeError``.
+Document that ``mode`` has no setter: unlike ``poll_interval``, ``timeout``, ``blocking`` and ``lifetime``, it is fixed at construction and ``lock.mode = ...`` raises ``AttributeError``.

--- a/docs/changelog/716.doc.rst
+++ b/docs/changelog/716.doc.rst
@@ -1,0 +1,1 @@
+Clarify in the thread-local section that ``mode`` is read-only and fixed at construction, unlike ``poll_interval``, ``timeout``, ``blocking`` and ``lifetime``; assigning ``mode`` raises ``AttributeError``.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -730,13 +730,13 @@ each thread gets its own context via ``threading.local``. This means:
 - Two threads holding the same ``FileLock`` object each maintain
   independent lock counters.
 - Thread A releasing the lock doesn't affect Thread B's counter.
-- Setting a writable configuration property (``poll_interval``, ``timeout``,
-  ``blocking``, or ``lifetime``; ``mode`` is read-only and fixed at
-  construction) - for example ``lock.poll_interval = 0.5`` - affects only the
-  thread that performed the write. Other threads continue to see the value
-  supplied to the lock's constructor; ``threading.local`` re-applies the
-  original constructor arguments the first time each new thread accesses the
-  context.
+- Setting a configuration property (for example ``lock.poll_interval = 0.5``)
+  affects only the thread that performed the write. Other threads continue
+  to see the value supplied to the lock's constructor; ``threading.local``
+  re-applies the original constructor arguments the first time each new
+  thread accesses the context.
+- ``mode`` is the one exception: it has no setter, so construction is the only
+  place it is ever set and ``lock.mode = ...`` raises ``AttributeError``.
 
 When ``thread_local=False``, all threads share the same context, including
 configuration values. This is useful for objects passed between threads or

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -730,11 +730,13 @@ each thread gets its own context via ``threading.local``. This means:
 - Two threads holding the same ``FileLock`` object each maintain
   independent lock counters.
 - Thread A releasing the lock doesn't affect Thread B's counter.
-- Setting a configuration property (for example ``lock.poll_interval = 0.5``)
-  affects only the thread that performed the write. Other threads continue
-  to see the value supplied to the lock's constructor; ``threading.local``
-  re-applies the original constructor arguments the first time each new
-  thread accesses the context.
+- Setting a writable configuration property (``poll_interval``, ``timeout``,
+  ``blocking``, or ``lifetime``; ``mode`` is read-only and fixed at
+  construction) - for example ``lock.poll_interval = 0.5`` - affects only the
+  thread that performed the write. Other threads continue to see the value
+  supplied to the lock's constructor; ``threading.local`` re-applies the
+  original constructor arguments the first time each new thread accesses the
+  context.
 
 When ``thread_local=False``, all threads share the same context, including
 configuration values. This is useful for objects passed between threads or

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -673,10 +673,11 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
         :param thread_local: Whether this object's internal context should be thread local or not. If this is set to
             ``False`` then the lock will be reentrant across threads. When ``True`` (the default), **all fields of the
             lock's internal context are per-thread**, including the configuration values ``poll_interval``, ``timeout``,
-            ``blocking``, ``mode``, and ``lifetime``. Setting one of these properties from one thread does not change
-            the value seen by another thread; threads that did not perform the write continue to see the value supplied
-            at construction time. If you need configuration values to be visible across threads, construct the lock
-            with ``thread_local=False``.
+            ``blocking``, ``mode``, and ``lifetime``. Setting one of the writable properties (``poll_interval``,
+            ``timeout``, ``blocking``, or ``lifetime``; ``mode`` is read-only and fixed at construction) from one
+            thread does not change the value seen by another thread; threads that did not perform the write
+            continue to see the value supplied at construction time. If you need configuration values to be
+            visible across threads, construct the lock with ``thread_local=False``.
         :param blocking: whether the lock should be blocking or not
         :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per lock
             file. This is useful if you want to use the lock object for reentrant locking without needing to pass the

--- a/src/filelock/_api.py
+++ b/src/filelock/_api.py
@@ -673,11 +673,10 @@ class BaseFileLock(contextlib.ContextDecorator, metaclass=FileLockMeta):  # ruff
         :param thread_local: Whether this object's internal context should be thread local or not. If this is set to
             ``False`` then the lock will be reentrant across threads. When ``True`` (the default), **all fields of the
             lock's internal context are per-thread**, including the configuration values ``poll_interval``, ``timeout``,
-            ``blocking``, ``mode``, and ``lifetime``. Setting one of the writable properties (``poll_interval``,
-            ``timeout``, ``blocking``, or ``lifetime``; ``mode`` is read-only and fixed at construction) from one
-            thread does not change the value seen by another thread; threads that did not perform the write
-            continue to see the value supplied at construction time. If you need configuration values to be
-            visible across threads, construct the lock with ``thread_local=False``.
+            ``blocking``, ``mode``, and ``lifetime``. Setting one of these properties from one thread does not change
+            the value seen by another thread; threads that did not perform the write continue to see the value supplied
+            at construction time. ``mode`` has no setter, so construction is the only place it is ever set. If you need
+            configuration values to be visible across threads, construct the lock with ``thread_local=False``.
         :param blocking: whether the lock should be blocking or not
         :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per lock
             file. This is useful if you want to use the lock object for reentrant locking without needing to pass the

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -165,10 +165,11 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         :param thread_local: Whether this object's internal context should be thread local or not. If this is set to
             ``False`` then the lock will be reentrant across threads. When ``True`` (the default), **all fields of the
             lock's internal context are per-thread**, including the configuration values ``poll_interval``, ``timeout``,
-            ``blocking``, ``mode``, and ``lifetime``. Setting one of these properties from one thread does not change
-            the value seen by another thread; threads that did not perform the write continue to see the value supplied
-            at construction time. If you need configuration values to be visible across threads, construct the lock
-            with ``thread_local=False``.
+            ``blocking``, ``mode``, and ``lifetime``. Setting one of the writable properties (``poll_interval``,
+            ``timeout``, ``blocking``, or ``lifetime``; ``mode`` is read-only and fixed at construction) from one
+            thread does not change the value seen by another thread; threads that did not perform the write
+            continue to see the value supplied at construction time. If you need configuration values to be
+            visible across threads, construct the lock with ``thread_local=False``.
         :param blocking: whether the lock should be blocking or not
         :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per lock
             file. This is useful if you want to use the lock object for reentrant locking without needing to pass the

--- a/src/filelock/asyncio.py
+++ b/src/filelock/asyncio.py
@@ -165,11 +165,10 @@ class BaseAsyncFileLock(BaseFileLock, metaclass=AsyncFileLockMeta):
         :param thread_local: Whether this object's internal context should be thread local or not. If this is set to
             ``False`` then the lock will be reentrant across threads. When ``True`` (the default), **all fields of the
             lock's internal context are per-thread**, including the configuration values ``poll_interval``, ``timeout``,
-            ``blocking``, ``mode``, and ``lifetime``. Setting one of the writable properties (``poll_interval``,
-            ``timeout``, ``blocking``, or ``lifetime``; ``mode`` is read-only and fixed at construction) from one
-            thread does not change the value seen by another thread; threads that did not perform the write
-            continue to see the value supplied at construction time. If you need configuration values to be
-            visible across threads, construct the lock with ``thread_local=False``.
+            ``blocking``, ``mode``, and ``lifetime``. Setting one of these properties from one thread does not change
+            the value seen by another thread; threads that did not perform the write continue to see the value supplied
+            at construction time. ``mode`` has no setter, so construction is the only place it is ever set. If you need
+            configuration values to be visible across threads, construct the lock with ``thread_local=False``.
         :param blocking: whether the lock should be blocking or not
         :param is_singleton: If this is set to ``True`` then only one instance of this class will be created per lock
             file. This is useful if you want to use the lock object for reentrant locking without needing to pass the

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -787,6 +787,25 @@ def test_non_thread_local_setter_visibility(lock_type: type[BaseFileLock], tmp_p
     assert observed == [pytest.approx(0.5)]
 
 
+@pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+def test_mode_is_read_only(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+    """``mode`` is fixed at construction; the other config properties are writable.
+
+    The thread-local documentation lists ``mode`` among the per-thread context
+    fields but, unlike ``poll_interval``, ``timeout``, ``blocking`` and
+    ``lifetime``, it has no setter. This pins that contract so the docstring and
+    the code cannot drift.
+    """
+    lock = lock_type(tmp_path / "x.lock", mode=0o644)
+
+    with pytest.raises(AttributeError):
+        lock.mode = 0o600  # ty: ignore[invalid-assignment]  # intentionally assigning a read-only property
+
+    # the properties the docstring lists as writable each expose a setter.
+    for prop in ("poll_interval", "timeout", "blocking", "lifetime"):
+        assert getattr(type(lock), prop).fset is not None, prop
+
+
 def test_subclass_compatibility(tmp_path: Path) -> None:
     class MyFileLock(FileLock):
         def __init__(

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -789,21 +789,17 @@ def test_non_thread_local_setter_visibility(lock_type: type[BaseFileLock], tmp_p
 
 @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
 def test_mode_is_read_only(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
-    """``mode`` is fixed at construction; the other config properties are writable.
+    """``mode`` has no setter, unlike the other per-thread configuration values.
 
-    The thread-local documentation lists ``mode`` among the per-thread context
-    fields but, unlike ``poll_interval``, ``timeout``, ``blocking`` and
-    ``lifetime``, it has no setter. This pins that contract so the docstring and
-    the code cannot drift.
+    Reading it back afterwards separates a missing setter from a missing attribute; no ``match`` because the message
+    differs across interpreters.
     """
     lock = lock_type(tmp_path / "x.lock", mode=0o644)
 
     with pytest.raises(AttributeError):
-        lock.mode = 0o600  # ty: ignore[invalid-assignment]  # intentionally assigning a read-only property
+        lock.mode = 0o600  # ty: ignore[invalid-assignment]  # the absent setter is the contract under test
 
-    # the properties the docstring lists as writable each expose a setter.
-    for prop in ("poll_interval", "timeout", "blocking", "lifetime"):
-        assert getattr(type(lock), prop).fset is not None, prop
+    assert lock.mode == 0o644
 
 
 def test_subclass_compatibility(tmp_path: Path) -> None:


### PR DESCRIPTION
The thread-local section from #543 lists `mode` among the per-thread configuration values and then says that setting one of these properties from one thread leaves the value other threads see alone. 📝 `mode` has no setter, so `lock.mode = ...` raises `AttributeError`, and the sentence promises an operation the API does not offer.

`mode` stays in the list, because the context does hold it per thread. What changes is one added sentence naming the missing setter, in the `thread_local` parameter docs of `BaseFileLock` and `BaseAsyncFileLock` and as its own bullet in `docs/concepts.rst`. Splitting it into a separate bullet keeps the surrounding sentence about property setters reading the way it did before.

No behaviour change.
