### PR TITLE
🐛 fix(soft-rw): reject non-finite timing options

### DIFF
--- a/docs/changelog/724.bugfix.rst
+++ b/docs/changelog/724.bugfix.rst
@@ -1,0 +1,2 @@
+``SoftReadWriteLock`` now rejects non-finite heartbeat, stale, and polling intervals at construction instead of
+allowing them to disrupt heartbeat or polling behavior later.

--- a/docs/changelog/724.bugfix.rst
+++ b/docs/changelog/724.bugfix.rst
@@ -1,2 +1,2 @@
-``SoftReadWriteLock`` now rejects non-finite heartbeat, stale, and polling intervals at construction instead of
-allowing them to disrupt heartbeat or polling behavior later.
+Reject non-finite heartbeat, stale, and polling intervals in ``SoftReadWriteLock`` and ``AsyncSoftReadWriteLock``,
+including cached singleton construction and overflow in the default stale threshold.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -603,8 +603,8 @@ participating clocks and fence protected writes if an expired holder can resume.
 
    ``SoftReadWriteLock`` and ``ReadWriteLock`` are singletons by default. A second construction for the same path
    raises ``ValueError`` if ``timeout`` or ``blocking`` differ, but ``heartbeat_interval``, ``stale_threshold``, and
-   ``poll_interval`` are **silently ignored** on a cache hit: you get the first instance, with the first call's tuning.
-   Configure a path in one place.
+   ``poll_interval`` keep the first call's tuning on a cache hit. ``SoftReadWriteLock`` still validates these intervals
+   before returning the cached instance. Configure a path in one place.
 
 :meth:`get_lock() <filelock.SoftReadWriteLock.get_lock>` is sugar for the same singleton lookup, spelling the intent
 out at the call site. ``ReadWriteLock`` has the same classmethod. It offers nothing the constructor does not:

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -14,6 +14,7 @@ import time
 import uuid
 from contextlib import closing, contextmanager, suppress
 from dataclasses import dataclass
+from math import isfinite
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, Literal
 from weakref import WeakValueDictionary
@@ -173,16 +174,19 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         poll_interval: float = 0.25,
     ) -> None:
         self._creator_pid = os.getpid()
-        if heartbeat_interval <= 0:
-            msg = f"heartbeat_interval must be positive, got {heartbeat_interval}"
+        if not isfinite(heartbeat_interval) or heartbeat_interval <= 0:
+            msg = f"heartbeat_interval must be positive and finite, got {heartbeat_interval}"
             raise ValueError(msg)
         if stale_threshold is None:
             stale_threshold = heartbeat_interval * 3
-        if stale_threshold <= heartbeat_interval:
-            msg = f"stale_threshold must exceed heartbeat_interval ({stale_threshold} <= {heartbeat_interval})"
+        if not isfinite(stale_threshold) or stale_threshold <= heartbeat_interval:
+            msg = (
+                "stale_threshold must exceed heartbeat_interval and be finite "
+                f"({stale_threshold} <= {heartbeat_interval})"
+            )
             raise ValueError(msg)
-        if poll_interval <= 0:
-            msg = f"poll_interval must be positive, got {poll_interval}"
+        if not isfinite(poll_interval) or poll_interval <= 0:
+            msg = f"poll_interval must be positive and finite, got {poll_interval}"
             raise ValueError(msg)
 
         self.lock_file: str = os.fspath(lock_file)

--- a/src/filelock/_soft_rw/_sync.py
+++ b/src/filelock/_soft_rw/_sync.py
@@ -110,6 +110,8 @@ class _SoftRWMeta(type):
                     f" cannot be changed to timeout={timeout}, blocking={blocking}"
                 )
                 raise ValueError(msg)
+            else:
+                _validate_intervals(heartbeat_interval, stale_threshold, poll_interval)
             return instance
 
 
@@ -174,20 +176,7 @@ class SoftReadWriteLock(metaclass=_SoftRWMeta):
         poll_interval: float = 0.25,
     ) -> None:
         self._creator_pid = os.getpid()
-        if not isfinite(heartbeat_interval) or heartbeat_interval <= 0:
-            msg = f"heartbeat_interval must be positive and finite, got {heartbeat_interval}"
-            raise ValueError(msg)
-        if stale_threshold is None:
-            stale_threshold = heartbeat_interval * 3
-        if not isfinite(stale_threshold) or stale_threshold <= heartbeat_interval:
-            msg = (
-                "stale_threshold must exceed heartbeat_interval and be finite "
-                f"({stale_threshold} <= {heartbeat_interval})"
-            )
-            raise ValueError(msg)
-        if not isfinite(poll_interval) or poll_interval <= 0:
-            msg = f"poll_interval must be positive and finite, got {poll_interval}"
-            raise ValueError(msg)
+        stale_threshold = _validate_intervals(heartbeat_interval, stale_threshold, poll_interval)
 
         self.lock_file: str = os.fspath(lock_file)
         self.timeout: float = timeout
@@ -937,6 +926,24 @@ def _file_exists(path: str) -> bool:
 
 def _is_housekeeping_name(name: str) -> bool:
     return name.startswith(".") or _BREAK_SUFFIX in name
+
+
+def _validate_intervals(heartbeat_interval: float, stale_threshold: float | None, poll_interval: float) -> float:
+    if not isfinite(heartbeat_interval) or heartbeat_interval <= 0:
+        msg = f"heartbeat_interval must be positive and finite, got {heartbeat_interval}"
+        raise ValueError(msg)
+    if stale_threshold is None:
+        stale_threshold = heartbeat_interval * 3
+    if not isfinite(stale_threshold) or stale_threshold <= heartbeat_interval:
+        msg = (
+            f"stale_threshold must exceed heartbeat_interval ({heartbeat_interval}) "
+            f"and be finite, got {stale_threshold}"
+        )
+        raise ValueError(msg)
+    if not isfinite(poll_interval) or poll_interval <= 0:
+        msg = f"poll_interval must be positive and finite, got {poll_interval}"
+        raise ValueError(msg)
+    return stale_threshold
 
 
 @dataclass(frozen=True)

--- a/tests/soft_rw/test_soft_rw_intervals.py
+++ b/tests/soft_rw/test_soft_rw_intervals.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from filelock import AsyncSoftReadWriteLock, SoftReadWriteLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    "lock_type",
+    [pytest.param(SoftReadWriteLock, id="sync"), pytest.param(AsyncSoftReadWriteLock, id="async")],
+)
+@pytest.mark.parametrize("cached", [pytest.param(False, id="new"), pytest.param(True, id="cached")])
+@pytest.mark.parametrize(
+    ("settings", "message"),
+    [
+        pytest.param({name: value}, name, id=f"{name}-{label}")
+        for name in ("heartbeat_interval", "stale_threshold", "poll_interval")
+        for label, value in (("nan", float("nan")), ("infinity", float("inf")), ("negative-infinity", float("-inf")))
+    ]
+    + [
+        pytest.param({"heartbeat_interval": sys.float_info.max}, "stale_threshold", id="default-overflow"),
+    ],
+)
+def test_rejects_invalid_intervals(
+    tmp_path: Path,
+    lock_type: type[SoftReadWriteLock | AsyncSoftReadWriteLock],
+    cached: bool,
+    settings: dict[str, float],
+    message: str,
+) -> None:
+    path: Final = tmp_path / "timing.lock"
+    # Keep the weakly cached instance alive through the second construction.
+    existing: Final = SoftReadWriteLock(path) if cached else None
+    try:
+        with pytest.raises(ValueError, match=rf"{message} must .*finite"):
+            lock_type(
+                path,
+                heartbeat_interval=settings.get("heartbeat_interval", 30),
+                stale_threshold=settings.get("stale_threshold"),
+                poll_interval=settings.get("poll_interval", 0.25),
+            )
+    finally:
+        if existing is not None:
+            existing.close()

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -68,6 +68,24 @@ def test_rejects_non_positive_poll_interval(lock_file: str) -> None:
         SoftReadWriteLock(lock_file, poll_interval=0, is_singleton=False)
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_rejects_non_finite_heartbeat_interval(lock_file: str, value: float) -> None:
+    with pytest.raises(ValueError, match=r"heartbeat_interval must .*finite"):
+        SoftReadWriteLock(lock_file, heartbeat_interval=value, is_singleton=False)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_rejects_non_finite_stale_threshold(lock_file: str, value: float) -> None:
+    with pytest.raises(ValueError, match=r"stale_threshold must .*finite"):
+        SoftReadWriteLock(lock_file, stale_threshold=value, is_singleton=False)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_rejects_non_finite_poll_interval(lock_file: str, value: float) -> None:
+    with pytest.raises(ValueError, match=r"poll_interval must .*finite"):
+        SoftReadWriteLock(lock_file, poll_interval=value, is_singleton=False)
+
+
 def test_public_attributes(lock_file: str) -> None:
     lock = SoftReadWriteLock(
         lock_file,

--- a/tests/soft_rw/test_soft_rw_sync.py
+++ b/tests/soft_rw/test_soft_rw_sync.py
@@ -68,24 +68,6 @@ def test_rejects_non_positive_poll_interval(lock_file: str) -> None:
         SoftReadWriteLock(lock_file, poll_interval=0, is_singleton=False)
 
 
-@pytest.mark.parametrize("value", [float("nan"), float("inf")])
-def test_rejects_non_finite_heartbeat_interval(lock_file: str, value: float) -> None:
-    with pytest.raises(ValueError, match=r"heartbeat_interval must .*finite"):
-        SoftReadWriteLock(lock_file, heartbeat_interval=value, is_singleton=False)
-
-
-@pytest.mark.parametrize("value", [float("nan"), float("inf")])
-def test_rejects_non_finite_stale_threshold(lock_file: str, value: float) -> None:
-    with pytest.raises(ValueError, match=r"stale_threshold must .*finite"):
-        SoftReadWriteLock(lock_file, stale_threshold=value, is_singleton=False)
-
-
-@pytest.mark.parametrize("value", [float("nan"), float("inf")])
-def test_rejects_non_finite_poll_interval(lock_file: str, value: float) -> None:
-    with pytest.raises(ValueError, match=r"poll_interval must .*finite"):
-        SoftReadWriteLock(lock_file, poll_interval=value, is_singleton=False)
-
-
 def test_public_attributes(lock_file: str) -> None:
     lock = SoftReadWriteLock(
         lock_file,


### PR DESCRIPTION
## Problem

`SoftReadWriteLock` accepts NaN and Infinity for its timing options. Those values can turn heartbeat waits into a busy loop, prevent stale markers from expiring, or defer an invalid poll delay until `sleep()`.

## Change

Reject non-finite `heartbeat_interval`, `stale_threshold`, and `poll_interval` values alongside the existing range checks.

## Validation

- Regression test: 6/6 non-finite cases pass after failing before the fix
- `pytest -q tests/soft_rw` — 104 passed
- `ruff check src tests/soft_rw`
- `ruff format --check src tests/soft_rw`
- `ty check tests/soft_rw/test_soft_rw_sync.py`
- `git diff --check`

No public API shape changes; valid timing values behave as before.
