### PR TITLE
Fix test for musl libc

### DIFF
--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -2042,7 +2042,7 @@ def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:
     (tmp_path / "link").symlink_to(tmp_path / "target")
     # Keeping the final symlink a distinct key is safe because the backend still refuses to lock through it. O_NOFOLLOW
     # reports the refusal as ELOOP on Linux and macOS, and as EFTYPE ("inappropriate file type") on NetBSD.
-    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link|Inappropriate file type"):
+    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link|Inappropriate file type|Symbolic link loop"):
         FileLock(str(tmp_path / "link")).acquire()
 
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -2042,7 +2042,9 @@ def test_final_symlink_backend_refuses_to_lock(tmp_path: Path) -> None:
     (tmp_path / "link").symlink_to(tmp_path / "target")
     # Keeping the final symlink a distinct key is safe because the backend still refuses to lock through it. O_NOFOLLOW
     # reports the refusal as ELOOP on Linux and macOS, and as EFTYPE ("inappropriate file type") on NetBSD.
-    with pytest.raises(OSError, match=r"Too many levels of symbolic links|symbolic link|Inappropriate file type|Symbolic link loop"):
+    with pytest.raises(
+        OSError, match=r"Too many levels of symbolic links|symbolic link|Inappropriate file type|Symbolic link loop"
+    ):
         FileLock(str(tmp_path / "link")).acquire()
 
 


### PR DESCRIPTION
When packaging new version for Void Linux I've noticed that one of the tests fails on musl-based systems. Fail was due to error message, which wasn't caught by regex.