### PR TITLE
🐛 fix(lease): clear token after failed acquire

### DIFF
--- a/docs/changelog/721.bugfix.rst
+++ b/docs/changelog/721.bugfix.rst
@@ -1,3 +1,2 @@
-``SoftFileLease.token`` and ``AsyncSoftFileLease.token`` now read ``None`` after an acquisition that ends without the
-lease, so a contender turned away by a live holder, or one whose acquire raises, no longer reports a token for a claim
-it never published.
+``SoftFileLease.token`` and ``AsyncSoftFileLease.token`` now read ``None`` after a failed acquisition, so a contender
+turned away by a live holder no longer reports a token for a claim it never published.

--- a/docs/changelog/721.bugfix.rst
+++ b/docs/changelog/721.bugfix.rst
@@ -1,0 +1,3 @@
+``SoftFileLease.token`` and ``AsyncSoftFileLease.token`` now read ``None`` after an acquisition that ends without the
+lease, so a contender turned away by a live holder, or one whose acquire raises, no longer reports a token for a claim
+it never published.

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -181,15 +181,24 @@ class SoftFileLease(MarkerSoftFileLock):
     def _acquire(self) -> None:
         claim = self._claim
         self._stop_heartbeat()  # no earlier claim's heartbeat outlives the acquisition of the next one
+        # The published record carries the token, so the claim has to name it before the marker is written. An attempt
+        # that ends up holding nothing hands it back, or token keeps naming a claim this process never took. A raise
+        # once the descriptor is held needs nothing here: that rollback releases, and a release clears the token.
         claim.token = token = secrets.token_hex(16)
         claim.compromise = None
-        super()._acquire()
+        try:
+            super()._acquire()
+        except BaseException:
+            claim.token = None
+            raise
         # The context is thread-local by default, so the heartbeat thread cannot read the descriptor this one just
         # published, nor the claim this one owns. Hand it the fd, the inode it verified and the claim instead.
         if (fd := self._context.lock_file_fd) is not None and (
             identity := self._context.lock_file_fd_identity
         ) is not None:
             self._start_heartbeat(claim, fd, identity, token)
+        else:  # the marker turned this contender away, so it published nothing and holds no claim to name
+            claim.token = None
 
     def _release(self) -> None:
         self._stop_heartbeat()

--- a/src/filelock/_lease.py
+++ b/src/filelock/_lease.py
@@ -181,9 +181,7 @@ class SoftFileLease(MarkerSoftFileLock):
     def _acquire(self) -> None:
         claim = self._claim
         self._stop_heartbeat()  # no earlier claim's heartbeat outlives the acquisition of the next one
-        # The published record carries the token, so the claim has to name it before the marker is written. An attempt
-        # that ends up holding nothing hands it back, or token keeps naming a claim this process never took. A raise
-        # once the descriptor is held needs nothing here: that rollback releases, and a release clears the token.
+        # The published record reads the token, so it exists before the marker is written and goes back on failure.
         claim.token = token = secrets.token_hex(16)
         claim.compromise = None
         try:
@@ -197,7 +195,7 @@ class SoftFileLease(MarkerSoftFileLock):
             identity := self._context.lock_file_fd_identity
         ) is not None:
             self._start_heartbeat(claim, fd, identity, token)
-        else:  # the marker turned this contender away, so it published nothing and holds no claim to name
+        else:
             claim.token = None
 
     def _release(self) -> None:

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -82,6 +82,27 @@ def test_lease_token_names_the_claim_only_while_held(marker: Path) -> None:
     assert lease.token is None
 
 
+def test_lease_token_names_no_claim_after_a_contended_acquire(marker: Path) -> None:
+    contender = _lease(marker, timeout=0)
+
+    with _lease(marker):
+        with pytest.raises(Timeout):
+            contender.acquire()
+        assert contender.token is None
+
+
+def test_lease_token_names_no_claim_after_an_acquire_that_raises(tmp_path: Path) -> None:
+    # The marker's parent is a regular file, so the acquire raises while creating the directory, before it ever holds
+    # a descriptor. Nothing rolls the token back for it: that rollback only runs for an acquire that reached held.
+    (blocker := tmp_path / "blocker").touch()
+    lease = _lease(blocker / "resource.lock")
+
+    with pytest.raises(FileExistsError):
+        lease.acquire()
+
+    assert lease.token is None
+
+
 def test_lease_heartbeat_keeps_a_live_claim_past_its_duration(marker: Path) -> None:
     holder = _lease(marker)
 

--- a/tests/test_soft_lease.py
+++ b/tests/test_soft_lease.py
@@ -92,8 +92,7 @@ def test_lease_token_names_no_claim_after_a_contended_acquire(marker: Path) -> N
 
 
 def test_lease_token_names_no_claim_after_an_acquire_that_raises(tmp_path: Path) -> None:
-    # The marker's parent is a regular file, so the acquire raises while creating the directory, before it ever holds
-    # a descriptor. Nothing rolls the token back for it: that rollback only runs for an acquire that reached held.
+    # The one path no rollback covers: a raise before the acquire holds a descriptor.
     (blocker := tmp_path / "blocker").touch()
     lease = _lease(blocker / "resource.lock")
 


### PR DESCRIPTION
`SoftFileLease.token` documents itself as naming the claim while the lease is held and reading `None` otherwise. A
contended acquire broke that. The attempt generated a token, lost the marker to the live holder, and left the token in
place, so `is_locked` read false while `token` still named a claim no peer could ever see.

The published record carries the token, so the claim has to name it before `_acquire` writes the marker. This hands it
back on the two paths that end without the lease: an acquire that raises before it holds a descriptor, and a contender
the marker turns away. A raise once the acquire holds the descriptor needs nothing new, since
`_rollback_failed_acquire` releases and `_release` already clears the token.

Both paths get a test. The raising one drives a real failure rather than a mock. The marker's parent is a regular file,
so `ensure_directory_exists` raises `FileExistsError` before any descriptor exists, which is the one path no rollback
covers.

`AsyncSoftFileLease` inherits `_acquire`, so it carries the same fix.
